### PR TITLE
Modify the clang-format file to add the pointer on left.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,3 +6,4 @@ ColumnLimit: 80
 AlignAfterOpenBracket: AlwaysBreak
 BinPackParameters: false
 BinPackArguments: false
+PointerAlignment: Left


### PR DESCRIPTION
I know that having the pointer on the right is more correct but I like it on the left.