### PR TITLE
fix linking on linux

### DIFF
--- a/tests/frame/file/CMakeLists.txt
+++ b/tests/frame/file/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(FrameFileTest
   PUBLIC
     Frame
     FrameFile
+    FrameJson
     GTest::gmock
     GTest::gtest
 )


### PR DESCRIPTION
the issue is with tests/frame/file build

frame/file/image.h is using frame/json/parse_pixel.h