### PR TITLE
Handle null uniforms when creating uniform list

### DIFF
--- a/src/frame/opengl/program.cpp
+++ b/src/frame/opengl/program.cpp
@@ -104,6 +104,11 @@ void Program::AddUniform(std::unique_ptr<UniformInterface>&& uniform_interface)
 void Program::AddUniformInternal(
     std::unique_ptr<UniformInterface>&& uniform_interface, bool bypass_check)
 {
+    if (!uniform_interface)
+    {
+        // Unknown types yield a null pointer; skip them silently.
+        return;
+    }
     std::string name = uniform_interface->GetName();
     if (!bypass_check && !HasUniform(name))
     {
@@ -398,7 +403,10 @@ void Program::CreateUniformList()
             logger_->error(
                 std::format("Unknown uniform name: {} type: {}", name, type));
         }
-        AddUniformInternal(std::move(uniform_interface), true);
+        if (uniform_interface)
+        {
+            AddUniformInternal(std::move(uniform_interface), true);
+        }
     }
     UnUse();
 }

--- a/src/frame/opengl/program.h
+++ b/src/frame/opengl/program.h
@@ -115,7 +115,9 @@ class Program : public ProgramInterface
      * linking where all uniforms reported by OpenGL must be inserted
      * unconditionally.
      *
-     * @param uniform Interface to add to the program.
+     * Unknown uniform types yield a null pointer and are silently skipped.
+     *
+     * @param uniform Interface to add to the program. May be nullptr.
      * @param bypass_check If true the presence check is bypassed.
      */
     void AddUniformInternal(
@@ -136,6 +138,8 @@ class Program : public ProgramInterface
     void ThrowIsInTextureIds(EntityId texture_id) const;
     /**
      * @brief Create the uniform value list (internal).
+     *
+     * Unknown uniform types reported by OpenGL are skipped.
      */
     void CreateUniformList();
     /**


### PR DESCRIPTION
## Summary
- skip AddUniformInternal when no uniform exists
- ignore nullptr in AddUniformInternal
- document behaviour of unknown uniform types

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "absl")*
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ae96d1c88329bf5e0e08b3d78e9d