### PR TITLE
Fix BGR texture loading

### DIFF
--- a/src/frame/file/image.cpp
+++ b/src/frame/file/image.cpp
@@ -29,7 +29,27 @@ Image::Image(
     const auto& logger = frame::Logger::GetInstance();
     logger->info("Openning image: [{}].", file.string());
     int channels;
-    int desired_channels = {static_cast<int>(pixel_structure.value())};
+    auto GetDesiredChannels = [](const proto::PixelStructure& pixel_structure) {
+        switch (pixel_structure.value())
+        {
+        case proto::PixelStructure::GREY:
+        case proto::PixelStructure::DEPTH:
+            return 1;
+        case proto::PixelStructure::GREY_ALPHA:
+            return 2;
+        case proto::PixelStructure::RGB:
+        case proto::PixelStructure::BGR:
+            return 3;
+        case proto::PixelStructure::RGB_ALPHA:
+        case proto::PixelStructure::BGR_ALPHA:
+            return 4;
+        default:
+            throw std::runtime_error(
+                "unsupported pixel structure : " +
+                std::to_string(static_cast<int>(pixel_structure.value())));
+        }
+    };
+    int desired_channels = GetDesiredChannels(pixel_structure);
     // This is in the case of OpenGL (for now the only case).
     stbi_set_flip_vertically_on_load(true);
     glm::ivec2 size = glm::ivec2(0, 0);

--- a/src/frame/opengl/cubemap.cpp
+++ b/src/frame/opengl/cubemap.cpp
@@ -280,6 +280,7 @@ void Cubemap::CreateCubemapFromFile(
         frame::file::FindFile(file_name),
         data_.pixel_element_size(),
         data_.pixel_structure());
+    data_.mutable_size()->CopyFrom(json::SerializeSize(image.GetSize()));
     CreateCubemapFromPointer(
         image.Data(),
         image.GetSize(),
@@ -311,6 +312,7 @@ void Cubemap::CreateCubemapFromFiles(
     cubemap_files.set_positive_z(frame::file::PurifyFilePath(paths[4]));
     cubemap_files.set_negative_z(frame::file::PurifyFilePath(paths[5]));
     data_.mutable_file_names()->CopyFrom(cubemap_files);
+    data_.mutable_size()->CopyFrom(json::SerializeSize(images[0]->GetSize()));
     CreateCubemapFromPointers(
         {images[0]->Data(),
          images[1]->Data(),
@@ -331,6 +333,7 @@ void Cubemap::CreateCubemapFromPointer(
 {
     data_.mutable_pixel_element_size()->CopyFrom(pixel_element_size);
     data_.mutable_pixel_structure()->CopyFrom(pixel_structure);
+    data_.mutable_size()->CopyFrom(json::SerializeSize(size));
     auto& logger = Logger::GetInstance();
     std::unique_ptr<TextureInterface> equirectangular =
         std::make_unique<Texture>(
@@ -408,6 +411,7 @@ void Cubemap::CreateCubemapFromPointers(
 {
     data_.mutable_pixel_element_size()->CopyFrom(pixel_element_size);
     data_.mutable_pixel_structure()->CopyFrom(pixel_structure);
+    data_.mutable_size()->CopyFrom(json::SerializeSize(size));
     inner_size_ = size;
     glGenTextures(1, &texture_id_);
     ScopedBind scoped_bind(*this);

--- a/src/frame/opengl/pixel.cpp
+++ b/src/frame/opengl/pixel.cpp
@@ -87,8 +87,12 @@ GLenum ConvertToGLType(
         case frame::proto::PixelStructure::GREY_ALPHA:
             return GL_RG16;
         case frame::proto::PixelStructure::RGB:
+            [[fallthrough]];
+        case frame::proto::PixelStructure::BGR:
             return GL_RGB16;
         case frame::proto::PixelStructure::RGB_ALPHA:
+            [[fallthrough]];
+        case frame::proto::PixelStructure::BGR_ALPHA:
             return GL_RGBA16;
         default:
             throw std::runtime_error(
@@ -105,8 +109,12 @@ GLenum ConvertToGLType(
         case frame::proto::PixelStructure::GREY_ALPHA:
             return GL_RG16F;
         case frame::proto::PixelStructure::RGB:
+            [[fallthrough]];
+        case frame::proto::PixelStructure::BGR:
             return GL_RGB16F;
         case frame::proto::PixelStructure::RGB_ALPHA:
+            [[fallthrough]];
+        case frame::proto::PixelStructure::BGR_ALPHA:
             return GL_RGBA16F;
         default:
             throw std::runtime_error(
@@ -123,8 +131,12 @@ GLenum ConvertToGLType(
         case frame::proto::PixelStructure::GREY_ALPHA:
             return GL_RG32F;
         case frame::proto::PixelStructure::RGB:
+            [[fallthrough]];
+        case frame::proto::PixelStructure::BGR:
             return GL_RGB32F;
         case frame::proto::PixelStructure::RGB_ALPHA:
+            [[fallthrough]];
+        case frame::proto::PixelStructure::BGR_ALPHA:
             return GL_RGBA32F;
         default:
             throw std::runtime_error(


### PR DESCRIPTION
## Summary
- fix texture loader to request correct channel count for BGR formats
- allow BGR/BGR_ALPHA pixel formats for all element sizes

## Testing
- `cmake --preset linux-debug` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_68443b86bcd88329b06528a46afc2216