### PR TITLE
Fix texture size proto test

### DIFF
--- a/tests/frame/json/parse_texture_test.cpp
+++ b/tests/frame/json/parse_texture_test.cpp
@@ -42,7 +42,7 @@ TEST_F(ParseTextureTest, CreateTextureFromProtoCheckSizeTest)
     EXPECT_TRUE(texture_);
     glm::uvec2 test_size = {256, 256};
     auto texture_size = frame::json::ParseSize(texture_->GetData().size());
-    EXPECT_NE(test_size, texture_size);
+    EXPECT_EQ(test_size, texture_size);
 }
 
 TEST_F(ParseTextureTest, CreateTextureFromProtoWrongSizeTest)


### PR DESCRIPTION
## Summary
- correct texture size check to expect equality

## Testing
- `cmake --preset linux-debug` *(fails: vcpkg building abseil)*

------
https://chatgpt.com/codex/tasks/task_e_684552b918088329af866371d3906758