### PR TITLE
Fix Save dialog to preserve full path

### DIFF
--- a/src/frame/file/file_system.cpp
+++ b/src/frame/file/file_system.cpp
@@ -22,6 +22,13 @@ const std::filesystem::path FindElement(
     auto normalized_input = std::filesystem::absolute(file).lexically_normal();
     if (test(normalized_input))
     {
+        // If the user passed an absolute path, honor it even if it contains
+        // one of the avoided directory names (like "build").  The avoidance
+        // logic is primarily meant for relative asset paths searched from the
+        // source tree, not for explicitly selected absolute files.
+        if (file.is_absolute())
+            return normalized_input;
+
         bool found = false;
         for (const auto& element : avoid_elements)
         {

--- a/src/frame/gui/window_file_dialog.cpp
+++ b/src/frame/gui/window_file_dialog.cpp
@@ -167,8 +167,10 @@ bool WindowFileDialog::DrawCallback()
     case FileDialogEnum::NEW:
         if (ImGui::Button("New File"))
         {
-            file_name_ =
+            std::filesystem::path selected_path =
                 (std::strlen(file_buffer)) ? file_buffer : file_name_;
+            if (selected_path.is_relative()) selected_path = current_path / selected_path;
+            file_name_ = selected_path.string();
             get_file_(file_name_);
             end_ = true;
         }
@@ -176,8 +178,10 @@ bool WindowFileDialog::DrawCallback()
     case FileDialogEnum::OPEN:
         if (ImGui::Button("Open File"))
         {
-            file_name_ =
+            std::filesystem::path selected_path =
                 (std::strlen(file_buffer)) ? file_buffer : file_name_;
+            if (selected_path.is_relative()) selected_path = current_path / selected_path;
+            file_name_ = selected_path.string();
             get_file_(file_name_);
             end_ = true;
         }
@@ -185,8 +189,10 @@ bool WindowFileDialog::DrawCallback()
     case FileDialogEnum::SAVE_AS:
         if (ImGui::Button("Save As"))
         {
-            file_name_ =
+            std::filesystem::path selected_path =
                 (std::strlen(file_buffer)) ? file_buffer : file_name_;
+            if (selected_path.is_relative()) selected_path = current_path / selected_path;
+            file_name_ = selected_path.string();
             get_file_(file_name_);
             end_ = true;
         }


### PR DESCRIPTION
## Summary
- preserve the selected directory when choosing a file in `WindowFileDialog`

## Testing
- `cmake --preset linux-debug` *(fails: Could not find toolchain file)*
- `cmake -S . -B build && cmake --build build` *(fails: Could not find package configuration file provided by `absl`)*

------
https://chatgpt.com/codex/tasks/task_e_68468dd302f08329bcc23cadba4f2c3b