### PR TITLE
Fix serialization of textures and materials

### DIFF
--- a/include/frame/program_interface.h
+++ b/include/frame/program_interface.h
@@ -117,6 +117,21 @@ struct ProgramInterface : public Serialize<proto::Program>
      * @return True if present false otherwise.
      */
     virtual bool HasUniform(const std::string& name) const = 0;
+
+    /**
+     * @brief Check if the program stores an enum for the given uniform.
+     * @param name Name of the uniform.
+     * @return True if an enum value is recorded.
+     */
+    virtual bool HasUniformEnum(const std::string& name) const = 0;
+
+    /**
+     * @brief Get the enum associated with a uniform.
+     * @param name Name of the uniform.
+     * @return The enum value or INVALID_UNIFORM if not found.
+     */
+    virtual proto::Uniform::UniformEnum GetUniformEnum(
+        const std::string& name) const = 0;
 };
 
 } // End namespace frame.

--- a/include/frame/program_interface.h
+++ b/include/frame/program_interface.h
@@ -117,7 +117,6 @@ struct ProgramInterface : public Serialize<proto::Program>
      * @return True if present false otherwise.
      */
     virtual bool HasUniform(const std::string& name) const = 0;
-
 };
 
 } // End namespace frame.

--- a/include/frame/program_interface.h
+++ b/include/frame/program_interface.h
@@ -118,20 +118,6 @@ struct ProgramInterface : public Serialize<proto::Program>
      */
     virtual bool HasUniform(const std::string& name) const = 0;
 
-    /**
-     * @brief Check if the program stores an enum for the given uniform.
-     * @param name Name of the uniform.
-     * @return True if an enum value is recorded.
-     */
-    virtual bool HasUniformEnum(const std::string& name) const = 0;
-
-    /**
-     * @brief Get the enum associated with a uniform.
-     * @param name Name of the uniform.
-     * @return The enum value or INVALID_UNIFORM if not found.
-     */
-    virtual proto::Uniform::UniformEnum GetUniformEnum(
-        const std::string& name) const = 0;
 };
 
 } // End namespace frame.

--- a/src/frame/json/parse_material.cpp
+++ b/src/frame/json/parse_material.cpp
@@ -16,13 +16,15 @@ std::unique_ptr<frame::MaterialInterface> ParseMaterialOpenGL(
     const std::size_t inner_size = proto_material.inner_names_size();
     if (texture_size != inner_size)
     {
-        throw std::runtime_error(fmt::format(
-            "Not the same size for texture and inner names: {} != {}.",
-            texture_size,
-            inner_size));
+        throw std::runtime_error(
+            fmt::format(
+                "Not the same size for texture and inner names: {} != {}.",
+                texture_size,
+                inner_size));
     }
     auto material = std::make_unique<frame::opengl::Material>();
     material->SetName(proto_material.name());
+    material->SetSerializeEnable(true);
     if (proto_material.program_name().empty())
     {
         throw std::runtime_error(

--- a/src/frame/json/parse_program.cpp
+++ b/src/frame/json/parse_program.cpp
@@ -100,6 +100,7 @@ std::unique_ptr<frame::ProgramInterface> ParseProgramOpenGL(
             std::unique_ptr<UniformInterface> uniform_interface =
                 std::make_unique<frame::Uniform>(
                     parameter.name(), glm_size, int_list);
+            program->AddUniform(std::move(uniform_interface));
             break;
         }
         case proto::Uniform::kUniformFloat: {
@@ -119,6 +120,7 @@ std::unique_ptr<frame::ProgramInterface> ParseProgramOpenGL(
             std::unique_ptr<UniformInterface> uniform_interface =
                 std::make_unique<frame::Uniform>(
                     parameter.name(), glm_size, float_list);
+            program->AddUniform(std::move(uniform_interface));
             break;
         }
         case proto::Uniform::kUniformVec2: {

--- a/src/frame/json/parse_scene_tree.cpp
+++ b/src/frame/json/parse_scene_tree.cpp
@@ -163,19 +163,19 @@ std::function<NodeInterface*(const std::string& name)> GetFunctor(
             proto_scene_static_mesh.render_primitive_enum());
         auto str = fmt::format("{}.{}", proto_scene_static_mesh.name(), i);
         mesh.SetName(str);
+        auto& static_mesh_node = dynamic_cast<NodeStaticMesh&>(node);
         // Rename the node to match the reference name (without the 'Node.'
         // prefix) so serialization will use the same identifier as the input
         // file.
         if (vec_node_mesh_id.size() == 1)
         {
-            node.SetName(proto_scene_static_mesh.name());
+            static_mesh_node.SetName(proto_scene_static_mesh.name());
         }
         else
         {
-            node.SetName(str);
+            static_mesh_node.SetName(str);
         }
         node.SetParentName(proto_scene_static_mesh.parent());
-        auto& static_mesh_node = dynamic_cast<NodeStaticMesh&>(node);
         static_mesh_node.GetData().set_material_name(
             proto_scene_static_mesh.material_name());
         static_mesh_node.GetData().set_render_time_enum(

--- a/src/frame/json/parse_scene_tree.cpp
+++ b/src/frame/json/parse_scene_tree.cpp
@@ -164,6 +164,17 @@ std::function<NodeInterface*(const std::string& name)> GetFunctor(
         auto str = fmt::format("{}.{}", proto_scene_static_mesh.name(), i);
         mesh.SetName(str);
         node.SetParentName(proto_scene_static_mesh.parent());
+        auto& static_mesh_node = dynamic_cast<NodeStaticMesh&>(node);
+        static_mesh_node.GetData().set_material_name(
+            proto_scene_static_mesh.material_name());
+        static_mesh_node.GetData().set_render_time_enum(
+            proto_scene_static_mesh.render_time_enum());
+        auto material_id =
+            level.GetIdFromName(proto_scene_static_mesh.material_name());
+        level.AddMeshMaterialId(
+            node_mesh_id,
+            material_id,
+            proto_scene_static_mesh.render_time_enum());
         ++i;
     }
     return true;

--- a/src/frame/json/parse_scene_tree.cpp
+++ b/src/frame/json/parse_scene_tree.cpp
@@ -163,6 +163,17 @@ std::function<NodeInterface*(const std::string& name)> GetFunctor(
             proto_scene_static_mesh.render_primitive_enum());
         auto str = fmt::format("{}.{}", proto_scene_static_mesh.name(), i);
         mesh.SetName(str);
+        // Rename the node to match the reference name (without the 'Node.'
+        // prefix) so serialization will use the same identifier as the input
+        // file.
+        if (vec_node_mesh_id.size() == 1)
+        {
+            node.SetName(proto_scene_static_mesh.name());
+        }
+        else
+        {
+            node.SetName(str);
+        }
         node.SetParentName(proto_scene_static_mesh.parent());
         auto& static_mesh_node = dynamic_cast<NodeStaticMesh&>(node);
         static_mesh_node.GetData().set_material_name(

--- a/src/frame/json/parse_texture.cpp
+++ b/src/frame/json/parse_texture.cpp
@@ -41,6 +41,11 @@ std::unique_ptr<frame::TextureInterface> ParseTexture(
     }
     std::unique_ptr<TextureInterface> texture_interface =
         std::make_unique<opengl::Texture>(proto_texture, size);
+    // Preserve the original file name in case the texture was loaded from disk
+    if (proto_texture.has_file_name())
+    {
+        texture_interface->GetData().set_file_name(proto_texture.file_name());
+    }
     texture_interface->SetSerializeEnable(true);
     return texture_interface;
 }
@@ -55,6 +60,11 @@ std::unique_ptr<TextureInterface> ParseCubemap(
     }
     std::unique_ptr<TextureInterface> texture_interface =
         std::make_unique<opengl::Cubemap>(proto_texture, size);
+    if (proto_texture.has_file_names())
+    {
+        *texture_interface->GetData().mutable_file_names() =
+            proto_texture.file_names();
+    }
     texture_interface->SetSerializeEnable(true);
     return texture_interface;
 }

--- a/src/frame/json/parse_texture.cpp
+++ b/src/frame/json/parse_texture.cpp
@@ -41,6 +41,7 @@ std::unique_ptr<frame::TextureInterface> ParseTexture(
     }
     std::unique_ptr<TextureInterface> texture_interface =
         std::make_unique<opengl::Texture>(proto_texture, size);
+    texture_interface->SetSerializeEnable(true);
     return texture_interface;
 }
 
@@ -54,6 +55,7 @@ std::unique_ptr<TextureInterface> ParseCubemap(
     }
     std::unique_ptr<TextureInterface> texture_interface =
         std::make_unique<opengl::Cubemap>(proto_texture, size);
+    texture_interface->SetSerializeEnable(true);
     return texture_interface;
 }
 

--- a/src/frame/json/parse_uniform.cpp
+++ b/src/frame/json/parse_uniform.cpp
@@ -73,7 +73,6 @@ void RegisterUniformFromProto(
         RegisterUniformEnumFromProto(
             uniform.name(),
             uniform.uniform_enum(),
-            uniform_collection_interface,
             program_interface);
         return;
     }
@@ -123,86 +122,22 @@ void RegisterUniformFromProto(
 void RegisterUniformEnumFromProto(
     const std::string& name,
     const proto::Uniform::UniformEnum& uniform_enum,
-    const UniformCollectionInterface& uniform_collection_interface,
     ProgramInterface& program_interface)
 {
+    // Register the uniform using its enum so that serialization retains the
+    // original identifier. Runtime values will be applied later via the
+    // UniformCollectionWrapper.
     switch (uniform_enum)
     {
-    case proto::Uniform::PROJECTION_MAT4: {
-        std::unique_ptr<frame::UniformInterface> uniform_interface =
-            std::make_unique<frame::Uniform>(
-                name,
-                json::ParseUniform(
-                    uniform_collection_interface.GetUniform("projection")
-                        .GetData()
-                        .uniform_mat4()));
-        program_interface.AddUniform(std::move(uniform_interface));
-        break;
-    }
-    case proto::Uniform::PROJECTION_INV_MAT4: {
-        std::unique_ptr<frame::UniformInterface> uniform_interface =
-            std::make_unique<frame::Uniform>(
-                name,
-                glm::inverse(json::ParseUniform(
-                    uniform_collection_interface.GetUniform("projection")
-                        .GetData()
-                        .uniform_mat4())));
-        program_interface.AddUniform(std::move(uniform_interface));
-        break;
-    }
-    case proto::Uniform::VIEW_MAT4: {
-        std::unique_ptr<frame::UniformInterface> uniform_interface =
-            std::make_unique<frame::Uniform>(
-                name,
-                json::ParseUniform(
-                    uniform_collection_interface.GetUniform("view")
-                        .GetData()
-                        .uniform_mat4()));
-        program_interface.AddUniform(std::move(uniform_interface));
-        break;
-    }
-    case proto::Uniform::VIEW_INV_MAT4: {
-        std::unique_ptr<frame::UniformInterface> uniform_interface =
-            std::make_unique<frame::Uniform>(
-                name,
-                glm::inverse(json::ParseUniform(
-                    uniform_collection_interface.GetUniform("view")
-                        .GetData()
-                        .uniform_mat4())));
-        program_interface.AddUniform(std::move(uniform_interface));
-        break;
-    }
-    case proto::Uniform::MODEL_MAT4: {
-        std::unique_ptr<frame::UniformInterface> uniform_interface =
-            std::make_unique<frame::Uniform>(
-                name,
-                json::ParseUniform(
-                    uniform_collection_interface.GetUniform("model")
-                        .GetData()
-                        .uniform_mat4()));
-        program_interface.AddUniform(std::move(uniform_interface));
-        break;
-    }
-    case proto::Uniform::MODEL_INV_MAT4: {
-        std::unique_ptr<frame::UniformInterface> uniform_interface =
-            std::make_unique<frame::Uniform>(
-                name,
-                glm::inverse(json::ParseUniform(
-                    uniform_collection_interface.GetUniform("model")
-                        .GetData()
-                        .uniform_mat4())));
-        program_interface.AddUniform(std::move(uniform_interface));
-        break;
-    }
+    case proto::Uniform::PROJECTION_MAT4:
+    case proto::Uniform::PROJECTION_INV_MAT4:
+    case proto::Uniform::VIEW_MAT4:
+    case proto::Uniform::VIEW_INV_MAT4:
+    case proto::Uniform::MODEL_MAT4:
+    case proto::Uniform::MODEL_INV_MAT4:
     case proto::Uniform::FLOAT_TIME_S: {
-        static Logger& logger_ = Logger::GetInstance();
         std::unique_ptr<frame::UniformInterface> uniform_interface =
-            std::make_unique<frame::Uniform>(
-                name,
-                static_cast<float>(
-                    uniform_collection_interface.GetUniform("time")
-                        .GetData()
-                        .uniform_float()));
+            std::make_unique<frame::Uniform>(name, uniform_enum);
         program_interface.AddUniform(std::move(uniform_interface));
         break;
     }

--- a/src/frame/json/parse_uniform.h
+++ b/src/frame/json/parse_uniform.h
@@ -97,7 +97,6 @@ void RegisterUniformFromProto(
 void RegisterUniformEnumFromProto(
     const std::string& name,
     const frame::proto::Uniform::UniformEnum& uniform_enum,
-    const UniformCollectionInterface& uniform_interface,
     ProgramInterface& program_interface);
 
 } // namespace frame::json.

--- a/src/frame/json/serialize_level.cpp
+++ b/src/frame/json/serialize_level.cpp
@@ -22,8 +22,10 @@ std::string GetMaterialNameFromProgramName(
             return material.name();
         }
     }
-    throw std::runtime_error(std::format(
-        "Couldn't find material name from program name: [{}]?", program_name));
+    throw std::runtime_error(
+        std::format(
+            "Couldn't find material name from program name: [{}]?",
+            program_name));
 }
 
 } // End anonymous namespace.
@@ -41,6 +43,10 @@ proto::Level SerializeLevel(const LevelInterface& level_interface)
     {
         TextureInterface& texture_interface =
             level_interface.GetTextureFromId(texture_id);
+        if (!texture_interface.SerializeEnable())
+        {
+            continue;
+        }
         proto::Texture proto_texture = SerializeTexture(texture_interface);
         *proto_level.add_textures() = proto_texture;
     }
@@ -48,6 +54,10 @@ proto::Level SerializeLevel(const LevelInterface& level_interface)
     {
         MaterialInterface& material_interface =
             level_interface.GetMaterialFromId(material_id);
+        if (!material_interface.SerializeEnable())
+        {
+            continue;
+        }
         proto::Material proto_material =
             SerializeMaterial(material_interface, level_interface);
         *proto_level.add_materials() = proto_material;

--- a/src/frame/json/serialize_program.cpp
+++ b/src/frame/json/serialize_program.cpp
@@ -57,17 +57,16 @@ proto::Program SerializeProgram(
             program_interface.GetTemporarySceneRoot();
     }
     *proto_program.mutable_input_scene_type() = proto_scene_type;
-//    for (const auto& uniform : program_interface.GetData().uniforms())
-//    {
-//        proto::Uniform proto_uniform;
-//        proto_uniform = SerializeUniform(
-//            program_interface.GetUniform(uniform_name), level_interface);
-//        // Could return an empty name in case it was found in the materials.
-//        if (proto_uniform.name() != "")
-//        {
-//            *proto_program.add_parameters() = proto_uniform;
-//        }
-//    }
+    for (const auto& uniform_name : program_interface.GetUniformNameList())
+    {
+        proto::Uniform proto_uniform = SerializeUniform(
+            program_interface.GetUniform(uniform_name), level_interface);
+        // Could return an empty name in case it was found in the materials.
+        if (!proto_uniform.name().empty())
+        {
+            *proto_program.add_uniforms() = proto_uniform;
+        }
+    }
     return proto_program;
 }
 

--- a/src/frame/json/serialize_program.cpp
+++ b/src/frame/json/serialize_program.cpp
@@ -59,19 +59,20 @@ proto::Program SerializeProgram(
     *proto_program.mutable_input_scene_type() = proto_scene_type;
     for (const auto& uniform_name : program_interface.GetUniformNameList())
     {
+        const auto& uniform = program_interface.GetUniform(uniform_name);
+        const auto& data = uniform.GetData();
         proto::Uniform proto_uniform;
-        if (program_interface.HasUniformEnum(uniform_name))
+        if (data.type() == proto::Uniform::INVALID_TYPE &&
+            data.uniform_enum() != proto::Uniform::INVALID_UNIFORM)
         {
             proto_uniform.set_name(uniform_name);
-            proto_uniform.set_uniform_enum(
-                program_interface.GetUniformEnum(uniform_name));
+            proto_uniform.set_uniform_enum(data.uniform_enum());
         }
         else
         {
-            proto_uniform = SerializeUniform(
-                program_interface.GetUniform(uniform_name), level_interface);
+            proto_uniform =
+                SerializeUniform(uniform, level_interface);
         }
-        // Could return an empty name in case it was found in the materials.
         if (!proto_uniform.name().empty())
         {
             *proto_program.add_uniforms() = proto_uniform;

--- a/src/frame/json/serialize_program.cpp
+++ b/src/frame/json/serialize_program.cpp
@@ -59,8 +59,18 @@ proto::Program SerializeProgram(
     *proto_program.mutable_input_scene_type() = proto_scene_type;
     for (const auto& uniform_name : program_interface.GetUniformNameList())
     {
-        proto::Uniform proto_uniform = SerializeUniform(
-            program_interface.GetUniform(uniform_name), level_interface);
+        proto::Uniform proto_uniform;
+        if (program_interface.HasUniformEnum(uniform_name))
+        {
+            proto_uniform.set_name(uniform_name);
+            proto_uniform.set_uniform_enum(
+                program_interface.GetUniformEnum(uniform_name));
+        }
+        else
+        {
+            proto_uniform = SerializeUniform(
+                program_interface.GetUniform(uniform_name), level_interface);
+        }
         // Could return an empty name in case it was found in the materials.
         if (!proto_uniform.name().empty())
         {

--- a/src/frame/json/serialize_program.cpp
+++ b/src/frame/json/serialize_program.cpp
@@ -62,16 +62,14 @@ proto::Program SerializeProgram(
         const auto& uniform = program_interface.GetUniform(uniform_name);
         const auto& data = uniform.GetData();
         proto::Uniform proto_uniform;
-        if (data.type() == proto::Uniform::INVALID_TYPE &&
-            data.uniform_enum() != proto::Uniform::INVALID_UNIFORM)
+        if (data.uniform_enum() != proto::Uniform::INVALID_UNIFORM)
         {
             proto_uniform.set_name(uniform_name);
             proto_uniform.set_uniform_enum(data.uniform_enum());
         }
         else
         {
-            proto_uniform =
-                SerializeUniform(uniform, level_interface);
+            proto_uniform = SerializeUniform(uniform, level_interface);
         }
         if (!proto_uniform.name().empty())
         {

--- a/src/frame/opengl/cubemap.cpp
+++ b/src/frame/opengl/cubemap.cpp
@@ -291,7 +291,6 @@ void Cubemap::CreateCubemapFromFile(
         frame::file::FindFile(file_name),
         data_.pixel_element_size(),
         data_.pixel_structure());
-    data_.mutable_size()->CopyFrom(json::SerializeSize(image.GetSize()));
     CreateCubemapFromPointer(
         image.Data(),
         image.GetSize(),
@@ -323,7 +322,6 @@ void Cubemap::CreateCubemapFromFiles(
     cubemap_files.set_positive_z(frame::file::PurifyFilePath(paths[4]));
     cubemap_files.set_negative_z(frame::file::PurifyFilePath(paths[5]));
     data_.mutable_file_names()->CopyFrom(cubemap_files);
-    data_.mutable_size()->CopyFrom(json::SerializeSize(images[0]->GetSize()));
     CreateCubemapFromPointers(
         {images[0]->Data(),
          images[1]->Data(),
@@ -344,7 +342,6 @@ void Cubemap::CreateCubemapFromPointer(
 {
     data_.mutable_pixel_element_size()->CopyFrom(pixel_element_size);
     data_.mutable_pixel_structure()->CopyFrom(pixel_structure);
-    data_.mutable_size()->CopyFrom(json::SerializeSize(size));
     auto& logger = Logger::GetInstance();
     std::unique_ptr<TextureInterface> equirectangular =
         std::make_unique<Texture>(
@@ -411,9 +408,8 @@ void Cubemap::CreateCubemapFromPointer(
     texture_id_ = cubemap.GetId();
     cubemap.texture_id_ = 0;
     inner_size_ = cube_pair_res;
-    // Record the actual cubemap size in the proto so callers such as tests
-    // query the correct dimensions after the equirectangular conversion.
-    data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
+    // Keep the original size from the proto, inner_size_ stores the computed
+    // resolution for the GPU.
 }
 
 void Cubemap::CreateCubemapFromPointers(
@@ -424,7 +420,6 @@ void Cubemap::CreateCubemapFromPointers(
 {
     data_.mutable_pixel_element_size()->CopyFrom(pixel_element_size);
     data_.mutable_pixel_structure()->CopyFrom(pixel_structure);
-    data_.mutable_size()->CopyFrom(json::SerializeSize(size));
     inner_size_ = size;
     glGenTextures(1, &texture_id_);
     ScopedBind scoped_bind(*this);

--- a/src/frame/opengl/program.cpp
+++ b/src/frame/opengl/program.cpp
@@ -444,7 +444,6 @@ bool Program::HasUniform(const std::string& name) const
     return true;
 }
 
-
 std::string Program::GetTemporarySceneRoot() const
 {
     return temporary_scene_root_;
@@ -522,7 +521,9 @@ std::unique_ptr<ProgramInterface> CreateProgram(
     // enum identifiers from the proto so serialization keeps the same names.
     for (const auto& uniform : proto_program.uniforms())
     {
-        if (uniform.has_uniform_enum() && program->HasUniform(uniform.name()))
+        ProgramInterface* program_iface = program.get();
+        if (uniform.has_uniform_enum() &&
+            program_iface->HasUniform(uniform.name()))
         {
             std::unique_ptr<UniformInterface> uniform_interface =
                 std::make_unique<Uniform>(

--- a/src/frame/opengl/program.cpp
+++ b/src/frame/opengl/program.cpp
@@ -517,17 +517,21 @@ std::unique_ptr<ProgramInterface> CreateProgram(
     program->AddShader(vertex);
     program->AddShader(fragment);
     // Need to add the uniform enum list for serialization.
+    program->LinkShader();
+    // After linking, the program knows about all active uniforms. Preserve the
+    // enum identifiers from the proto so serialization keeps the same names.
     for (const auto& uniform : proto_program.uniforms())
     {
-        if (uniform.has_uniform_enum())
+        if (uniform.has_uniform_enum() && program->HasUniform(uniform.name()))
         {
             std::unique_ptr<UniformInterface> uniform_interface =
                 std::make_unique<Uniform>(
                     uniform.name(), uniform.uniform_enum());
+            // Bypass the check because the uniform exists but may not be
+            // currently active due to the INVALID_TYPE placeholder.
             program->AddUniform(std::move(uniform_interface));
         }
     }
-    program->LinkShader();
     program->GetData().set_shader(proto_program.shader());
 #ifdef _DEBUG
     logger->info("with pointer := {}", static_cast<void*>(program.get()));

--- a/src/frame/opengl/program.cpp
+++ b/src/frame/opengl/program.cpp
@@ -129,13 +129,6 @@ void Program::AddUniformInternal(
         uniform_map_[name] = std::move(uniform_interface);
     }
     auto* uniform_ptr = uniform_map_[name].get();
-    if (
-        uniform_ptr->GetData().type() == proto::Uniform::INVALID_TYPE &&
-        uniform_ptr->GetData().uniform_enum() !=
-            proto::Uniform::INVALID_UNIFORM)
-    {
-        name_uniform_enums_[name] = uniform_ptr->GetData().uniform_enum();
-    }
     switch (uniform_ptr->GetData().type())
     {
     case proto::Uniform::INVALID_TYPE:
@@ -215,7 +208,6 @@ void Program::RemoveUniform(const std::string& name)
     {
         uniform_map_.erase(it);
     }
-    name_uniform_enums_.erase(name);
 }
 
 int Program::GetMemoizeUniformLocation(const std::string& name) const
@@ -441,21 +433,6 @@ bool Program::HasUniform(const std::string& name) const
     return true;
 }
 
-bool Program::HasUniformEnum(const std::string& name) const
-{
-    return name_uniform_enums_.count(name) > 0;
-}
-
-proto::Uniform::UniformEnum Program::GetUniformEnum(
-    const std::string& name) const
-{
-    auto it = name_uniform_enums_.find(name);
-    if (it == name_uniform_enums_.end())
-    {
-        return proto::Uniform::INVALID_UNIFORM;
-    }
-    return it->second;
-}
 
 std::string Program::GetTemporarySceneRoot() const
 {

--- a/src/frame/opengl/program.cpp
+++ b/src/frame/opengl/program.cpp
@@ -129,6 +129,13 @@ void Program::AddUniformInternal(
         uniform_map_[name] = std::move(uniform_interface);
     }
     auto* uniform_ptr = uniform_map_[name].get();
+    if (
+        uniform_ptr->GetData().type() == proto::Uniform::INVALID_TYPE &&
+        uniform_ptr->GetData().uniform_enum() !=
+            proto::Uniform::INVALID_UNIFORM)
+    {
+        name_uniform_enums_[name] = uniform_ptr->GetData().uniform_enum();
+    }
     switch (uniform_ptr->GetData().type())
     {
     case proto::Uniform::INVALID_TYPE:
@@ -208,6 +215,7 @@ void Program::RemoveUniform(const std::string& name)
     {
         uniform_map_.erase(it);
     }
+    name_uniform_enums_.erase(name);
 }
 
 int Program::GetMemoizeUniformLocation(const std::string& name) const
@@ -431,6 +439,22 @@ bool Program::HasUniform(const std::string& name) const
             uniform_list.begin(), uniform_list.end(), name + "[0]");
     }
     return true;
+}
+
+bool Program::HasUniformEnum(const std::string& name) const
+{
+    return name_uniform_enums_.count(name) > 0;
+}
+
+proto::Uniform::UniformEnum Program::GetUniformEnum(
+    const std::string& name) const
+{
+    auto it = name_uniform_enums_.find(name);
+    if (it == name_uniform_enums_.end())
+    {
+        return proto::Uniform::INVALID_UNIFORM;
+    }
+    return it->second;
 }
 
 std::string Program::GetTemporarySceneRoot() const

--- a/src/frame/opengl/program.cpp
+++ b/src/frame/opengl/program.cpp
@@ -125,13 +125,11 @@ void Program::AddUniformInternal(
         // Preserve the enum from the existing uniform if the new value does not
         // specify one. This allows runtime updates to keep their original
         // serialization identifier.
-        auto* old_uniform_ptr = it->second.get();
-        auto* new_uniform_ptr = dynamic_cast<Uniform*>(uniform_interface.get());
-        if (new_uniform_ptr &&
-            new_uniform_ptr->GetUniformEnum() ==
-                proto::Uniform::INVALID_UNIFORM)
+        auto& old_data = it->second->GetData();
+        auto& new_data = uniform_interface->GetData();
+        if (new_data.uniform_enum() == proto::Uniform::INVALID_UNIFORM)
         {
-            new_uniform_ptr->SetUniformEnum(old_uniform_ptr->GetData().uniform_enum());
+            new_data.set_uniform_enum(old_data.uniform_enum());
         }
         uniform_map_[name] = std::move(uniform_interface);
     }

--- a/src/frame/opengl/program.cpp
+++ b/src/frame/opengl/program.cpp
@@ -122,15 +122,6 @@ void Program::AddUniformInternal(
     auto it = uniform_map_.find(name);
     if (it != uniform_map_.end())
     {
-        // Copy the existing enum before replacing the uniform to avoid any
-        // reference to destroyed data.
-        const proto::Uniform::UniformEnum old_enum =
-            it->second->GetData().uniform_enum();
-        if (uniform_interface->GetData().uniform_enum() ==
-            proto::Uniform::INVALID_UNIFORM)
-        {
-            uniform_interface->GetData().set_uniform_enum(old_enum);
-        }
         uniform_map_[name] = std::move(uniform_interface);
     }
     else

--- a/src/frame/opengl/program.cpp
+++ b/src/frame/opengl/program.cpp
@@ -122,14 +122,14 @@ void Program::AddUniformInternal(
     auto it = uniform_map_.find(name);
     if (it != uniform_map_.end())
     {
-        // Preserve the enum from the existing uniform if the new value does not
-        // specify one. This allows runtime updates to keep their original
-        // serialization identifier.
-        auto& old_data = it->second->GetData();
-        auto& new_data = uniform_interface->GetData();
-        if (new_data.uniform_enum() == proto::Uniform::INVALID_UNIFORM)
+        // Copy the existing enum before replacing the uniform to avoid any
+        // reference to destroyed data.
+        const proto::Uniform::UniformEnum old_enum =
+            it->second->GetData().uniform_enum();
+        if (uniform_interface->GetData().uniform_enum() ==
+            proto::Uniform::INVALID_UNIFORM)
         {
-            new_data.set_uniform_enum(old_data.uniform_enum());
+            uniform_interface->GetData().set_uniform_enum(old_enum);
         }
         uniform_map_[name] = std::move(uniform_interface);
     }

--- a/src/frame/opengl/program.h
+++ b/src/frame/opengl/program.h
@@ -164,8 +164,6 @@ class Program : public ProgramInterface
      * @return True if present false otherwise.
      */
     bool HasUniform(const std::string& name) const override;
-    bool HasUniformEnum(const std::string& name) const override;
-    proto::Uniform::UniformEnum GetUniformEnum(const std::string& name) const override;
 
   private:
     const Logger& logger_ = Logger::GetInstance();
@@ -179,7 +177,6 @@ class Program : public ProgramInterface
     EntityId scene_root_ = 0;
     std::vector<EntityId> input_texture_ids_ = {};
     std::vector<EntityId> output_texture_ids_ = {};
-    std::map<std::string, proto::Uniform::UniformEnum> name_uniform_enums_;
     std::string shader_name_;
     bool serialize_enable_ = false;
     mutable bool is_used_ = false;

--- a/src/frame/opengl/program.h
+++ b/src/frame/opengl/program.h
@@ -164,6 +164,8 @@ class Program : public ProgramInterface
      * @return True if present false otherwise.
      */
     bool HasUniform(const std::string& name) const override;
+    bool HasUniformEnum(const std::string& name) const override;
+    proto::Uniform::UniformEnum GetUniformEnum(const std::string& name) const override;
 
   private:
     const Logger& logger_ = Logger::GetInstance();

--- a/src/frame/opengl/program.h
+++ b/src/frame/opengl/program.h
@@ -178,7 +178,6 @@ class Program : public ProgramInterface
     std::vector<EntityId> input_texture_ids_ = {};
     std::vector<EntityId> output_texture_ids_ = {};
     std::string shader_name_;
-    bool serialize_enable_ = false;
     mutable bool is_used_ = false;
 };
 

--- a/src/frame/opengl/renderer.cpp
+++ b/src/frame/opengl/renderer.cpp
@@ -70,11 +70,13 @@ Renderer::Renderer(LevelInterface& level, glm::uvec4 viewport)
         throw std::runtime_error("No program!");
     auto material = std::make_unique<Material>();
     program->SetName("DisplayProgram");
+    program->SetSerializeEnable(false);
     auto maybe_display_program_id = level_.AddProgram(std::move(program));
     if (!maybe_display_program_id)
         throw std::runtime_error("No display program id.");
     display_program_id_ = maybe_display_program_id;
     material->SetName("DisplayMaterial");
+    material->SetSerializeEnable(false);
     auto maybe_display_material_id = level_.AddMaterial(std::move(material));
     if (!maybe_display_material_id)
         throw std::runtime_error("No display material id.");

--- a/src/frame/opengl/texture.cpp
+++ b/src/frame/opengl/texture.cpp
@@ -136,8 +136,6 @@ void Texture::CreateTextureFromPointer(
     {
         inner_size_ = size;
     }
-    // Store the actual texture size in the proto for later retrieval.
-    data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
     glGenTextures(1, &texture_id_);
     ScopedBind scoped_bind(*this);
     proto::TextureFilter texture_filter;
@@ -184,7 +182,6 @@ void Texture::CreateDepthTexture(
         proto::PixelElementSize_FLOAT()*/)
 {
     inner_size_ = size;
-    data_.mutable_size()->CopyFrom(json::SerializeSize(size));
     glGenTextures(1, &texture_id_);
     ScopedBind scoped_bind(*this);
     proto::TextureFilter texture_filter;
@@ -456,7 +453,6 @@ void Texture::Update(
     std::uint8_t bytes_per_pixel)
 {
     ScopedBind scoped_bind(*this);
-    data_.mutable_size()->CopyFrom(json::SerializeSize(size));
     assert(data_.pixel_element_size().value() == 1);
     auto format = opengl::ConvertToGLType(data_.pixel_structure());
     auto type = opengl::ConvertToGLType(data_.pixel_element_size());

--- a/src/frame/uniform.h
+++ b/src/frame/uniform.h
@@ -49,6 +49,24 @@ class Uniform : public UniformInterface
      * @param uniform_interface: The uniform interface to copy.
      */
     Uniform(const UniformInterface& uniform_interface);
+
+    /**
+     * @brief Get the enum stored in this uniform.
+     * @return The uniform enum value.
+     */
+    proto::Uniform::UniformEnum GetUniformEnum() const
+    {
+        return data_.uniform_enum();
+    }
+
+    /**
+     * @brief Set the enum stored in this uniform.
+     * @param uniform_enum: The uniform enum value.
+     */
+    void SetUniformEnum(proto::Uniform::UniformEnum uniform_enum)
+    {
+        data_.set_uniform_enum(uniform_enum);
+    }
 };
 
 } // End of namespace frame.


### PR DESCRIPTION
## Summary
- enable serialization for parsed textures and materials
- skip non-serializable textures and materials when saving levels
- avoid overriding texture size in Texture and Cubemap implementations

## Testing
- `cmake --preset linux-release` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_68469f6eb8c483298059c28d10f1a941