### PR TITLE
Fix FrameTest link order

### DIFF
--- a/src/frame/CMakeLists.txt
+++ b/src/frame/CMakeLists.txt
@@ -61,7 +61,6 @@ target_link_libraries(Frame
     absl::flags
     absl::flags_parse
     absl::strings
-    FrameJson
     SDL3::SDL3
     spdlog::spdlog
     glm::glm

--- a/src/frame/logger.cpp
+++ b/src/frame/logger.cpp
@@ -1,6 +1,6 @@
 #include "frame/logger.h"
 
-#include "include/frame/gui/gui_logger_sink.h"
+#include "frame/gui/gui_logger_sink.h"
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 

--- a/tests/frame/CMakeLists.txt
+++ b/tests/frame/CMakeLists.txt
@@ -24,6 +24,8 @@ target_link_libraries(FrameTest
   PUBLIC
     GTest::gmock
     GTest::gtest
+    Frame
+    FrameOpenGL
     FrameOpenGLFile
     FrameJson
 )

--- a/tests/frame/CMakeLists.txt
+++ b/tests/frame/CMakeLists.txt
@@ -24,8 +24,8 @@ target_link_libraries(FrameTest
   PUBLIC
     GTest::gmock
     GTest::gtest
-    FrameJson
     FrameOpenGLFile
+    FrameJson
 )
 
 # In order to remove the tests from the bin folder.

--- a/tests/frame/json/CMakeLists.txt
+++ b/tests/frame/json/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(FrameJsonTest
   PUBLIC
   Frame
   FrameFile
+  FrameJson
   FrameProto
   GTest::gmock
   GTest::gtest

--- a/tests/frame/opengl/CMakeLists.txt
+++ b/tests/frame/opengl/CMakeLists.txt
@@ -45,10 +45,10 @@ target_link_libraries(FrameOpenGLTest
   PUBLIC
     GTest::gmock
     GTest::gtest
-    FrameJson
     FrameFile
     FrameOpenGL
     FrameOpenGLFile
+    FrameJson
 )
 
 # In order to remove the tests from the bin folder.


### PR DESCRIPTION
## Summary
- break static library loop by not linking FrameJson into Frame
- link FrameJson after FrameOpenGLFile to resolve FrameTest link errors
- fix remaining test link orders

## Testing
- `cmake --preset linux-debug` *(fails: vcpkg install failed - missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684a8835f1008329864b057b34dfb1c1