### PR TITLE
Fix OpenGL texture metadata

### DIFF
--- a/src/frame/opengl/cubemap.cpp
+++ b/src/frame/opengl/cubemap.cpp
@@ -408,6 +408,7 @@ void Cubemap::CreateCubemapFromPointer(
     texture_id_ = cubemap.GetId();
     cubemap.texture_id_ = 0;
     inner_size_ = cube_pair_res;
+    data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
     // Keep the original size from the proto, inner_size_ stores the computed
     // resolution for the GPU.
 }
@@ -421,6 +422,7 @@ void Cubemap::CreateCubemapFromPointers(
     data_.mutable_pixel_element_size()->CopyFrom(pixel_element_size);
     data_.mutable_pixel_structure()->CopyFrom(pixel_structure);
     inner_size_ = size;
+    data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
     glGenTextures(1, &texture_id_);
     ScopedBind scoped_bind(*this);
     glTexParameteri(

--- a/src/frame/opengl/texture.cpp
+++ b/src/frame/opengl/texture.cpp
@@ -136,6 +136,7 @@ void Texture::CreateTextureFromPointer(
     {
         inner_size_ = size;
     }
+    data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
     glGenTextures(1, &texture_id_);
     ScopedBind scoped_bind(*this);
     proto::TextureFilter texture_filter;
@@ -182,6 +183,7 @@ void Texture::CreateDepthTexture(
         proto::PixelElementSize_FLOAT()*/)
 {
     inner_size_ = size;
+    data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
     glGenTextures(1, &texture_id_);
     ScopedBind scoped_bind(*this);
     proto::TextureFilter texture_filter;


### PR DESCRIPTION
## Summary
- propagate texture size to proto when creating OpenGL textures and cubemaps

## Testing
- `cmake --preset linux-debug` *(fails: vcpkg install failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ab84387c0832993f902ceeaf024ea