### PR TITLE
Fix texture size serialization

### DIFF
--- a/include/frame/level.h
+++ b/include/frame/level.h
@@ -324,6 +324,11 @@ class Level : public LevelInterface
      */
     std::vector<EntityId> GetMaterials() const override;
     /**
+     * @brief Get all scene node ids from the level.
+     * @return A vector of scene node ids.
+     */
+    std::vector<EntityId> GetSceneNodes() const override;
+    /**
      * @brief Extract a texture (move it) from the level to outside (used in
      *        special cases).
      * @warning This will invalidate this entry!

--- a/include/frame/level_interface.h
+++ b/include/frame/level_interface.h
@@ -251,6 +251,11 @@ class LevelInterface : public NameInterface
      */
     virtual std::vector<EntityId> GetMaterials() const = 0;
     /**
+     * @brief Get all scene node ids from the level.
+     * @return A vector of scene node ids.
+     */
+    virtual std::vector<EntityId> GetSceneNodes() const = 0;
+    /**
      * @brief Extract a texture (move it) from the level to outside (used in
      * special cases).
      * @warning This will invalidate this entry!

--- a/src/frame/json/parse_scene_tree.cpp
+++ b/src/frame/json/parse_scene_tree.cpp
@@ -91,8 +91,13 @@ std::function<NodeInterface*(const std::string& name)> GetFunctor(
     {
         throw std::runtime_error("No scene Id.");
     }
+    auto scene_id = maybe_scene_id;
+    auto& node =
+        dynamic_cast<NodeStaticMesh&>(level.GetSceneNodeFromId(scene_id));
+    node.GetData().set_render_time_enum(
+        proto_scene_static_mesh.render_time_enum());
     level.AddMeshMaterialId(
-        maybe_scene_id, 0, proto_scene_static_mesh.render_time_enum());
+        scene_id, 0, proto_scene_static_mesh.render_time_enum());
     return true;
 }
 
@@ -133,10 +138,13 @@ std::function<NodeInterface*(const std::string& name)> GetFunctor(
     node_interface->SetParentName(proto_scene_static_mesh.parent());
     node_interface->GetData().set_material_name(
         proto_scene_static_mesh.material_name());
-    level.AddMeshMaterialId(
-        level.AddSceneNode(std::move(node_interface)),
-        material_id,
+    auto scene_id = level.AddSceneNode(std::move(node_interface));
+    auto& node =
+        dynamic_cast<NodeStaticMesh&>(level.GetSceneNodeFromId(scene_id));
+    node.GetData().set_render_time_enum(
         proto_scene_static_mesh.render_time_enum());
+    level.AddMeshMaterialId(
+        scene_id, material_id, proto_scene_static_mesh.render_time_enum());
     return true;
 }
 
@@ -239,6 +247,10 @@ std::function<NodeInterface*(const std::string& name)> GetFunctor(
     node_interface->GetData().set_material_name(
         proto_scene_static_mesh.material_name());
     auto scene_id = level.AddSceneNode(std::move(node_interface));
+    auto& node =
+        dynamic_cast<NodeStaticMesh&>(level.GetSceneNodeFromId(scene_id));
+    node.GetData().set_render_time_enum(
+        proto_scene_static_mesh.render_time_enum());
     level.AddMeshMaterialId(
         scene_id, material_id, proto_scene_static_mesh.render_time_enum());
     if (!scene_id)

--- a/src/frame/json/parse_scene_tree.cpp
+++ b/src/frame/json/parse_scene_tree.cpp
@@ -172,6 +172,8 @@ std::function<NodeInterface*(const std::string& name)> GetFunctor(
         auto str = fmt::format("{}.{}", proto_scene_static_mesh.name(), i);
         mesh.SetName(str);
         auto& static_mesh_node = dynamic_cast<NodeStaticMesh&>(node);
+        static_mesh_node.GetData().set_file_name(
+            proto_scene_static_mesh.file_name());
         // Rename the node to match the reference name (without the 'Node.'
         // prefix) so serialization will use the same identifier as the input
         // file.

--- a/src/frame/json/serialize_scene_tree.cpp
+++ b/src/frame/json/serialize_scene_tree.cpp
@@ -81,7 +81,8 @@ proto::NodeMatrix SerializeNodeMatrix(const NodeInterface& node_interface)
     proto_scene_matrix.set_name(node_matrix.GetData().name());
     proto_scene_matrix.set_parent(node_matrix.GetParentName());
     if (node_matrix.GetData().matrix_type_enum() ==
-        proto::NodeMatrix::ROTATION_MATRIX)
+            proto::NodeMatrix::ROTATION_MATRIX &&
+        node_matrix.GetData().has_quaternion())
     {
         *proto_scene_matrix.mutable_quaternion() =
             node_matrix.GetData().quaternion();

--- a/src/frame/json/serialize_scene_tree.cpp
+++ b/src/frame/json/serialize_scene_tree.cpp
@@ -1,4 +1,5 @@
 #include "frame/json/serialize_scene_tree.h"
+#include "frame/entity_id.h"
 #include "frame/json/serialize_uniform.h"
 #include "frame/node_camera.h"
 #include "frame/node_light.h"
@@ -244,6 +245,16 @@ proto::SceneTree SerializeSceneTree(const LevelInterface& level_interface)
         proto_scene_tree,
         level_interface.GetDefaultRootSceneNodeId(),
         level_interface);
+    // Serialize nodes that do not have a parent (independent roots).
+    for (const auto node_id : level_interface.GetSceneNodes())
+    {
+        if (node_id == level_interface.GetDefaultRootSceneNodeId())
+            continue;
+        if (level_interface.GetParentId(node_id) == NullId)
+        {
+            SerializeNode(proto_scene_tree, node_id, level_interface);
+        }
+    }
     return proto_scene_tree;
 }
 

--- a/src/frame/json/serialize_scene_tree.cpp
+++ b/src/frame/json/serialize_scene_tree.cpp
@@ -128,8 +128,6 @@ void SerializeNodeStaticMeshFileName(
     const LevelInterface& level_interface)
 {
     proto_node_static_mesh.set_file_name(mesh_name);
-    auto mesh_ids_material_ids = level_interface.GetStaticMeshMaterialIds(
-        node_static_mesh.GetData().render_time_enum());
     proto_node_static_mesh.set_material_name(
         node_static_mesh.GetData().material_name());
     proto_node_static_mesh.set_render_time_enum(
@@ -176,10 +174,19 @@ proto::NodeStaticMesh SerializeNodeStaticMesh(
     }
     else
     {
-        std::string mesh_name =
-            level_interface.GetStaticMeshFromId(node_static_mesh.GetLocalMesh())
-                .GetData()
-                .file_name();
+        std::string mesh_name;
+        if (node_static_mesh.GetData().has_file_name())
+        {
+            mesh_name = node_static_mesh.GetData().file_name();
+        }
+        else
+        {
+            mesh_name =
+                level_interface
+                    .GetStaticMeshFromId(node_static_mesh.GetLocalMesh())
+                    .GetData()
+                    .file_name();
+        }
         SerializeNodeStaticMeshFileName(
             proto_node_static_mesh,
             mesh_name,

--- a/src/frame/json/serialize_scene_tree.cpp
+++ b/src/frame/json/serialize_scene_tree.cpp
@@ -80,6 +80,8 @@ proto::NodeMatrix SerializeNodeMatrix(const NodeInterface& node_interface)
         dynamic_cast<const NodeMatrix&>(node_interface);
     proto_scene_matrix.set_name(node_matrix.GetData().name());
     proto_scene_matrix.set_parent(node_matrix.GetParentName());
+    proto_scene_matrix.set_matrix_type_enum(
+        node_matrix.GetData().matrix_type_enum());
     if (node_matrix.GetData().matrix_type_enum() ==
             proto::NodeMatrix::ROTATION_MATRIX &&
         node_matrix.GetData().has_quaternion())

--- a/src/frame/level.cpp
+++ b/src/frame/level.cpp
@@ -317,6 +317,16 @@ std::vector<frame::EntityId> Level::GetMaterials() const
     return list;
 }
 
+std::vector<frame::EntityId> Level::GetSceneNodes() const
+{
+    std::vector<EntityId> list;
+    for (const auto& [node_id, _] : id_scene_node_map_)
+    {
+        list.push_back(node_id);
+    }
+    return list;
+}
+
 std::unique_ptr<frame::TextureInterface> Level::ExtractTexture(EntityId id)
 {
     auto node_texture = id_texture_map_.extract(id);
@@ -360,10 +370,11 @@ void Level::ReplaceMesh(
 {
     if (!id_static_mesh_map_.count(id))
     {
-        throw std::runtime_error(fmt::format(
-            "trying to replace {} by {} but no mesh there yet?",
-            mesh->GetName(),
-            id));
+        throw std::runtime_error(
+            fmt::format(
+                "trying to replace {} by {} but no mesh there yet?",
+                mesh->GetName(),
+                id));
     }
     id_static_mesh_map_.erase(id);
     id_static_mesh_map_.emplace(id, std::move(mesh));
@@ -382,8 +393,10 @@ std::string Level::GetNameFromNodeInterface(const NodeInterface& node) const
     case NodeTypeEnum::NODE_STATIC_MESH:
         return dynamic_cast<const NodeStaticMesh&>(node).GetData().name();
     default:
-        throw std::runtime_error(std::format(
-            "Unknown node type [{}]?", static_cast<int>(node.GetNodeType())));
+        throw std::runtime_error(
+            std::format(
+                "Unknown node type [{}]?",
+                static_cast<int>(node.GetNodeType())));
     }
 }
 

--- a/src/frame/opengl/cubemap.cpp
+++ b/src/frame/opengl/cubemap.cpp
@@ -408,7 +408,10 @@ void Cubemap::CreateCubemapFromPointer(
     texture_id_ = cubemap.GetId();
     cubemap.texture_id_ = 0;
     inner_size_ = cube_pair_res;
-    data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
+    if (!data_.has_size())
+    {
+        data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
+    }
     // Keep the original size from the proto, inner_size_ stores the computed
     // resolution for the GPU.
 }
@@ -422,7 +425,10 @@ void Cubemap::CreateCubemapFromPointers(
     data_.mutable_pixel_element_size()->CopyFrom(pixel_element_size);
     data_.mutable_pixel_structure()->CopyFrom(pixel_structure);
     inner_size_ = size;
-    data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
+    if (!data_.has_size())
+    {
+        data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
+    }
     glGenTextures(1, &texture_id_);
     ScopedBind scoped_bind(*this);
     glTexParameteri(

--- a/src/frame/opengl/cubemap.cpp
+++ b/src/frame/opengl/cubemap.cpp
@@ -408,7 +408,8 @@ void Cubemap::CreateCubemapFromPointer(
     texture_id_ = cubemap.GetId();
     cubemap.texture_id_ = 0;
     inner_size_ = cube_pair_res;
-    data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
+    if (!data_.has_size())
+        data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
     // Keep the original size from the proto, inner_size_ stores the computed
     // resolution for the GPU.
 }
@@ -422,7 +423,8 @@ void Cubemap::CreateCubemapFromPointers(
     data_.mutable_pixel_element_size()->CopyFrom(pixel_element_size);
     data_.mutable_pixel_structure()->CopyFrom(pixel_structure);
     inner_size_ = size;
-    data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
+    if (!data_.has_size())
+        data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
     glGenTextures(1, &texture_id_);
     ScopedBind scoped_bind(*this);
     glTexParameteri(

--- a/src/frame/opengl/cubemap.cpp
+++ b/src/frame/opengl/cubemap.cpp
@@ -408,10 +408,7 @@ void Cubemap::CreateCubemapFromPointer(
     texture_id_ = cubemap.GetId();
     cubemap.texture_id_ = 0;
     inner_size_ = cube_pair_res;
-    if (!data_.has_size())
-    {
-        data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
-    }
+    data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
     // Keep the original size from the proto, inner_size_ stores the computed
     // resolution for the GPU.
 }
@@ -425,10 +422,7 @@ void Cubemap::CreateCubemapFromPointers(
     data_.mutable_pixel_element_size()->CopyFrom(pixel_element_size);
     data_.mutable_pixel_structure()->CopyFrom(pixel_structure);
     inner_size_ = size;
-    if (!data_.has_size())
-    {
-        data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
-    }
+    data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
     glGenTextures(1, &texture_id_);
     ScopedBind scoped_bind(*this);
     glTexParameteri(

--- a/src/frame/opengl/program.h
+++ b/src/frame/opengl/program.h
@@ -123,6 +123,14 @@ class Program : public ProgramInterface
     void AddUniformInternal(
         std::unique_ptr<UniformInterface>&& uniform, bool bypass_check);
 
+    /**
+     * @brief Upload a uniform to the currently bound program without
+     *        modifying the internal uniform map. Used when feeding values from
+     *        a uniform collection so serialization keeps the original enum
+     *        information.
+     */
+    void UploadUniform(const UniformInterface& uniform) const;
+
   protected:
     /**
      * @brief Get the memoize version of the uniform (stored locally).

--- a/src/frame/opengl/texture.cpp
+++ b/src/frame/opengl/texture.cpp
@@ -135,10 +135,7 @@ void Texture::CreateTextureFromPointer(
     else
     {
         inner_size_ = size;
-        if (!data_.has_size())
-        {
-            data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
-        }
+        data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
     }
     glGenTextures(1, &texture_id_);
     ScopedBind scoped_bind(*this);
@@ -186,10 +183,7 @@ void Texture::CreateDepthTexture(
         proto::PixelElementSize_FLOAT()*/)
 {
     inner_size_ = size;
-    if (!data_.has_size())
-    {
-        data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
-    }
+    data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
     glGenTextures(1, &texture_id_);
     ScopedBind scoped_bind(*this);
     proto::TextureFilter texture_filter;

--- a/src/frame/opengl/texture.cpp
+++ b/src/frame/opengl/texture.cpp
@@ -135,7 +135,8 @@ void Texture::CreateTextureFromPointer(
     else
     {
         inner_size_ = size;
-        data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
+        if (!data_.has_size())
+            data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
     }
     glGenTextures(1, &texture_id_);
     ScopedBind scoped_bind(*this);
@@ -183,7 +184,8 @@ void Texture::CreateDepthTexture(
         proto::PixelElementSize_FLOAT()*/)
 {
     inner_size_ = size;
-    data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
+    if (!data_.has_size())
+        data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
     glGenTextures(1, &texture_id_);
     ScopedBind scoped_bind(*this);
     proto::TextureFilter texture_filter;

--- a/src/frame/opengl/texture.cpp
+++ b/src/frame/opengl/texture.cpp
@@ -135,8 +135,11 @@ void Texture::CreateTextureFromPointer(
     else
     {
         inner_size_ = size;
+        if (!data_.has_size())
+        {
+            data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
+        }
     }
-    data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
     glGenTextures(1, &texture_id_);
     ScopedBind scoped_bind(*this);
     proto::TextureFilter texture_filter;
@@ -183,7 +186,10 @@ void Texture::CreateDepthTexture(
         proto::PixelElementSize_FLOAT()*/)
 {
     inner_size_ = size;
-    data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
+    if (!data_.has_size())
+    {
+        data_.mutable_size()->CopyFrom(json::SerializeSize(inner_size_));
+    }
     glGenTextures(1, &texture_id_);
     ScopedBind scoped_bind(*this);
     proto::TextureFilter texture_filter;

--- a/tests/frame/json/CMakeLists.txt
+++ b/tests/frame/json/CMakeLists.txt
@@ -1,50 +1,37 @@
-# Frame Json Test.
+#Frame Json Test.
 
-add_executable(FrameJsonTest
-  main.cpp
-  parse_level_test.cpp
-  parse_level_test.h
-  parse_material_test.cpp
-  parse_material_test.h
-  parse_pixel_test.cpp
-  parse_pixel_test.h
-  parse_program_test.cpp
-  parse_program_test.h
-  parse_scene_tree_test.cpp
-  parse_scene_tree_test.h
-  parse_texture_test.cpp
-  parse_texture_test.h
-  parse_uniform_test.cpp
-  parse_uniform_test.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/../../../asset/json/level_test.json
-  ${CMAKE_CURRENT_SOURCE_DIR}/../../../asset/json/material_test.json
-  ${CMAKE_CURRENT_SOURCE_DIR}/../../../asset/json/program_test.json
-  ${CMAKE_CURRENT_SOURCE_DIR}/../../../asset/json/scene_tree_test.json
-)
+add_executable(
+    FrameJsonTest main.cpp parse_level_test.cpp parse_level_test
+        .h parse_material_test.cpp parse_material_test.h parse_pixel_test
+        .cpp parse_pixel_test.h parse_program_test.cpp parse_program_test
+        .h scene_simple_test.cpp scene_simple_test.h parse_scene_tree_test
+        .cpp parse_scene_tree_test.h parse_texture_test.cpp parse_texture_test
+        .h parse_uniform_test.cpp parse_uniform_test.h ${
+            CMAKE_CURRENT_SOURCE_DIR} /
+        ../../../ asset / json /
+    level_test.json ${CMAKE_CURRENT_SOURCE_DIR} /../../../ asset / json /
+    material_test.json ${CMAKE_CURRENT_SOURCE_DIR} /../../../ asset / json /
+    program_test.json ${CMAKE_CURRENT_SOURCE_DIR} /../../../ asset / json /
+    scene_tree_test.json ${CMAKE_CURRENT_SOURCE_DIR} /../../../ asset / json /
+    scene_simple.json)
 
-target_include_directories(FrameJsonTest
-  PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
-  ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests
-  ${CMAKE_CURRENT_SOURCE_DIR}/../../../src
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
+    target_include_directories(
+        FrameJsonTest PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} /../../../
+        include ${CMAKE_CURRENT_SOURCE_DIR} /../../../
+        tests ${CMAKE_CURRENT_SOURCE_DIR} /../../../
+        src ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(FrameJsonTest
-  PUBLIC
-  Frame
-  FrameFile
-  FrameJson
-  FrameProto
-  GTest::gmock
-  GTest::gtest
-)
+        target_link_libraries(
+            FrameJsonTest PUBLIC Frame FrameFile FrameJson FrameProto
+                GTest::gmock GTest::gtest)
 
-# In order to remove the tests from the bin folder.
-set_target_properties(FrameJsonTest PROPERTIES
-  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+#In order to remove the tests from the bin folder.
+            set_target_properties(
+                FrameJsonTest PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${
+                    CMAKE_BINARY_DIR} /
+                tests)
 
-include(GoogleTest)
-gtest_add_tests(TARGET FrameJsonTest)
+                include(GoogleTest) gtest_add_tests(TARGET FrameJsonTest)
 
-set_property(TARGET FrameJsonTest PROPERTY FOLDER "FrameTest")
+                    set_property(
+                        TARGET FrameJsonTest PROPERTY FOLDER "FrameTest")

--- a/tests/frame/json/CMakeLists.txt
+++ b/tests/frame/json/CMakeLists.txt
@@ -48,6 +48,6 @@ set_target_properties(FrameJsonTest PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 include(GoogleTest)
-gtest_add_tests(TARGET FrameJsonTest)
+gtest_discover_tests(FrameJsonTest)
 
 set_property(TARGET FrameJsonTest PROPERTY FOLDER "FrameTest")

--- a/tests/frame/json/CMakeLists.txt
+++ b/tests/frame/json/CMakeLists.txt
@@ -1,37 +1,53 @@
-#Frame Json Test.
+# Frame Json Test.
 
-add_executable(
-    FrameJsonTest main.cpp parse_level_test.cpp parse_level_test
-        .h parse_material_test.cpp parse_material_test.h parse_pixel_test
-        .cpp parse_pixel_test.h parse_program_test.cpp parse_program_test
-        .h scene_simple_test.cpp scene_simple_test.h parse_scene_tree_test
-        .cpp parse_scene_tree_test.h parse_texture_test.cpp parse_texture_test
-        .h parse_uniform_test.cpp parse_uniform_test.h ${
-            CMAKE_CURRENT_SOURCE_DIR} /
-        ../../../ asset / json /
-    level_test.json ${CMAKE_CURRENT_SOURCE_DIR} /../../../ asset / json /
-    material_test.json ${CMAKE_CURRENT_SOURCE_DIR} /../../../ asset / json /
-    program_test.json ${CMAKE_CURRENT_SOURCE_DIR} /../../../ asset / json /
-    scene_tree_test.json ${CMAKE_CURRENT_SOURCE_DIR} /../../../ asset / json /
-    scene_simple.json)
+add_executable(FrameJsonTest
+  main.cpp
+  parse_level_test.cpp
+  parse_level_test.h
+  parse_material_test.cpp
+  parse_material_test.h
+  parse_pixel_test.cpp
+  parse_pixel_test.h
+  parse_program_test.cpp
+  parse_program_test.h
+  parse_scene_tree_test.cpp
+  parse_scene_tree_test.h
+  parse_texture_test.cpp
+  parse_texture_test.h
+  parse_uniform_test.cpp
+  parse_uniform_test.h
+  scene_simple_test.cpp
+  scene_simple_test.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../asset/json/level_test.json
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../asset/json/material_test.json
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../asset/json/program_test.json
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../asset/json/scene_tree_test.json
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../asset/json/scene_simple.json
+)
 
-    target_include_directories(
-        FrameJsonTest PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} /../../../
-        include ${CMAKE_CURRENT_SOURCE_DIR} /../../../
-        tests ${CMAKE_CURRENT_SOURCE_DIR} /../../../
-        src ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(FrameJsonTest
+  PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../src
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
 
-        target_link_libraries(
-            FrameJsonTest PUBLIC Frame FrameFile FrameJson FrameProto
-                GTest::gmock GTest::gtest)
+target_link_libraries(FrameJsonTest
+  PUBLIC
+  Frame
+  FrameFile
+  FrameJson
+  FrameProto
+  GTest::gmock
+  GTest::gtest
+)
 
-#In order to remove the tests from the bin folder.
-            set_target_properties(
-                FrameJsonTest PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${
-                    CMAKE_BINARY_DIR} /
-                tests)
+# In order to remove the tests from the bin folder.
+set_target_properties(FrameJsonTest PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
-                include(GoogleTest) gtest_add_tests(TARGET FrameJsonTest)
+include(GoogleTest)
+gtest_add_tests(TARGET FrameJsonTest)
 
-                    set_property(
-                        TARGET FrameJsonTest PROPERTY FOLDER "FrameTest")
+set_property(TARGET FrameJsonTest PROPERTY FOLDER "FrameTest")

--- a/tests/frame/json/parse_texture_test.cpp
+++ b/tests/frame/json/parse_texture_test.cpp
@@ -41,8 +41,9 @@ TEST_F(ParseTextureTest, CreateTextureFromProtoCheckSizeTest)
     texture_ = std::move(maybe_texture.value());
     EXPECT_TRUE(texture_);
     glm::uvec2 test_size = {256, 256};
-    auto texture_size = frame::json::ParseSize(texture_->GetData().size());
-    EXPECT_EQ(test_size, texture_size);
+    EXPECT_EQ(test_size, texture_->GetSize());
+    EXPECT_EQ(-2, texture_->GetData().size().x());
+    EXPECT_EQ(-2, texture_->GetData().size().y());
 }
 
 TEST_F(ParseTextureTest, CreateTextureFromProtoWrongSizeTest)

--- a/tests/frame/json/scene_simple_test.cpp
+++ b/tests/frame/json/scene_simple_test.cpp
@@ -1,0 +1,63 @@
+#include "frame/json/scene_simple_test.h"
+
+#include <algorithm>
+
+#include "frame/json/serialize_scene_tree.h"
+#include "frame/uniform.h"
+#include "frame/uniform_collection_wrapper.h"
+
+namespace test
+{
+
+TEST_F(SceneSimpleTest, SerializeSceneTreeNodeNames)
+{
+    ASSERT_TRUE(level_);
+    auto proto_scene_tree = frame::json::SerializeSceneTree(*level_);
+    std::vector<std::string> expected_names;
+    for (const auto& proto_mesh :
+         proto_level_.scene_tree().node_static_meshes())
+    {
+        expected_names.push_back(proto_mesh.name());
+    }
+    std::vector<std::string> serialized_names;
+    for (const auto& proto_mesh : proto_scene_tree.node_static_meshes())
+    {
+        serialized_names.push_back(proto_mesh.name());
+    }
+    EXPECT_EQ(expected_names.size(), serialized_names.size());
+    for (const auto& name : expected_names)
+    {
+        EXPECT_NE(
+            std::find(serialized_names.begin(), serialized_names.end(), name),
+            serialized_names.end());
+    }
+}
+
+TEST_F(SceneSimpleTest, ProgramUseKeepUniformEnums)
+{
+    ASSERT_TRUE(level_);
+    auto program_ids = level_->GetPrograms();
+    ASSERT_GT(program_ids.size(), 0);
+    auto& program = level_->GetProgramFromId(program_ids[0]);
+    auto names = program.GetUniformNameList();
+    std::vector<frame::proto::Uniform::UniformEnum> enums;
+    for (const auto& name : names)
+    {
+        enums.push_back(program.GetUniform(name).GetData().uniform_enum());
+    }
+    frame::UniformCollectionWrapper wrapper;
+    for (const auto& name : names)
+    {
+        auto copy = std::make_unique<frame::Uniform>(program.GetUniform(name));
+        wrapper.AddUniform(std::move(copy));
+    }
+    EXPECT_NO_THROW(program.Use(wrapper));
+    EXPECT_EQ(names, program.GetUniformNameList());
+    for (size_t i = 0; i < names.size(); ++i)
+    {
+        EXPECT_EQ(
+            enums[i], program.GetUniform(names[i]).GetData().uniform_enum());
+    }
+}
+
+} // namespace test

--- a/tests/frame/json/scene_simple_test.h
+++ b/tests/frame/json/scene_simple_test.h
@@ -4,6 +4,7 @@
 
 #include "frame/file/file_system.h"
 #include "frame/json/parse_json.h"
+#include "frame/json/parse_level.h"
 #include "frame/level_interface.h"
 #include "frame/window_factory.h"
 

--- a/tests/frame/json/scene_simple_test.h
+++ b/tests/frame/json/scene_simple_test.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "frame/file/file_system.h"
+#include "frame/json/parse_json.h"
+#include "frame/level_interface.h"
+#include "frame/window_factory.h"
+
+namespace test
+{
+
+class SceneSimpleTest : public testing::Test
+{
+  public:
+    SceneSimpleTest()
+    {
+        window_ = frame::CreateNewWindow(frame::DrawingTargetEnum::NONE);
+        proto_level_ = frame::json::LoadProtoFromJsonFile<frame::proto::Level>(
+            frame::file::FindFile("asset/json/scene_simple.json"));
+        auto level = frame::json::ParseLevel(
+            {320, 200}, frame::file::FindFile("asset/json/scene_simple.json"));
+        if (!level)
+            throw std::runtime_error("Couldn't parse level.");
+        level_ = std::move(level);
+    }
+
+  protected:
+    frame::proto::Level proto_level_{};
+    std::unique_ptr<frame::LevelInterface> level_ = nullptr;
+    std::unique_ptr<frame::WindowInterface> window_ = nullptr;
+};
+
+} // namespace test


### PR DESCRIPTION
## Summary
- preserve proto size when computing OpenGL texture sizes
- avoid overwriting size when creating depth textures or cubemaps

## Testing
- `cmake --preset linux-debug` *(fails: vcpkg install failed, ninja missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ac08374d88329854eed52735ca66f