### PR TITLE
Fix cubemap creation from files

### DIFF
--- a/src/frame/opengl/cubemap.cpp
+++ b/src/frame/opengl/cubemap.cpp
@@ -311,7 +311,9 @@ void Cubemap::CreateCubemapFromFiles(
     {
         paths.push_back(file_name);
         auto image_ptr = std::make_unique<frame::file::Image>(
-            frame::file::FindFile(file_name));
+            frame::file::FindFile(file_name),
+            pixel_element_size,
+            pixel_structure);
         images.push_back(std::move(image_ptr));
     }
     proto::CubemapFiles cubemap_files;


### PR DESCRIPTION
## Summary
- pass requested pixel format when loading cubemap faces

## Testing
- `cmake --preset linux-debug` *(fails: vcpkg install failed)*

------
https://chatgpt.com/codex/tasks/task_e_684dac07a5b483299aa020bd696db6ad