### PR TITLE
Unify test output directory

### DIFF
--- a/tests/frame/CMakeLists.txt
+++ b/tests/frame/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(FrameTest
 
 # In order to remove the tests from the bin folder.
 set_target_properties(FrameTest PROPERTIES
-  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests)
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 include(GoogleTest)
 gtest_add_tests(TARGET FrameTest)

--- a/tests/frame/opengl/file/CMakeLists.txt
+++ b/tests/frame/opengl/file/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(FrameOpenGLFileTest
 
 # In order to remove the tests from the bin folder.
 set_target_properties(FrameOpenGLFileTest PROPERTIES
-  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests)
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 include(GoogleTest)
 gtest_add_tests(TARGET FrameOpenGLFileTest)


### PR DESCRIPTION
## Summary
- set all test executables to use `${CMAKE_BINARY_DIR}/tests` as runtime output directory

## Testing
- `cmake --preset linux-debug` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_684dae89d144832981c43c12b2a43f95