### PR TITLE
Fix cubemap orientation mismatch

### DIFF
--- a/asset/shader/opengl/irradiance_cubemap.frag
+++ b/asset/shader/opengl/irradiance_cubemap.frag
@@ -15,8 +15,8 @@ void main()
     // incoming radiance of the environment. The result of this radiance
     // is the radiance of light coming from -Normal direction, which is what
     // we use in the PBR shader to sample irradiance.
-    // Flip the Y axis to align with the cubemap convention.
-    vec3 normal = normalize(vec3(vert_local.x, -vert_local.y, vert_local.z));
+    // Flip Y and Z axes to mirror the skybox orientation.
+    vec3 normal = normalize(vec3(vert_local.x, -vert_local.y, -vert_local.z));
     vec3 irradiance = vec3(0.0);
 
     vec3 up = vec3(0.0, 1.0, 0.0);


### PR DESCRIPTION
## Summary
- ensure cubemap views use the same orientation across the codebase

## Testing
- `cmake --preset linux-debug` *(fails: Could not find toolchain file /workspace/Frame/external/vcpkg/scripts/buildsystems/vcpkg.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_684ed052413c832998468e52b5b98e86