### PR TITLE
Refactor cubemap view matrices into shared header

### DIFF
--- a/src/frame/opengl/CMakeLists.txt
+++ b/src/frame/opengl/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(FrameOpenGL
     texture.h
     cubemap.cpp
     cubemap.h
+    cubemap_views.h
     sdl_opengl_none.cpp
     sdl_opengl_none.h
     sdl_opengl_window.cpp

--- a/src/frame/opengl/cubemap.cpp
+++ b/src/frame/opengl/cubemap.cpp
@@ -14,6 +14,7 @@
 #include "frame/json/parse_uniform.h"
 #include "frame/json/serialize_uniform.h"
 #include "frame/level.h"
+#include "frame/opengl/cubemap_views.h"
 #include "frame/opengl/file/load_program.h"
 #include "frame/opengl/frame_buffer.h"
 #include "frame/opengl/pixel.h"
@@ -27,32 +28,7 @@ namespace frame::opengl
 
 namespace
 {
-// Get the 6 view for the cube map.
-const std::array<glm::mat4, 6> views_cubemap = {
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(-1.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, 1.0f, 0.0f)),
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(1.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, 1.0f, 0.0f)),
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, -1.0f, 0.0f),
-        glm::vec3(0.0f, 0.0f, 1.0f)),
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, 1.0f, 0.0f),
-        glm::vec3(0.0f, 0.0f, -1.0f)),
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, 0.0f, 1.0f),
-        glm::vec3(0.0f, 1.0f, 0.0f)),
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, 0.0f, -1.0f),
-        glm::vec3(0.0f, 1.0f, 0.0f))};
+// View matrices for each cubemap face (see cubemap_views.h).
 // Projection cube map.
 const glm::mat4 projection_cubemap =
     glm::perspective(glm::radians(90.0f), 1.0f, 0.01f, 10.0f);
@@ -392,12 +368,12 @@ void Cubemap::CreateCubemapFromPointer(
     {
         renderer.SetCubeMapTarget(Cubemap::GetTextureFrameFromPosition(i));
         renderer.RenderMesh(
-            mesh_ref, material_ref, projection_cubemap, views_cubemap[i]);
+            mesh_ref, material_ref, projection_cubemap, kCubemapViews[i]);
     }
     // FIXME(anirul): Why?
     renderer.SetCubeMapTarget(Cubemap::GetTextureFrameFromPosition(0));
     renderer.RenderMesh(
-        mesh_ref, material_ref, projection_cubemap, views_cubemap[0]);
+        mesh_ref, material_ref, projection_cubemap, kCubemapViews[0]);
     // Get the output image (cube map).
     auto maybe_output_id = level->GetIdFromName("OutputTexture");
     if (!maybe_output_id)

--- a/src/frame/opengl/cubemap_views.h
+++ b/src/frame/opengl/cubemap_views.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <array>
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+namespace frame::opengl
+{
+
+/**
+ * @brief Predefined view matrices for capturing cubemap faces.
+ *
+ * The orientation matches the skybox vertex shader which flips the Y and Z
+ * axes (rotation of 180 degrees around X).
+ */
+inline constexpr std::array<glm::mat4, 6> kCubemapViews = {
+    glm::lookAt(
+        glm::vec3(0.0f, 0.0f, 0.0f),
+        glm::vec3(1.0f, 0.0f, 0.0f),
+        glm::vec3(0.0f, -1.0f, 0.0f)),
+    glm::lookAt(
+        glm::vec3(0.0f, 0.0f, 0.0f),
+        glm::vec3(-1.0f, 0.0f, 0.0f),
+        glm::vec3(0.0f, -1.0f, 0.0f)),
+    glm::lookAt(
+        glm::vec3(0.0f, 0.0f, 0.0f),
+        glm::vec3(0.0f, 1.0f, 0.0f),
+        glm::vec3(0.0f, 0.0f, 1.0f)),
+    glm::lookAt(
+        glm::vec3(0.0f, 0.0f, 0.0f),
+        glm::vec3(0.0f, -1.0f, 0.0f),
+        glm::vec3(0.0f, 0.0f, -1.0f)),
+    glm::lookAt(
+        glm::vec3(0.0f, 0.0f, 0.0f),
+        glm::vec3(0.0f, 0.0f, 1.0f),
+        glm::vec3(0.0f, -1.0f, 0.0f)),
+    glm::lookAt(
+        glm::vec3(0.0f, 0.0f, 0.0f),
+        glm::vec3(0.0f, 0.0f, -1.0f),
+        glm::vec3(0.0f, -1.0f, 0.0f))};
+
+} // namespace frame::opengl

--- a/src/frame/opengl/fill.cpp
+++ b/src/frame/opengl/fill.cpp
@@ -10,38 +10,14 @@
 #include "frame/open_gl/render_buffer.h"
 #include "frame/open_gl/renderer.h"
 #include "frame/open_gl/static_mesh.h"
+#include "frame/opengl/cubemap_views.h"
 
 namespace frame::opengl
 {
 
 namespace
 {
-// Get the 6 view for the cube map.
-const std::array<glm::mat4, 6> views_cubemap = {
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(1.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, -1.0f, 0.0f)),
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(-1.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, -1.0f, 0.0f)),
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, 1.0f, 0.0f),
-        glm::vec3(0.0f, 0.0f, 1.0f)),
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, -1.0f, 0.0f),
-        glm::vec3(0.0f, 0.0f, -1.0f)),
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, 0.0f, 1.0f),
-        glm::vec3(0.0f, -1.0f, 0.0f)),
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, 0.0f, -1.0f),
-        glm::vec3(0.0f, -1.0f, 0.0f))};
+// View matrices for each cubemap face (see cubemap_views.h).
 } // namespace
 
 void FillProgramMultiTexture(
@@ -174,7 +150,7 @@ void FillProgramMultiTextureCubeMapMipmap(
         frame.AttachRender(render);
         glViewport(0, 0, temporary_size.first, temporary_size.second);
         int cubemap_element = 0;
-        for (const auto& view : views_cubemap)
+        for (const auto& view : kCubemapViews)
         {
             int i = 0;
             for (const auto& texture_id : program->GetOutputTextureIds())

--- a/src/frame/opengl/renderer.cpp
+++ b/src/frame/opengl/renderer.cpp
@@ -11,6 +11,7 @@
 #include "frame/node_matrix.h"
 #include "frame/node_static_mesh.h"
 #include "frame/opengl/cubemap.h"
+#include "frame/opengl/cubemap_views.h"
 #include "frame/opengl/file/load_program.h"
 #include "frame/opengl/material.h"
 #include "frame/opengl/static_mesh.h"
@@ -22,32 +23,7 @@ namespace frame::opengl
 
 namespace
 {
-// Get the 6 view for the cube map.
-const std::array<glm::mat4, 6> views_cubemap = {
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(-1.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, 1.0f, 0.0f)),
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(1.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, 1.0f, 0.0f)),
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, -1.0f, 0.0f),
-        glm::vec3(0.0f, 0.0f, 1.0f)),
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, 1.0f, 0.0f),
-        glm::vec3(0.0f, 0.0f, -1.0f)),
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, 0.0f, 1.0f),
-        glm::vec3(0.0f, 1.0f, 0.0f)),
-    glm::lookAt(
-        glm::vec3(0.0f, 0.0f, 0.0f),
-        glm::vec3(0.0f, 0.0f, -1.0f),
-        glm::vec3(0.0f, 1.0f, 0.0f))};
+// View matrices for each cubemap face (see cubemap_views.h).
 // Projection cube map.
 const glm::mat4 projection_cubemap =
     glm::perspective(glm::radians(90.0f), 1.0f, 0.01f, 10.0f);
@@ -279,10 +255,11 @@ void Renderer::RenderMesh(
                 nullptr);
             break;
         default:
-            throw std::runtime_error(std::format(
-                "Couldn't draw primitive {}",
-                proto::NodeStaticMesh_RenderPrimitiveEnum_Name(
-                    static_mesh.GetData().render_primitive_enum())));
+            throw std::runtime_error(
+                std::format(
+                    "Couldn't draw primitive {}",
+                    proto::NodeStaticMesh_RenderPrimitiveEnum_Name(
+                        static_mesh.GetData().render_primitive_enum())));
         }
         gl_index_buffer.UnBind();
     }
@@ -397,20 +374,22 @@ void Renderer::PreRender()
             for (std::uint32_t i = 0; i < 6; ++i)
             {
                 proto::TextureFrame texture_frame;
-                texture_frame.set_value(static_cast<proto::TextureFrame::Enum>(
-                    proto::TextureFrame::CUBE_MAP_POSITIVE_X + i));
+                texture_frame.set_value(
+                    static_cast<proto::TextureFrame::Enum>(
+                        proto::TextureFrame::CUBE_MAP_POSITIVE_X + i));
                 SetCubeMapTarget(texture_frame);
                 RenderNode(
-                    p.first, material_id, projection_cubemap, views_cubemap[i]);
+                    p.first, material_id, projection_cubemap, kCubemapViews[i]);
             }
             {
                 // Again why?
                 proto::TextureFrame texture_frame;
-                texture_frame.set_value(static_cast<proto::TextureFrame::Enum>(
-                    proto::TextureFrame::CUBE_MAP_POSITIVE_X));
+                texture_frame.set_value(
+                    static_cast<proto::TextureFrame::Enum>(
+                        proto::TextureFrame::CUBE_MAP_POSITIVE_X));
                 SetCubeMapTarget(texture_frame);
                 RenderNode(
-                    p.first, material_id, projection_cubemap, views_cubemap[0]);
+                    p.first, material_id, projection_cubemap, kCubemapViews[0]);
             }
             viewport_ = temp_viewport;
         }
@@ -438,10 +417,11 @@ void Renderer::RenderShadows(const CameraInterface& camera)
         auto texture_id = level_.GetIdFromName(texture_name);
         if (texture_id == NullId)
         {
-            throw std::runtime_error(fmt::format(
-                "Couldn't find texture {} for light {}",
-                texture_name,
-                light.GetName()));
+            throw std::runtime_error(
+                fmt::format(
+                    "Couldn't find texture {} for light {}",
+                    texture_name,
+                    light.GetName()));
         }
         // Save the current context.
         std::unique_ptr<FrameBuffer> temp_frame_buffer =
@@ -516,7 +496,7 @@ void Renderer::RenderShadows(const CameraInterface& camera)
                     // If you want that single “camera-based” pass:
                     glm::mat4 proj =
                         glm::perspective(glm::radians(90.f), 1.f, 0.1f, 1000.f);
-                    glm::mat4 rotation = views_cubemap[i];
+                    glm::mat4 rotation = kCubemapViews[i];
                     glm::mat4 translation =
                         glm::translate(glm::mat4(1.0f), -light.GetVector());
                     glm::mat4 view = rotation * translation;


### PR DESCRIPTION
## Summary
- add `kCubemapViews` helper defining the six cubemap orientations
- include the helper in `renderer.cpp`, `cubemap.cpp` and `fill.cpp`
- remove duplicated arrays and update references
- list new header in OpenGL CMake configuration

## Testing
- `cmake --preset linux-release` *(fails: Could not find toolchain file)*
- `cmake --build build/linux-release` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684f23fae3788329bd77912aeb77bfaf