### PR TITLE
Fix texture window closure

### DIFF
--- a/editor/menubar_view.cpp
+++ b/editor/menubar_view.cpp
@@ -130,7 +130,11 @@ void MenubarView::ShowTexturesWindow(DeviceInterface& device)
             {
                 draw_gui_.DeleteWindow(
                     std::format(
-                        "{} - [{}]", str_type, texture_interface.GetName()));
+                        "{} - [{}] - ({}, {})",
+                        str_type,
+                        texture_interface.GetName(),
+                        texture_interface.GetSize().x,
+                        texture_interface.GetSize().y));
             }
         }
     }

--- a/src/frame/gui/window_cubemap.cpp
+++ b/src/frame/gui/window_cubemap.cpp
@@ -19,7 +19,12 @@ WindowCubemap::WindowCubemap(TextureInterface& texture_interface)
     {
         throw std::runtime_error("Cannot create a normal texture!");
     }
-    name_ = std::format("cubemap - [{}]", texture_interface_.GetName());
+    auto display_size = texture_interface_.GetSize();
+    name_ = std::format(
+        "cubemap - [{}] - ({}, {})",
+        texture_interface_.GetName(),
+        display_size.x,
+        display_size.y);
 
     opengl::Cubemap& texture_cubemap =
         dynamic_cast<opengl::Cubemap&>(texture_interface_);


### PR DESCRIPTION
## Summary
- close texture preview windows properly when toggling off

## Testing
- `cmake -B build` *(fails: Could not find abslConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6853d5d16eb88329941bdca305670eaf