### PR TITLE
Handle invalid JSON reload in editor

### DIFF
--- a/include/frame/gui/window_raw_file.h
+++ b/include/frame/gui/window_raw_file.h
@@ -30,6 +30,7 @@ class WindowRawFile : public GuiWindowInterface
     DeviceInterface& device_;
     std::vector<char> buffer_;
     bool end_ = false;
+    std::string error_message_;
 };
 
 } // End namespace frame::gui.

--- a/src/frame/gui/CMakeLists.txt
+++ b/src/frame/gui/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(FrameGui
     fmt::fmt
     glm::glm
     imgui::imgui
+    spdlog::spdlog
     protobuf::libprotobuf
 )
 

--- a/src/frame/gui/window_raw_file.cpp
+++ b/src/frame/gui/window_raw_file.cpp
@@ -1,10 +1,10 @@
 #include "frame/gui/window_raw_file.h"
 
+#include "frame/logger.h"
 #include <algorithm>
 #include <cstring>
 #include <fstream>
 #include <imgui.h>
-#include "frame/logger.h"
 
 #include "frame/file/file_system.h"
 #include "frame/json/parse_level.h"
@@ -59,6 +59,11 @@ bool WindowRawFile::DrawCallback()
         end_ = true;
     }
     ImGui::Separator();
+    if (!error_message_.empty())
+    {
+        ImGui::TextWrapped("%s", error_message_.c_str());
+        ImGui::Separator();
+    }
     ImVec2 avail = ImGui::GetContentRegionAvail();
     ImGui::InputTextMultiline(
         "##rawtext",
@@ -66,10 +71,6 @@ bool WindowRawFile::DrawCallback()
         buffer_.size(),
         avail,
         ImGuiInputTextFlags_AllowTabInput);
-    if (!error_message_.empty())
-    {
-        ImGui::Text("%s", error_message_.c_str());
-    }
     return true;
 }
 

--- a/src/frame/gui/window_raw_file.cpp
+++ b/src/frame/gui/window_raw_file.cpp
@@ -61,7 +61,11 @@ bool WindowRawFile::DrawCallback()
     ImGui::Separator();
     if (!error_message_.empty())
     {
+        ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.5f, 0.1f, 0.1f, 1.0f));
+        ImGui::BeginChild("##error_message", ImVec2(0, 0), true);
         ImGui::TextWrapped("%s", error_message_.c_str());
+        ImGui::EndChild();
+        ImGui::PopStyleColor();
         ImGui::Separator();
     }
     ImVec2 avail = ImGui::GetContentRegionAvail();

--- a/src/frame/gui/window_raw_file.cpp
+++ b/src/frame/gui/window_raw_file.cpp
@@ -63,19 +63,20 @@ bool WindowRawFile::DrawCallback()
     if (!error_message_.empty())
     {
         ImVec2 avail = ImGui::GetContentRegionAvail();
-        float text_height = ImGui::CalcTextSize(
-                                error_message_.c_str(), nullptr, false, avail.x)
-                              .y +
-                           ImGui::GetStyle().FramePadding.y * 2 +
-                           ImGui::GetStyle().ItemSpacing.y;
-        text_height = std::ceil(text_height);
-        ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.5f, 0.1f, 0.1f, 1.0f));
+        float text_height =
+            ImGui::CalcTextSize(error_message_.c_str(), nullptr, false, avail.x)
+                .y;
+        float padding = ImGui::GetStyle().WindowPadding.y;
+        text_height = std::ceil(text_height + padding * 2);
+        ImGui::PushStyleColor(
+            ImGuiCol_ChildBg, ImVec4(0.5f, 0.1f, 0.1f, 1.0f));
         ImGui::BeginChild(
             "##error_message", ImVec2(0, text_height), true,
             ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
         ImGui::TextWrapped("%s", error_message_.c_str());
         ImGui::EndChild();
         ImGui::PopStyleColor();
+        ImGui::Spacing();
         ImGui::Separator();
     }
     ImVec2 avail = ImGui::GetContentRegionAvail();

--- a/src/frame/gui/window_raw_file.cpp
+++ b/src/frame/gui/window_raw_file.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cstring>
 #include <fstream>
+#include <cmath>
 #include <imgui.h>
 
 #include "frame/file/file_system.h"
@@ -63,9 +64,11 @@ bool WindowRawFile::DrawCallback()
     {
         ImVec2 avail = ImGui::GetContentRegionAvail();
         float text_height = ImGui::CalcTextSize(
-            error_message_.c_str(), nullptr, true, avail.x)
+                                error_message_.c_str(), nullptr, false, avail.x)
                               .y +
-                           ImGui::GetStyle().FramePadding.y * 2;
+                           ImGui::GetStyle().FramePadding.y * 2 +
+                           ImGui::GetStyle().ItemSpacing.y;
+        text_height = std::ceil(text_height);
         ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.5f, 0.1f, 0.1f, 1.0f));
         ImGui::BeginChild(
             "##error_message", ImVec2(0, text_height), true,

--- a/src/frame/gui/window_raw_file.cpp
+++ b/src/frame/gui/window_raw_file.cpp
@@ -61,8 +61,15 @@ bool WindowRawFile::DrawCallback()
     ImGui::Separator();
     if (!error_message_.empty())
     {
+        ImVec2 avail = ImGui::GetContentRegionAvail();
+        float text_height = ImGui::CalcTextSize(
+            error_message_.c_str(), nullptr, true, avail.x)
+                              .y +
+                           ImGui::GetStyle().FramePadding.y * 2;
         ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.5f, 0.1f, 0.1f, 1.0f));
-        ImGui::BeginChild("##error_message", ImVec2(0, 0), true);
+        ImGui::BeginChild(
+            "##error_message", ImVec2(0, text_height), true,
+            ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
         ImGui::TextWrapped("%s", error_message_.c_str());
         ImGui::EndChild();
         ImGui::PopStyleColor();

--- a/src/frame/gui/window_raw_file.cpp
+++ b/src/frame/gui/window_raw_file.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <fstream>
 #include <imgui.h>
+#include "frame/logger.h"
 
 #include "frame/file/file_system.h"
 #include "frame/json/parse_level.h"
@@ -39,9 +40,18 @@ bool WindowRawFile::DrawCallback()
 {
     if (ImGui::Button("Reload"))
     {
-        std::string content(buffer_.data());
-        auto level = frame::json::ParseLevel(device_.GetSize(), content);
-        device_.Startup(std::move(level));
+        try
+        {
+            std::string content(buffer_.data());
+            auto level = frame::json::ParseLevel(device_.GetSize(), content);
+            device_.Startup(std::move(level));
+            error_message_.clear();
+        }
+        catch (const std::exception& e)
+        {
+            error_message_ = e.what();
+            frame::Logger::GetInstance()->error(e.what());
+        }
     }
     ImGui::SameLine();
     if (ImGui::Button("Close"))
@@ -56,6 +66,10 @@ bool WindowRawFile::DrawCallback()
         buffer_.size(),
         avail,
         ImGuiInputTextFlags_AllowTabInput);
+    if (!error_message_.empty())
+    {
+        ImGui::Text("%s", error_message_.c_str());
+    }
     return true;
 }
 


### PR DESCRIPTION
## Summary
- add local logger include to the raw file window
- catch JSON parsing errors when reloading levels
- log the error and show the message inside the window

## Testing
- `cmake --preset linux-debug` *(fails: building glew:x64-linux failed)*

------
https://chatgpt.com/codex/tasks/task_e_6858f356ab788329b0111d598492e526