### PR TITLE
Separate vertex and fragment shader

### DIFF
--- a/asset/json/depth_normal.json
+++ b/asset/json/depth_normal.json
@@ -1,119 +1,149 @@
 {
-  "name": "DepthNormal",
-  "default_texture_name": "blured_normal_map",
-  "textures": [
-    {
-      "name": "input_depth",
-      "pixel_element_size": { "value": "SHORT" },
-      "pixel_structure": { "value": "GREY" },
-      "file_name": "asset/input.png"
-    },
-    {
-      "name": "normal_map",
-      "size": {
-        "x": "-1",
-        "y": "-1"
-      },
-      "cubemap": "false",
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    },
-    {
-      "name": "blured_normal_map",
-      "size": {
-        "x": "-1",
-        "y": "-1"
-      },
-      "cubemap": "false",
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    }
-  ],
-  "programs": [
-    {
-      "name": "ComputeNormalProgram",
-      "output_texture_names": [ "normal_map" ],
-      "input_scene_type": { "value": "QUAD" },
-      "shader": "depth_normal",
-      "uniforms": [
+    "name": "DepthNormal",
+    "default_texture_name": "blured_normal_map",
+    "textures": [
         {
-          "name": "time_s",
-          "uniform_enum": "FLOAT_TIME_S"
-        }
-      ]
-    },
-    {
-      "name": "BlurProgram",
-      "output_texture_names": [ "blured_normal_map" ],
-      "input_scene_type": { "value": "QUAD" },
-      "shader": "blur"
-    }
-  ],
-  "materials": [
-    {
-      "name": "ComputeNormalMaterial",
-      "program_name": "ComputeNormalProgram",
-      "texture_names": [ "input_depth" ],
-      "inner_names": [ "Depth" ]
-    },
-    {
-      "name": "BlurMaterial",
-      "program_name": "BlurProgram",
-      "texture_names": [ "normal_map" ],
-      "inner_names": [ "Image" ]
-    }
-  ],
-  "scene_tree": {
-    "default_root_name": "root",
-    "default_camera_name": "camera",
-    "node_matrices": [
-      {
-        "name": "root",
-        "matrix": {
-          "m11": "1.0",
-          "m22": "1.0",
-          "m33": "1.0",
-          "m44": "1.0"
-        }
-      }
-    ],
-    "node_cameras": [
-      {
-        "name": "camera",
-        "parent": "root",
-        "fov_degrees": "90.0",
-        "near_clip": "0.01",
-        "far_clip": "1000.0",
-        "position": {
-          "x": "0.0",
-          "y": "0.0",
-          "z": "-1.0"
+            "name": "input_depth",
+            "pixel_element_size": {
+                "value": "SHORT"
+            },
+            "pixel_structure": {
+                "value": "GREY"
+            },
+            "file_name": "asset/input.png"
         },
-        "target": {
-          "x": "0.0",
-          "y": "0.0",
-          "z": "1.0"
+        {
+            "name": "normal_map",
+            "size": {
+                "x": "-1",
+                "y": "-1"
+            },
+            "cubemap": "false",
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
         },
-        "up": {
-          "x": "0.0",
-          "y": "1.0",
-          "z": "0.0"
+        {
+            "name": "blured_normal_map",
+            "size": {
+                "x": "-1",
+                "y": "-1"
+            },
+            "cubemap": "false",
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
         }
-      }
     ],
-    "node_static_meshes": [
-      {
-        "name": "ComputeNormalMesh",
-        "parent": "root",
-        "material_name": "ComputeNormalMaterial",
-        "mesh_enum": "QUAD"
-      },
-      {
-        "name": "BlurMesh",
-        "parent": "root",
-        "material_name": "BlurMaterial",
-        "mesh_enum": "QUAD"
-      }
-    ]
-  }
+    "programs": [
+        {
+            "name": "ComputeNormalProgram",
+            "output_texture_names": [
+                "normal_map"
+            ],
+            "input_scene_type": {
+                "value": "QUAD"
+            },
+            "shader_vertex": "depth_normal.vert",
+            "shader_fragment": "depth_normal.frag",
+            "uniforms": [
+                {
+                    "name": "time_s",
+                    "uniform_enum": "FLOAT_TIME_S"
+                }
+            ]
+        },
+        {
+            "name": "BlurProgram",
+            "output_texture_names": [
+                "blured_normal_map"
+            ],
+            "input_scene_type": {
+                "value": "QUAD"
+            },
+            "shader_vertex": "blur.vert",
+            "shader_fragment": "blur.frag"
+        }
+    ],
+    "materials": [
+        {
+            "name": "ComputeNormalMaterial",
+            "program_name": "ComputeNormalProgram",
+            "texture_names": [
+                "input_depth"
+            ],
+            "inner_names": [
+                "Depth"
+            ]
+        },
+        {
+            "name": "BlurMaterial",
+            "program_name": "BlurProgram",
+            "texture_names": [
+                "normal_map"
+            ],
+            "inner_names": [
+                "Image"
+            ]
+        }
+    ],
+    "scene_tree": {
+        "default_root_name": "root",
+        "default_camera_name": "camera",
+        "node_matrices": [
+            {
+                "name": "root",
+                "matrix": {
+                    "m11": "1.0",
+                    "m22": "1.0",
+                    "m33": "1.0",
+                    "m44": "1.0"
+                }
+            }
+        ],
+        "node_cameras": [
+            {
+                "name": "camera",
+                "parent": "root",
+                "fov_degrees": "90.0",
+                "near_clip": "0.01",
+                "far_clip": "1000.0",
+                "position": {
+                    "x": "0.0",
+                    "y": "0.0",
+                    "z": "-1.0"
+                },
+                "target": {
+                    "x": "0.0",
+                    "y": "0.0",
+                    "z": "1.0"
+                },
+                "up": {
+                    "x": "0.0",
+                    "y": "1.0",
+                    "z": "0.0"
+                }
+            }
+        ],
+        "node_static_meshes": [
+            {
+                "name": "ComputeNormalMesh",
+                "parent": "root",
+                "material_name": "ComputeNormalMaterial",
+                "mesh_enum": "QUAD"
+            },
+            {
+                "name": "BlurMesh",
+                "parent": "root",
+                "material_name": "BlurMaterial",
+                "mesh_enum": "QUAD"
+            }
+        ]
+    }
 }

--- a/asset/json/editor.json
+++ b/asset/json/editor.json
@@ -1,218 +1,253 @@
 {
-  "name": "FrameEditor",
-  "default_texture_name": "albedo",
-  "materials": [
-    {
-      "name": "FrameEditorMaterial",
-      "program_name": "FrameEditorProgram",
-      "texture_names": [ "apple_texture" ],
-      "inner_names": [ "Color" ]
-    },
-    {
-      "name": "CubeMapMaterial",
-      "program_name": "CubeMapProgram",
-      "texture_names": [ "skybox" ],
-      "inner_names": [ "Skybox" ]
-    }
-  ],
-  "programs": [
-    {
-      "name": "CubeMapProgram",
-      "input_texture_names": "skybox",
-      "output_texture_names": "albedo",
-      "input_scene_type": { "value": "CUBE" },
-      "shader": "cubemap",
-      "uniforms": [
+    "name": "FrameEditor",
+    "default_texture_name": "albedo",
+    "materials": [
         {
-          "name": "projection",
-          "uniform_enum": "PROJECTION_MAT4"
+            "name": "FrameEditorMaterial",
+            "program_name": "FrameEditorProgram",
+            "texture_names": [
+                "apple_texture"
+            ],
+            "inner_names": [
+                "Color"
+            ]
         },
         {
-          "name": "view",
-          "uniform_enum": "VIEW_MAT4"
-        },
-        {
-          "name": "model",
-          "uniform_enum": "MODEL_MAT4"
+            "name": "CubeMapMaterial",
+            "program_name": "CubeMapProgram",
+            "texture_names": [
+                "skybox"
+            ],
+            "inner_names": [
+                "Skybox"
+            ]
         }
-      ]
-    },
-    {
-      "name": "FrameEditorProgram",
-      "output_texture_names": [
-        "albedo",
-        "zbuffer"
-      ],
-      "input_scene_type": { "value": "SCENE" },
-      "input_scene_root_name": "root",
-      "shader": "scene_simple",
-      "uniforms": [
-        {
-          "name": "projection",
-          "uniform_enum": "PROJECTION_MAT4"
-        },
-        {
-          "name": "view",
-          "uniform_enum": "VIEW_MAT4"
-        },
-        {
-          "name": "model",
-          "uniform_enum": "MODEL_MAT4"
-        },
-        {
-          "name": "time_s",
-          "uniform_enum": "FLOAT_TIME_S"
-        }
-      ]
-    }
-  ],
-  "textures": [
-    {
-      "name": "skybox",
-      "cubemap": "true",
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" },
-      "file_names": {
-        "positive_x": "asset/cubemap/negative_x.png",
-        "negative_x": "asset/cubemap/positive_x.png",
-        "positive_y": "asset/cubemap/negative_y.png",
-        "negative_y": "asset/cubemap/positive_y.png",
-        "positive_z": "asset/cubemap/negative_z.png",
-        "negative_z": "asset/cubemap/positive_z.png"
-      }
-    },
-    {
-      "name": "apple_texture",
-      "cubemap": "false",
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" },
-      "file_name": "asset/apple/color.jpg"
-    },
-    {
-      "name": "albedo",
-      "cubemap": "false",
-      "size": {
-        "x": "-1",
-        "y": "-1"
-      },
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    },
-    {
-      "name": "zbuffer",
-      "cubemap": "false",
-      "size": {
-        "x": "-1",
-        "y": "-1"
-      },
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    }
-  ],
-  "scene_tree": {
-    "default_camera_name": "camera",
-    "default_root_name": "root",
-    "node_matrices": [
-      {
-        "name": "root",
-        "matrix": {
-          "m11": 1,
-          "m22": 1,
-          "m33": 1,
-          "m44": 1
-        }
-      },
-      {
-        "name": "mesh_holder",
-        "parent": "root",
-        "quaternion": {
-          "x": 0.0,
-          "y": 0.1979232,
-          "z": 0.1484424,
-          "w": 0.9689124
-        }
-      },
-      {
-        "name": "skybox_holder",
-        "parent": "root",
-        "quaternion": {
-          "x": 0,
-          "y": 0.0499792,
-          "z": 0.0,
-          "w": 0.9987503
-        }
-      }
     ],
-    "node_static_meshes": [
-      {
-        "name": "InitCleanBuffer",
-        "clean_buffer": {
-          "values": [ "CLEAR_COLOR", "CLEAR_DEPTH" ]
+    "programs": [
+        {
+            "name": "CubeMapProgram",
+            "input_texture_names": "skybox",
+            "output_texture_names": "albedo",
+            "input_scene_type": {
+                "value": "CUBE"
+            },
+            "shader_vertex": "cubemap.vert",
+            "shader_fragment": "cubemap.frag",
+            "uniforms": [
+                {
+                    "name": "projection",
+                    "uniform_enum": "PROJECTION_MAT4"
+                },
+                {
+                    "name": "view",
+                    "uniform_enum": "VIEW_MAT4"
+                },
+                {
+                    "name": "model",
+                    "uniform_enum": "MODEL_MAT4"
+                }
+            ]
         },
-        "render_time_enum": "SKYBOX_RENDER_TIME"
-      },
-      {
-        "name": "CubeMapMesh",
-        "parent": "skybox_holder",
-        "material_name": "CubeMapMaterial",
-        "mesh_enum": "CUBE",
-        "render_time_enum": "SKYBOX_RENDER_TIME"
-      },
-      {
-        "name": "ClearDepthBuffer",
-        "clean_buffer": {
-          "values": [ "CLEAR_DEPTH" ]
-        },
-        "render_time_enum": "SKYBOX_RENDER_TIME"
-      },
-      {
-        "name": "AppleMesh",
-        "parent": "mesh_holder",
-        "file_name": "apple.obj",
-        "material_name": "FrameEditorMaterial",
-        "render_time_enum": "SCENE_RENDER_TIME"
-      }
-    ],
-    "node_cameras": [
-      {
-        "name": "camera",
-        "parent": "root",
-        "fov_degrees": 65.0,
-        "near_clip": 0.01,
-        "far_clip": 1000,
-        "position": {
-          "x": 0,
-          "y": 0,
-          "z": -2
-        },
-        "target": {
-          "x": 0,
-          "y": 0,
-          "z": 1
-        },
-        "up": {
-          "x": 0,
-          "y": 1,
-          "z": 0
+        {
+            "name": "FrameEditorProgram",
+            "output_texture_names": [
+                "albedo",
+                "zbuffer"
+            ],
+            "input_scene_type": {
+                "value": "SCENE"
+            },
+            "input_scene_root_name": "root",
+            "shader_vertex": "scene_simple.vert",
+            "shader_fragment": "scene_simple.frag",
+            "uniforms": [
+                {
+                    "name": "projection",
+                    "uniform_enum": "PROJECTION_MAT4"
+                },
+                {
+                    "name": "view",
+                    "uniform_enum": "VIEW_MAT4"
+                },
+                {
+                    "name": "model",
+                    "uniform_enum": "MODEL_MAT4"
+                },
+                {
+                    "name": "time_s",
+                    "uniform_enum": "FLOAT_TIME_S"
+                }
+            ]
         }
-      }
     ],
-    "node_lights": [
-      {
-        "name": "sun",
-        "parent": "root",
-        "light_type": "DIRECTIONAL_LIGHT",
-        "position": {
-          "x": "-1.0",
-          "y": "1.0",
-          "z": "1.0"
+    "textures": [
+        {
+            "name": "skybox",
+            "cubemap": "true",
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            },
+            "file_names": {
+                "positive_x": "asset/cubemap/negative_x.png",
+                "negative_x": "asset/cubemap/positive_x.png",
+                "positive_y": "asset/cubemap/negative_y.png",
+                "negative_y": "asset/cubemap/positive_y.png",
+                "positive_z": "asset/cubemap/negative_z.png",
+                "negative_z": "asset/cubemap/positive_z.png"
+            }
         },
-        "color": {
-          "x": "1.0",
-          "y": "1.0",
-          "z": "1.0"
+        {
+            "name": "apple_texture",
+            "cubemap": "false",
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            },
+            "file_name": "asset/apple/color.jpg"
+        },
+        {
+            "name": "albedo",
+            "cubemap": "false",
+            "size": {
+                "x": "-1",
+                "y": "-1"
+            },
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
+        },
+        {
+            "name": "zbuffer",
+            "cubemap": "false",
+            "size": {
+                "x": "-1",
+                "y": "-1"
+            },
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
         }
-      }
-    ]
-  }
+    ],
+    "scene_tree": {
+        "default_camera_name": "camera",
+        "default_root_name": "root",
+        "node_matrices": [
+            {
+                "name": "root",
+                "matrix": {
+                    "m11": 1,
+                    "m22": 1,
+                    "m33": 1,
+                    "m44": 1
+                }
+            },
+            {
+                "name": "mesh_holder",
+                "parent": "root",
+                "quaternion": {
+                    "x": 0.0,
+                    "y": 0.1979232,
+                    "z": 0.1484424,
+                    "w": 0.9689124
+                }
+            },
+            {
+                "name": "skybox_holder",
+                "parent": "root",
+                "quaternion": {
+                    "x": 0,
+                    "y": 0.0499792,
+                    "z": 0.0,
+                    "w": 0.9987503
+                }
+            }
+        ],
+        "node_static_meshes": [
+            {
+                "name": "InitCleanBuffer",
+                "clean_buffer": {
+                    "values": [
+                        "CLEAR_COLOR",
+                        "CLEAR_DEPTH"
+                    ]
+                },
+                "render_time_enum": "SKYBOX_RENDER_TIME"
+            },
+            {
+                "name": "CubeMapMesh",
+                "parent": "skybox_holder",
+                "material_name": "CubeMapMaterial",
+                "mesh_enum": "CUBE",
+                "render_time_enum": "SKYBOX_RENDER_TIME"
+            },
+            {
+                "name": "ClearDepthBuffer",
+                "clean_buffer": {
+                    "values": [
+                        "CLEAR_DEPTH"
+                    ]
+                },
+                "render_time_enum": "SKYBOX_RENDER_TIME"
+            },
+            {
+                "name": "AppleMesh",
+                "parent": "mesh_holder",
+                "file_name": "apple.obj",
+                "material_name": "FrameEditorMaterial",
+                "render_time_enum": "SCENE_RENDER_TIME"
+            }
+        ],
+        "node_cameras": [
+            {
+                "name": "camera",
+                "parent": "root",
+                "fov_degrees": 65.0,
+                "near_clip": 0.01,
+                "far_clip": 1000,
+                "position": {
+                    "x": 0,
+                    "y": 0,
+                    "z": -2
+                },
+                "target": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 1
+                },
+                "up": {
+                    "x": 0,
+                    "y": 1,
+                    "z": 0
+                }
+            }
+        ],
+        "node_lights": [
+            {
+                "name": "sun",
+                "parent": "root",
+                "light_type": "DIRECTIONAL_LIGHT",
+                "position": {
+                    "x": "-1.0",
+                    "y": "1.0",
+                    "z": "1.0"
+                },
+                "color": {
+                    "x": "1.0",
+                    "y": "1.0",
+                    "z": "1.0"
+                }
+            }
+        ]
+    }
 }

--- a/asset/json/equirectangular.json
+++ b/asset/json/equirectangular.json
@@ -1,104 +1,109 @@
 {
-  "name": "Equirectangular",
-  "default_texture_name": "OutputTexture",
-  "programs": [
-    {
-      "name": "EquirectangularProgram",
-      "shader": "equirectangular_cubemap",
-      "input_scene_type": {
-        "value": "QUAD"
-      },
-      "uniforms": [
+    "name": "Equirectangular",
+    "default_texture_name": "OutputTexture",
+    "programs": [
         {
-          "name": "projection",
-          "uniform_enum": "PROJECTION_MAT4"
-        },
-        {
-          "name": "view",
-          "uniform_enum": "VIEW_MAT4"
-        },
-        {
-          "name": "model",
-          "uniform_enum": "MODEL_MAT4"
+            "name": "EquirectangularProgram",
+            "shader_vertex": "equirectangular_cubemap.vert",
+            "shader_fragment": "equirectangular_cubemap.frag",
+            "input_scene_type": {
+                "value": "QUAD"
+            },
+            "uniforms": [
+                {
+                    "name": "projection",
+                    "uniform_enum": "PROJECTION_MAT4"
+                },
+                {
+                    "name": "view",
+                    "uniform_enum": "VIEW_MAT4"
+                },
+                {
+                    "name": "model",
+                    "uniform_enum": "MODEL_MAT4"
+                }
+            ],
+            "output_texture_names": [
+                "OutputTexture"
+            ]
         }
-      ],
-      "output_texture_names": [ "OutputTexture" ]
-    }
-  ],
-  "scene_tree": {
-    "default_root_name": "root",
-    "default_camera_name": "camera",
-    "node_matrices": [
-      {
-        "name": "root",
-        "matrix": {
-          "m11": 1,
-          "m22": 1,
-          "m33": 1,
-          "m44": 1
-        }
-      },
-      {
-        "name": "camera_boon",
-        "parent": "root"
-      }
     ],
-    "node_static_meshes": [
-      {
-        "name": "Cube",
-        "mesh_enum": "CUBE",
-        "material_name": "EquirectangularMaterial",
-        "parent": "root"
-      }
-    ],
-    "node_cameras": [
-      {
-        "name": "camera",
-        "parent": "camera_boon",
-        "fov_degrees": "90.0",
-        "near_clip": "0.1",
-        "far_clip": "1000.0",
-        "aspect_ratio": "1.0"
-      }
-    ]
-  },
-  "textures": [
-    {
-      "name": "InputTexture",
-      "file_name": "<filename>",
-      "cubemap": "false",
-      "size": {
-        "x": "<x>",
-        "y": "<y>"
-      },
-      "pixel_element_size": {
-        "value": "<pixel_element_size>"
-      },
-      "pixel_structure": {
-        "value": "<pixel_structure>"
-      }
+    "scene_tree": {
+        "default_root_name": "root",
+        "default_camera_name": "camera",
+        "node_matrices": [
+            {
+                "name": "root",
+                "matrix": {
+                    "m11": 1,
+                    "m22": 1,
+                    "m33": 1,
+                    "m44": 1
+                }
+            },
+            {
+                "name": "camera_boon",
+                "parent": "root"
+            }
+        ],
+        "node_static_meshes": [
+            {
+                "name": "Cube",
+                "mesh_enum": "CUBE",
+                "material_name": "EquirectangularMaterial",
+                "parent": "root"
+            }
+        ],
+        "node_cameras": [
+            {
+                "name": "camera",
+                "parent": "camera_boon",
+                "fov_degrees": "90.0",
+                "near_clip": "0.1",
+                "far_clip": "1000.0",
+                "aspect_ratio": "1.0"
+            }
+        ]
     },
-    {
-      "name": "OutputTexture",
-      "cubemap": "true",
-      "size": {
-        "x": "<x>",
-        "y": "<y>"
-      },
-      "pixel_element_size": {
-        "value": "<pixel_element_size>"
-      },
-      "pixel_structure": {
-        "value": "<pixel_structure>"
-      }
-    }
-  ],
-  "materials": [
-    {
-      "name": "EquirectangularMaterial",
-      "program_name": "EquirectangularProgram",
-      "texture_names": [ "InputTexture" ],
-      "inner_names": "Equirectangular"
-    }
-  ]
+    "textures": [
+        {
+            "name": "InputTexture",
+            "file_name": "<filename>",
+            "cubemap": "false",
+            "size": {
+                "x": "<x>",
+                "y": "<y>"
+            },
+            "pixel_element_size": {
+                "value": "<pixel_element_size>"
+            },
+            "pixel_structure": {
+                "value": "<pixel_structure>"
+            }
+        },
+        {
+            "name": "OutputTexture",
+            "cubemap": "true",
+            "size": {
+                "x": "<x>",
+                "y": "<y>"
+            },
+            "pixel_element_size": {
+                "value": "<pixel_element_size>"
+            },
+            "pixel_structure": {
+                "value": "<pixel_structure>"
+            }
+        }
+    ],
+    "materials": [
+        {
+            "name": "EquirectangularMaterial",
+            "program_name": "EquirectangularProgram",
+            "texture_names": [
+                "InputTexture"
+            ],
+            "inner_names": "Equirectangular"
+        }
+    ]
 }

--- a/asset/json/image_based_lighting.json
+++ b/asset/json/image_based_lighting.json
@@ -1,240 +1,302 @@
 {
-  "name": "LastMonsterStanding",
-  "default_texture_name": "albedo",
-  "textures": [
-    {
-      "name": "albedo",
-      "size": {
-        "x": -1,
-        "y": -1
-      },
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    },
-    {
-      "name": "skybox",
-      "cubemap": true,
-      "pixel_element_size": { "value": "FLOAT" },
-      "pixel_structure": { "value": "RGB" },
-      "file_name": "asset/cubemap/shiodome.hdr"
-    },
-    {
-      "name": "irradiance",
-      "cubemap": true,
-      "pixel_element_size": { "value": "FLOAT" },
-      "pixel_structure": { "value": "RGB" },
-      "size": {
-        "x": 512,
-        "y": 512
-      }
-    },
-    {
-      "name": "apple_texture",
-      "cubemap": false,
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" },
-      "file_name": "asset/apple/color.jpg"
-    },
-    {
-      "name": "zbuffer",
-      "cubemap": false,
-      "size": {
-        "x": -1,
-        "y": -1
-      },
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    }
-  ],
-  "materials": [
-    {
-      "name": "ImageBasedLightingMaterial",
-      "program_name": "ImageBasedLightingProgram",
-      "texture_names": [ "apple_texture", "irradiance" ],
-      "inner_names": [ "Color", "IrradianceMap" ]
-    },
-    {
-      "name": "CubeMapMaterial",
-      "program_name": "CubeMapProgram",
-      "texture_names": [ "skybox" ],
-      "inner_names": [ "Skybox" ]
-    },
-    {
-      "name": "IrradianceMaterial",
-      "program_name": "IrradianceProgram",
-      "texture_names": [ "skybox" ],
-      "inner_names": [ "Environment" ]
-    }
-  ],
-  "programs": [
-    {
-      "name": "IrradianceProgram",
-      "input_texture_names": [ "skybox" ],
-      "output_texture_names": [ "irradiance" ],
-      "input_scene_type": { "value": "CUBE" },
-      "shader": "irradiance_cubemap",
-      "uniforms": [
+    "name": "LastMonsterStanding",
+    "default_texture_name": "albedo",
+    "textures": [
         {
-          "name": "projection",
-          "uniform_enum": "PROJECTION_MAT4"
+            "name": "albedo",
+            "size": {
+                "x": -1,
+                "y": -1
+            },
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
         },
         {
-          "name": "view",
-          "uniform_enum": "VIEW_MAT4"
+            "name": "skybox",
+            "cubemap": true,
+            "pixel_element_size": {
+                "value": "FLOAT"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            },
+            "file_name": "asset/cubemap/shiodome.hdr"
         },
         {
-          "name": "model",
-          "uniform_enum": "MODEL_MAT4"
+            "name": "irradiance",
+            "cubemap": true,
+            "pixel_element_size": {
+                "value": "FLOAT"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            },
+            "size": {
+                "x": 512,
+                "y": 512
+            }
+        },
+        {
+            "name": "apple_texture",
+            "cubemap": false,
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            },
+            "file_name": "asset/apple/color.jpg"
+        },
+        {
+            "name": "zbuffer",
+            "cubemap": false,
+            "size": {
+                "x": -1,
+                "y": -1
+            },
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
         }
-      ]
-    },
-    {
-      "name": "CubeMapProgram",
-      "input_texture_names": [ "skybox" ],
-      "output_texture_names": [ "albedo" ],
-      "input_scene_type": { "value": "CUBE" },
-      "shader": "cubemap",
-      "uniforms": [
-        {
-          "name": "projection",
-          "uniform_enum": "PROJECTION_MAT4"
-        },
-        {
-          "name": "view",
-          "uniform_enum": "VIEW_MAT4"
-        },
-        {
-          "name": "model",
-          "uniform_enum": "MODEL_MAT4"
-        }
-      ]
-    },
-    {
-      "name": "ImageBasedLightingProgram",
-      "input_texture_names": [ "apple_texture", "skybox" ],
-      "output_texture_names": [ "albedo" ],
-      "input_scene_type": { "value": "SCENE" },
-      "input_scene_root_name": "root",
-      "shader": "image_based_lighting",
-      "uniforms": [
-        {
-          "name": "projection",
-          "uniform_enum": "PROJECTION_MAT4"
-        },
-        {
-          "name": "view",
-          "uniform_enum": "VIEW_MAT4"
-        },
-        {
-          "name": "model",
-          "uniform_enum": "MODEL_MAT4"
-        },
-        {
-          "name": "env_map_model",
-          "uniform_mat4": {
-            "m11": "1",
-            "m22": "1",
-            "m33": "1",
-            "m44": "1"
-          }
-        }
-      ]
-    }
-  ],
-  "scene_tree": {
-    "default_camera_name": "camera",
-    "default_root_name": "root",
-    "node_matrices": [
-      {
-        "name": "root",
-        "matrix": {
-          "m11": 1,
-          "m22": 1,
-          "m33": 1,
-          "m44": 1
-        }
-      },
-      {
-        "name": "mesh_holder",
-        "parent": "root",
-        "quaternion": {
-          "x": 0.0,
-          "y": 0.1979232,
-          "z": 0.1484424,
-          "w": 0.9689124
-        }
-      },
-      {
-        "name": "env_holder",
-        "parent": "root",
-        "quaternion": {
-          "x": 0,
-          "y": 0.0499792,
-          "z": 0.0,
-          "w": 0.9987503
-        }
-      }
     ],
-    "node_static_meshes": [
-      {
-        "name": "ComputeIrradianceMap",
-        "parent": "root",
-        "mesh_enum": "CUBE",
-        "material_name": "IrradianceMaterial",
-        "render_time_enum": "PRE_RENDER_TIME"
-      },
-      {
-        "name": "InitCleanBuffer",
-        "clean_buffer": {
-          "values": [ "CLEAR_COLOR", "CLEAR_DEPTH" ]
+    "materials": [
+        {
+            "name": "ImageBasedLightingMaterial",
+            "program_name": "ImageBasedLightingProgram",
+            "texture_names": [
+                "apple_texture",
+                "irradiance"
+            ],
+            "inner_names": [
+                "Color",
+                "IrradianceMap"
+            ]
         },
-        "render_time_enum": "SKYBOX_RENDER_TIME"
-      },
-      {
-        "name": "CubeMapMesh",
-        "parent": "env_holder",
-        "material_name": "CubeMapMaterial",
-        "mesh_enum": "CUBE",
-        "render_time_enum": "SKYBOX_RENDER_TIME"
-      },
-      {
-        "name": "ClearDepthBuffer",
-        "clean_buffer": {
-          "values": [ "CLEAR_COLOR", "CLEAR_DEPTH" ]
+        {
+            "name": "CubeMapMaterial",
+            "program_name": "CubeMapProgram",
+            "texture_names": [
+                "skybox"
+            ],
+            "inner_names": [
+                "Skybox"
+            ]
         },
-        "render_time_enum": "SCENE_RENDER_TIME"
-      },
-      {
-        "name": "AppleMesh",
-        "parent": "mesh_holder",
-        "file_name": "apple.obj",
-        "material_name": "ImageBasedLightingMaterial",
-        "render_time_enum": "SCENE_RENDER_TIME"
-      }
-    ],
-    "node_cameras": [
-      {
-        "name": "camera",
-        "parent": "root",
-        "fov_degrees": 65.0,
-        "near_clip": 0.01,
-        "far_clip": 1000,
-        "position": {
-          "x": 0,
-          "y": 0,
-          "z": -2
-        },
-        "target": {
-          "x": 0,
-          "y": 0,
-          "z": 1
-        },
-        "up": {
-          "x": 0,
-          "y": 1,
-          "z": 0
+        {
+            "name": "IrradianceMaterial",
+            "program_name": "IrradianceProgram",
+            "texture_names": [
+                "skybox"
+            ],
+            "inner_names": [
+                "Environment"
+            ]
         }
-      }
-    ]
-  }
+    ],
+    "programs": [
+        {
+            "name": "IrradianceProgram",
+            "input_texture_names": [
+                "skybox"
+            ],
+            "output_texture_names": [
+                "irradiance"
+            ],
+            "input_scene_type": {
+                "value": "CUBE"
+            },
+            "shader_vertex": "irradiance_cubemap.vert",
+            "shader_fragment": "irradiance_cubemap.frag",
+            "uniforms": [
+                {
+                    "name": "projection",
+                    "uniform_enum": "PROJECTION_MAT4"
+                },
+                {
+                    "name": "view",
+                    "uniform_enum": "VIEW_MAT4"
+                },
+                {
+                    "name": "model",
+                    "uniform_enum": "MODEL_MAT4"
+                }
+            ]
+        },
+        {
+            "name": "CubeMapProgram",
+            "input_texture_names": [
+                "skybox"
+            ],
+            "output_texture_names": [
+                "albedo"
+            ],
+            "input_scene_type": {
+                "value": "CUBE"
+            },
+            "shader_vertex": "cubemap.vert",
+            "shader_fragment": "cubemap.frag",
+            "uniforms": [
+                {
+                    "name": "projection",
+                    "uniform_enum": "PROJECTION_MAT4"
+                },
+                {
+                    "name": "view",
+                    "uniform_enum": "VIEW_MAT4"
+                },
+                {
+                    "name": "model",
+                    "uniform_enum": "MODEL_MAT4"
+                }
+            ]
+        },
+        {
+            "name": "ImageBasedLightingProgram",
+            "input_texture_names": [
+                "apple_texture",
+                "skybox"
+            ],
+            "output_texture_names": [
+                "albedo"
+            ],
+            "input_scene_type": {
+                "value": "SCENE"
+            },
+            "input_scene_root_name": "root",
+            "shader_vertex": "image_based_lighting.vert",
+            "shader_fragment": "image_based_lighting.frag",
+            "uniforms": [
+                {
+                    "name": "projection",
+                    "uniform_enum": "PROJECTION_MAT4"
+                },
+                {
+                    "name": "view",
+                    "uniform_enum": "VIEW_MAT4"
+                },
+                {
+                    "name": "model",
+                    "uniform_enum": "MODEL_MAT4"
+                },
+                {
+                    "name": "env_map_model",
+                    "uniform_mat4": {
+                        "m11": "1",
+                        "m22": "1",
+                        "m33": "1",
+                        "m44": "1"
+                    }
+                }
+            ]
+        }
+    ],
+    "scene_tree": {
+        "default_camera_name": "camera",
+        "default_root_name": "root",
+        "node_matrices": [
+            {
+                "name": "root",
+                "matrix": {
+                    "m11": 1,
+                    "m22": 1,
+                    "m33": 1,
+                    "m44": 1
+                }
+            },
+            {
+                "name": "mesh_holder",
+                "parent": "root",
+                "quaternion": {
+                    "x": 0.0,
+                    "y": 0.1979232,
+                    "z": 0.1484424,
+                    "w": 0.9689124
+                }
+            },
+            {
+                "name": "env_holder",
+                "parent": "root",
+                "quaternion": {
+                    "x": 0,
+                    "y": 0.0499792,
+                    "z": 0.0,
+                    "w": 0.9987503
+                }
+            }
+        ],
+        "node_static_meshes": [
+            {
+                "name": "ComputeIrradianceMap",
+                "parent": "root",
+                "mesh_enum": "CUBE",
+                "material_name": "IrradianceMaterial",
+                "render_time_enum": "PRE_RENDER_TIME"
+            },
+            {
+                "name": "InitCleanBuffer",
+                "clean_buffer": {
+                    "values": [
+                        "CLEAR_COLOR",
+                        "CLEAR_DEPTH"
+                    ]
+                },
+                "render_time_enum": "SKYBOX_RENDER_TIME"
+            },
+            {
+                "name": "CubeMapMesh",
+                "parent": "env_holder",
+                "material_name": "CubeMapMaterial",
+                "mesh_enum": "CUBE",
+                "render_time_enum": "SKYBOX_RENDER_TIME"
+            },
+            {
+                "name": "ClearDepthBuffer",
+                "clean_buffer": {
+                    "values": [
+                        "CLEAR_COLOR",
+                        "CLEAR_DEPTH"
+                    ]
+                },
+                "render_time_enum": "SCENE_RENDER_TIME"
+            },
+            {
+                "name": "AppleMesh",
+                "parent": "mesh_holder",
+                "file_name": "apple.obj",
+                "material_name": "ImageBasedLightingMaterial",
+                "render_time_enum": "SCENE_RENDER_TIME"
+            }
+        ],
+        "node_cameras": [
+            {
+                "name": "camera",
+                "parent": "root",
+                "fov_degrees": 65.0,
+                "near_clip": 0.01,
+                "far_clip": 1000,
+                "position": {
+                    "x": 0,
+                    "y": 0,
+                    "z": -2
+                },
+                "target": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 1
+                },
+                "up": {
+                    "x": 0,
+                    "y": 1,
+                    "z": 0
+                }
+            }
+        ]
+    }
 }

--- a/asset/json/japanese_flag.json
+++ b/asset/json/japanese_flag.json
@@ -1,80 +1,87 @@
 {
-  "name": "JapaneseFlag",
-  "default_texture_name": "billboard",
-  "textures": [
-    {
-      "name": "billboard",
-      "size": {
-        "x": "-1",
-        "y": "-1"
-      },
-      "cubemap": "false",
-      "pixel_element_size": { "value": "HALF" },
-      "pixel_structure": { "value": "RGB" }
-    }
-  ],
-  "programs": [
-    {
-      "name": "JapaneseFlagProgram",
-      "output_texture_names": "billboard",
-      "input_scene_type": { "value": "QUAD" },
-      "shader": "japanese_flag"
-    }
-  ],
-  "materials": [
-    {
-      "name": "JapaneseFlagMaterial",
-      "program_name": "JapaneseFlagProgram",
-      "texture_names": [],
-      "inner_names": []
-    }
-  ],
-  "scene_tree": {
-    "default_root_name": "root",
-    "default_camera_name": "camera",
-    "node_matrices": [
-      {
-        "name": "root",
-        "matrix": {
-          "m11": "1.0",
-          "m22": "1.0",
-          "m33": "1.0",
-          "m44": "1.0"
+    "name": "JapaneseFlag",
+    "default_texture_name": "billboard",
+    "textures": [
+        {
+            "name": "billboard",
+            "size": {
+                "x": "-1",
+                "y": "-1"
+            },
+            "cubemap": "false",
+            "pixel_element_size": {
+                "value": "HALF"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
         }
-      }
     ],
-    "node_cameras": [
-      {
-        "name": "camera",
-        "parent": "root",
-        "aspect_ratio": 1.3333,
-        "fov_degrees": 65.0,
-        "near_clip": 0.01,
-        "far_clip": 1000.0,
-        "position": {
-          "x": 0.0,
-          "y": 0.0,
-          "z": -2.0
-        },
-        "target": {
-          "x": 0.0,
-          "y": 0.0,
-          "z": 1.0
-        },
-        "up": {
-          "x": 0.0,
-          "y": 1.0,
-          "z": 0.0
+    "programs": [
+        {
+            "name": "JapaneseFlagProgram",
+            "output_texture_names": "billboard",
+            "input_scene_type": {
+                "value": "QUAD"
+            },
+            "shader_vertex": "japanese_flag.vert",
+            "shader_fragment": "japanese_flag.frag"
         }
-      }
     ],
-    "node_static_meshes": [
-      {
-        "name": "JapaneseFlagRendering",
-        "parent": "root",
-        "mesh_enum": "QUAD",
-        "material_name": "JapaneseFlagMaterial"
-      }
-    ]
-  }
+    "materials": [
+        {
+            "name": "JapaneseFlagMaterial",
+            "program_name": "JapaneseFlagProgram",
+            "texture_names": [],
+            "inner_names": []
+        }
+    ],
+    "scene_tree": {
+        "default_root_name": "root",
+        "default_camera_name": "camera",
+        "node_matrices": [
+            {
+                "name": "root",
+                "matrix": {
+                    "m11": "1.0",
+                    "m22": "1.0",
+                    "m33": "1.0",
+                    "m44": "1.0"
+                }
+            }
+        ],
+        "node_cameras": [
+            {
+                "name": "camera",
+                "parent": "root",
+                "aspect_ratio": 1.3333,
+                "fov_degrees": 65.0,
+                "near_clip": 0.01,
+                "far_clip": 1000.0,
+                "position": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": -2.0
+                },
+                "target": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 1.0
+                },
+                "up": {
+                    "x": 0.0,
+                    "y": 1.0,
+                    "z": 0.0
+                }
+            }
+        ],
+        "node_static_meshes": [
+            {
+                "name": "JapaneseFlagRendering",
+                "parent": "root",
+                "mesh_enum": "QUAD",
+                "material_name": "JapaneseFlagMaterial"
+            }
+        ]
+    }
 }

--- a/asset/json/material_test.json
+++ b/asset/json/material_test.json
@@ -1,74 +1,89 @@
 {
-  "name": "MaterialTest",
-  "default_texture_name": "DefaultTexture",
-  "textures": [
-    {
-      "name": "DefaultTexture",
-      "size": {
-        "x": "640",
-        "y": "480"
-      },
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    },
-    {
-      "name": "texture",
-      "size": {
-        "x": "320",
-        "y": "200"
-      },
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    }
-  ],
-  "programs": [
-    {
-      "name": "program",
-      "input_texture_names": ["texture"],
-      "output_texture_names": ["DefaultTexture"],
-      "input_scene_type": { "value": "SCENE" },
-      "input_scene_root_name": "root",
-      "shader": "blur"
-    }
-  ],
-  "scene_tree": {
-    "default_root_name": "root",
-    "default_camera_name": "camera",
-    "node_matrices": [
-      {
-        "name": "root",
-        "quaternion": {
-          "w": 1,
-          "x": 0,
-          "y": 0,
-          "z": 0
+    "name": "MaterialTest",
+    "default_texture_name": "DefaultTexture",
+    "textures": [
+        {
+            "name": "DefaultTexture",
+            "size": {
+                "x": "640",
+                "y": "480"
+            },
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
+        },
+        {
+            "name": "texture",
+            "size": {
+                "x": "320",
+                "y": "200"
+            },
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
         }
-      }
     ],
-    "node_cameras": [
-      {
-        "name": "camera",
-        "parent": "root",
-        "position": {
-          "x": 0,
-          "y": 0,
-          "z": 0
-        },
-        "target": {
-          "x": 0,
-          "y": 0,
-          "z": 1
-        },
-        "up": {
-          "x": 0,
-          "y": 1,
-          "z": 0
-        },
-        "fov_degrees": 65.0,
-        "aspect_ratio": 1.6,
-        "near_clip": 0.1,
-        "far_clip": 10000.0
-      }
-    ]
-  }
+    "programs": [
+        {
+            "name": "program",
+            "input_texture_names": [
+                "texture"
+            ],
+            "output_texture_names": [
+                "DefaultTexture"
+            ],
+            "input_scene_type": {
+                "value": "SCENE"
+            },
+            "input_scene_root_name": "root",
+            "shader_vertex": "blur.vert",
+            "shader_fragment": "blur.frag"
+        }
+    ],
+    "scene_tree": {
+        "default_root_name": "root",
+        "default_camera_name": "camera",
+        "node_matrices": [
+            {
+                "name": "root",
+                "quaternion": {
+                    "w": 1,
+                    "x": 0,
+                    "y": 0,
+                    "z": 0
+                }
+            }
+        ],
+        "node_cameras": [
+            {
+                "name": "camera",
+                "parent": "root",
+                "position": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 0
+                },
+                "target": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 1
+                },
+                "up": {
+                    "x": 0,
+                    "y": 1,
+                    "z": 0
+                },
+                "fov_degrees": 65.0,
+                "aspect_ratio": 1.6,
+                "near_clip": 0.1,
+                "far_clip": 10000.0
+            }
+        ]
+    }
 }

--- a/asset/json/point_cloud.json
+++ b/asset/json/point_cloud.json
@@ -1,218 +1,256 @@
 {
-  "name": "PointCloud",
-  "default_texture_name": "point_cloud_rendering",
-  "textures": [
-    {
-      "name": "skybox",
-      "cubemap": "true",
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" },
-      "file_names": {
-        "positive_x": "asset/cubemap/negative_x.png",
-        "negative_x": "asset/cubemap/positive_x.png",
-        "positive_y": "asset/cubemap/negative_y.png",
-        "negative_y": "asset/cubemap/positive_y.png",
-        "positive_z": "asset/cubemap/negative_z.png",
-        "negative_z": "asset/cubemap/positive_z.png"
-      }
-    },
-    {
-      "name": "black_texture",
-      "size": {
-        "x": 1,
-        "y": 1
-      },
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    },
-    {
-      "name": "point_cloud_rendering",
-      "size": {
-        "x": -1,
-        "y": -1
-      },
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    }
-  ],
-  "materials": [
-    {
-      "name": "PaintBlackMaterial",
-      "program_name": "PaintBlackProgram",
-      "texture_names": [ "black_texture" ],
-      "inner_names": [ "Display" ]
-    },
-    {
-      "name": "CubeMapMaterial",
-      "program_name": "CubeMapProgram",
-      "texture_names": [ "skybox" ],
-      "inner_names": [ "Skybox" ]
-    },
-    {
-      "name": "PointCloudMaterial",
-      "program_name": "PointCloudProgram"
-    }
-  ],
-  "programs": [
-    {
-      "name": "PaintBlackProgram",
-      "output_texture_names": [ "point_cloud_rendering" ],
-      "input_scene_type": { "value": "QUAD" },
-      "shader": "display"
-    },
-    {
-      "name": "CubeMapProgram",
-      "input_texture_names": "skybox",
-      "output_texture_names": "point_cloud_rendering",
-      "input_scene_type": { "value": "CUBE" },
-      "shader": "cubemap",
-      "uniforms": [
+    "name": "PointCloud",
+    "default_texture_name": "point_cloud_rendering",
+    "textures": [
         {
-          "name": "projection",
-          "uniform_enum": "PROJECTION_MAT4"
+            "name": "skybox",
+            "cubemap": "true",
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            },
+            "file_names": {
+                "positive_x": "asset/cubemap/negative_x.png",
+                "negative_x": "asset/cubemap/positive_x.png",
+                "positive_y": "asset/cubemap/negative_y.png",
+                "negative_y": "asset/cubemap/positive_y.png",
+                "positive_z": "asset/cubemap/negative_z.png",
+                "negative_z": "asset/cubemap/positive_z.png"
+            }
         },
         {
-          "name": "view",
-          "uniform_enum": "VIEW_MAT4"
+            "name": "black_texture",
+            "size": {
+                "x": 1,
+                "y": 1
+            },
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
         },
         {
-          "name": "model",
-          "uniform_enum": "MODEL_MAT4"
+            "name": "point_cloud_rendering",
+            "size": {
+                "x": -1,
+                "y": -1
+            },
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
         }
-      ]
-    },
-    {
-      "name": "PointCloudProgram",
-      "output_texture_names": [ "point_cloud_rendering" ],
-      "input_scene_type": { "value": "SCENE" },
-      "input_scene_root_name": "root",
-      "shader": "point_cloud",
-      "uniforms": [
-        {
-          "name": "projection",
-          "uniform_enum": "PROJECTION_MAT4"
-        },
-        {
-          "name": "view",
-          "uniform_enum": "VIEW_MAT4"
-        },
-        {
-          "name": "model",
-          "uniform_enum": "MODEL_MAT4"
-        },
-        {
-          "name": "time_s",
-          "uniform_enum": "FLOAT_TIME_S"
-        }
-      ]
-    }
-  ],
-  "scene_tree": {
-    "default_camera_name": "camera",
-    "default_root_name": "root",
-    "node_matrices": [
-      {
-        "name": "root",
-        "matrix": {
-          "m11": 1,
-          "m22": 1,
-          "m33": 1,
-          "m44": 1
-        }
-      },
-      {
-        "name": "move",
-        "parent": "root",
-        "matrix": {
-          "m11": 1,
-          "m22": 1,
-          "m33": 1,
-          "m34": -2,
-          "m44": 1
-        }
-      },
-      {
-        "name": "skybox_holder",
-        "parent": "root",
-        "matrix": {
-          "m11": 1,
-          "m22": 1,
-          "m33": 1,
-          "m44": 1
-        }
-      },
-      {
-        "name": "move_back",
-        "parent": "rotation",
-        "matrix": {
-          "m11": 1,
-          "m22": 1,
-          "m33": 1,
-          "m34": 2,
-          "m44": 1
-        }
-      },
-      {
-        "name": "rotation",
-        "parent": "root",
-        "quaternion": {
-          "x": 0,
-          "y": 0.0087265,
-          "z": 0,
-          "w": 0.9999619
-        }
-      }
     ],
-    "node_static_meshes": [
-      {
-        "name": "InitCleanBuffer",
-        "clean_buffer": {
-          "values": [ "CLEAR_COLOR", "CLEAR_DEPTH" ]
+    "materials": [
+        {
+            "name": "PaintBlackMaterial",
+            "program_name": "PaintBlackProgram",
+            "texture_names": [
+                "black_texture"
+            ],
+            "inner_names": [
+                "Display"
+            ]
+        },
+        {
+            "name": "CubeMapMaterial",
+            "program_name": "CubeMapProgram",
+            "texture_names": [
+                "skybox"
+            ],
+            "inner_names": [
+                "Skybox"
+            ]
+        },
+        {
+            "name": "PointCloudMaterial",
+            "program_name": "PointCloudProgram"
         }
-      },
-      {
-        "name": "CubeMapMesh",
-        "parent": "skybox_holder",
-        "material_name": "CubeMapMaterial",
-        "mesh_enum": "CUBE"
-      },
-      {
-        "name": "ClearDepthBuffer",
-        "clean_buffer": {
-          "values": [ "CLEAR_DEPTH" ]
-        }
-      },
-      {
-        "name": "PointCloudMesh",
-        "parent": "root",
-        "render_primitive_enum": "POINT_PRIMITIVE",
-        "file_name": "racing_turbo.ply",
-        "material_name": "PointCloudMaterial"
-      }
     ],
-    "node_cameras": [
-      {
-        "name": "camera",
-        "parent": "root",
-        "fov_degrees": 65.0,
-        "near_clip": 0.01,
-        "far_clip": 100000.0,
-        "position": {
-          "x": 0.0,
-          "y": 0.0,
-          "z": 0.5
+    "programs": [
+        {
+            "name": "PaintBlackProgram",
+            "output_texture_names": [
+                "point_cloud_rendering"
+            ],
+            "input_scene_type": {
+                "value": "QUAD"
+            },
+            "shader_vertex": "display.vert",
+            "shader_fragment": "display.frag"
         },
-        "target": {
-          "x": 0.0,
-          "y": 0.0,
-          "z": 1.0
+        {
+            "name": "CubeMapProgram",
+            "input_texture_names": "skybox",
+            "output_texture_names": "point_cloud_rendering",
+            "input_scene_type": {
+                "value": "CUBE"
+            },
+            "shader_vertex": "cubemap.vert",
+            "shader_fragment": "cubemap.frag",
+            "uniforms": [
+                {
+                    "name": "projection",
+                    "uniform_enum": "PROJECTION_MAT4"
+                },
+                {
+                    "name": "view",
+                    "uniform_enum": "VIEW_MAT4"
+                },
+                {
+                    "name": "model",
+                    "uniform_enum": "MODEL_MAT4"
+                }
+            ]
         },
-        "up": {
-          "x": 0.0,
-          "y": -1.0,
-          "z": 0.0
+        {
+            "name": "PointCloudProgram",
+            "output_texture_names": [
+                "point_cloud_rendering"
+            ],
+            "input_scene_type": {
+                "value": "SCENE"
+            },
+            "input_scene_root_name": "root",
+            "shader_vertex": "point_cloud.vert",
+            "shader_fragment": "point_cloud.frag",
+            "uniforms": [
+                {
+                    "name": "projection",
+                    "uniform_enum": "PROJECTION_MAT4"
+                },
+                {
+                    "name": "view",
+                    "uniform_enum": "VIEW_MAT4"
+                },
+                {
+                    "name": "model",
+                    "uniform_enum": "MODEL_MAT4"
+                },
+                {
+                    "name": "time_s",
+                    "uniform_enum": "FLOAT_TIME_S"
+                }
+            ]
         }
-      }
-    ]
-  }
+    ],
+    "scene_tree": {
+        "default_camera_name": "camera",
+        "default_root_name": "root",
+        "node_matrices": [
+            {
+                "name": "root",
+                "matrix": {
+                    "m11": 1,
+                    "m22": 1,
+                    "m33": 1,
+                    "m44": 1
+                }
+            },
+            {
+                "name": "move",
+                "parent": "root",
+                "matrix": {
+                    "m11": 1,
+                    "m22": 1,
+                    "m33": 1,
+                    "m34": -2,
+                    "m44": 1
+                }
+            },
+            {
+                "name": "skybox_holder",
+                "parent": "root",
+                "matrix": {
+                    "m11": 1,
+                    "m22": 1,
+                    "m33": 1,
+                    "m44": 1
+                }
+            },
+            {
+                "name": "move_back",
+                "parent": "rotation",
+                "matrix": {
+                    "m11": 1,
+                    "m22": 1,
+                    "m33": 1,
+                    "m34": 2,
+                    "m44": 1
+                }
+            },
+            {
+                "name": "rotation",
+                "parent": "root",
+                "quaternion": {
+                    "x": 0,
+                    "y": 0.0087265,
+                    "z": 0,
+                    "w": 0.9999619
+                }
+            }
+        ],
+        "node_static_meshes": [
+            {
+                "name": "InitCleanBuffer",
+                "clean_buffer": {
+                    "values": [
+                        "CLEAR_COLOR",
+                        "CLEAR_DEPTH"
+                    ]
+                }
+            },
+            {
+                "name": "CubeMapMesh",
+                "parent": "skybox_holder",
+                "material_name": "CubeMapMaterial",
+                "mesh_enum": "CUBE"
+            },
+            {
+                "name": "ClearDepthBuffer",
+                "clean_buffer": {
+                    "values": [
+                        "CLEAR_DEPTH"
+                    ]
+                }
+            },
+            {
+                "name": "PointCloudMesh",
+                "parent": "root",
+                "render_primitive_enum": "POINT_PRIMITIVE",
+                "file_name": "racing_turbo.ply",
+                "material_name": "PointCloudMaterial"
+            }
+        ],
+        "node_cameras": [
+            {
+                "name": "camera",
+                "parent": "root",
+                "fov_degrees": 65.0,
+                "near_clip": 0.01,
+                "far_clip": 100000.0,
+                "position": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.5
+                },
+                "target": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 1.0
+                },
+                "up": {
+                    "x": 0.0,
+                    "y": -1.0,
+                    "z": 0.0
+                }
+            }
+        ]
+    }
 }

--- a/asset/json/program_test.json
+++ b/asset/json/program_test.json
@@ -1,80 +1,95 @@
 {
-  "name": "ProgramTest",
-  "default_texture_name": "DefaultTexture",
-  "textures": [
-    {
-      "name": "DefaultTexture",
-      "size": {
-        "x": "640",
-        "y": "480"
-      },
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    },
-    {
-      "name": "texture",
-      "size": {
-        "x": "320",
-        "y": "200"
-      },
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    }
-  ],
-  "programs": [
-    {
-      "name": "program",
-      "input_texture_names": [ "texture" ],
-      "output_texture_names": [ "DefaultTexture" ],
-      "input_scene_type": { "value": "SCENE" },
-      "input_scene_root_name": "root",
-      "shader": "blur",
-      "uniforms": [
+    "name": "ProgramTest",
+    "default_texture_name": "DefaultTexture",
+    "textures": [
         {
-          "name": "exponent",
-          "uniform_float": "1.0"
+            "name": "DefaultTexture",
+            "size": {
+                "x": "640",
+                "y": "480"
+            },
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
+        },
+        {
+            "name": "texture",
+            "size": {
+                "x": "320",
+                "y": "200"
+            },
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
         }
-      ]
-    }
-  ],
-  "scene_tree": {
-    "default_root_name": "root",
-    "default_camera_name": "camera",
-    "node_matrices": [
-      {
-        "name": "root",
-        "quaternion": {
-          "w": 1,
-          "x": 0,
-          "y": 0,
-          "z": 0
-        }
-      }
     ],
-    "node_cameras": [
-      {
-        "name": "camera",
-        "parent": "root",
-        "position": {
-          "x": 0,
-          "y": 0,
-          "z": 0
-        },
-        "target": {
-          "x": 0,
-          "y": 0,
-          "z": 1
-        },
-        "up": {
-          "x": 0,
-          "y": 1,
-          "z": 0
-        },
-        "fov_degrees": 65.0,
-        "aspect_ratio": 1.6,
-        "near_clip": 0.1,
-        "far_clip": 10000.0
-      }
-    ]
-  }
+    "programs": [
+        {
+            "name": "program",
+            "input_texture_names": [
+                "texture"
+            ],
+            "output_texture_names": [
+                "DefaultTexture"
+            ],
+            "input_scene_type": {
+                "value": "SCENE"
+            },
+            "input_scene_root_name": "root",
+            "shader_vertex": "blur.vert",
+            "shader_fragment": "blur.frag",
+            "uniforms": [
+                {
+                    "name": "exponent",
+                    "uniform_float": "1.0"
+                }
+            ]
+        }
+    ],
+    "scene_tree": {
+        "default_root_name": "root",
+        "default_camera_name": "camera",
+        "node_matrices": [
+            {
+                "name": "root",
+                "quaternion": {
+                    "w": 1,
+                    "x": 0,
+                    "y": 0,
+                    "z": 0
+                }
+            }
+        ],
+        "node_cameras": [
+            {
+                "name": "camera",
+                "parent": "root",
+                "position": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 0
+                },
+                "target": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 1
+                },
+                "up": {
+                    "x": 0,
+                    "y": 1,
+                    "z": 0
+                },
+                "fov_degrees": 65.0,
+                "aspect_ratio": 1.6,
+                "near_clip": 0.1,
+                "far_clip": 10000.0
+            }
+        ]
+    }
 }

--- a/asset/json/ray_marching.json
+++ b/asset/json/ray_marching.json
@@ -1,87 +1,102 @@
 {
-  "name": "RayMarching",
-  "default_texture_name": "billboard",
-  "materials": [
-    {
-      "name": "RayMarchingMaterial",
-      "program_name": "RayMarchingProgram",
-      "texture_names": [],
-      "inner_names": []
-    }
-  ],
-  "programs": [
-    {
-      "name": "RayMarchingProgram",
-      "output_texture_names": "billboard",
-      "input_scene_type": { "value": "QUAD" },
-      "shader": "ray_marching",
-      "uniforms": [
+    "name": "RayMarching",
+    "default_texture_name": "billboard",
+    "materials": [
         {
-          "name": "time_s",
-          "uniform_enum": "FLOAT_TIME_S"
+            "name": "RayMarchingMaterial",
+            "program_name": "RayMarchingProgram",
+            "texture_names": [],
+            "inner_names": []
         }
-      ]
-    }
-  ],
-  "textures": [
-    {
-      "name": "billboard",
-      "size": {
-        "x": "-1",
-        "y": "-1"
-      },
-      "cubemap": "false",
-      "pixel_element_size": { "value": "HALF" },
-      "pixel_structure": { "value": "RGB" },
-      "min_filter": { "value": "LINEAR" },
-      "mag_filter": { "value": "LINEAR" },
-      "wrap_s": { "value": "CLAMP_TO_EDGE" },
-      "wrap_t": { "value": "CLAMP_TO_EDGE" }
-    }
-  ],
-  "scene_tree": {
-    "default_camera_name": "camera",
-    "default_root_name": "root",
-    "node_matrices": [
-      {
-        "name": "root",
-        "matrix": {
-          "m11": "1.0",
-          "m22": "1.0",
-          "m33": "1.0",
-          "m44": "1.0"
-        }
-      }
     ],
-    "node_cameras": [
-      {
-        "name": "camera",
-        "parent": "root",
-        "fov_degrees": "65.0",
-        "position": {
-          "x": "0",
-          "y": "0",
-          "z": "-1"
-        },
-        "target": {
-          "x": "0",
-          "y": "0",
-          "z": "1"
-        },
-        "up": {
-          "x": "0",
-          "y": "1",
-          "z": "0"
+    "programs": [
+        {
+            "name": "RayMarchingProgram",
+            "output_texture_names": "billboard",
+            "input_scene_type": {
+                "value": "QUAD"
+            },
+            "shader_vertex": "ray_marching.vert",
+            "shader_fragment": "ray_marching.frag",
+            "uniforms": [
+                {
+                    "name": "time_s",
+                    "uniform_enum": "FLOAT_TIME_S"
+                }
+            ]
         }
-      }
     ],
-    "node_static_meshes": [
-      {
-        "name": "RayMarchingRendering",
-        "parent": "root",
-        "mesh_enum": "QUAD",
-        "material_name": "RayMarchingMaterial"
-      }
-    ]
-  }
+    "textures": [
+        {
+            "name": "billboard",
+            "size": {
+                "x": "-1",
+                "y": "-1"
+            },
+            "cubemap": "false",
+            "pixel_element_size": {
+                "value": "HALF"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            },
+            "min_filter": {
+                "value": "LINEAR"
+            },
+            "mag_filter": {
+                "value": "LINEAR"
+            },
+            "wrap_s": {
+                "value": "CLAMP_TO_EDGE"
+            },
+            "wrap_t": {
+                "value": "CLAMP_TO_EDGE"
+            }
+        }
+    ],
+    "scene_tree": {
+        "default_camera_name": "camera",
+        "default_root_name": "root",
+        "node_matrices": [
+            {
+                "name": "root",
+                "matrix": {
+                    "m11": "1.0",
+                    "m22": "1.0",
+                    "m33": "1.0",
+                    "m44": "1.0"
+                }
+            }
+        ],
+        "node_cameras": [
+            {
+                "name": "camera",
+                "parent": "root",
+                "fov_degrees": "65.0",
+                "position": {
+                    "x": "0",
+                    "y": "0",
+                    "z": "-1"
+                },
+                "target": {
+                    "x": "0",
+                    "y": "0",
+                    "z": "1"
+                },
+                "up": {
+                    "x": "0",
+                    "y": "1",
+                    "z": "0"
+                }
+            }
+        ],
+        "node_static_meshes": [
+            {
+                "name": "RayMarchingRendering",
+                "parent": "root",
+                "mesh_enum": "QUAD",
+                "material_name": "RayMarchingMaterial"
+            }
+        ]
+    }
 }

--- a/asset/json/scene_simple.json
+++ b/asset/json/scene_simple.json
@@ -1,218 +1,253 @@
 {
-  "name": "SceneSimple",
-  "default_texture_name": "albedo",
-  "materials": [
-    {
-      "name": "SceneSimpleMaterial",
-      "program_name": "SceneSimpleProgram",
-      "texture_names": [ "apple_texture" ],
-      "inner_names": [ "Color" ]
-    },
-    {
-      "name": "CubeMapMaterial",
-      "program_name": "CubeMapProgram",
-      "texture_names": [ "skybox" ],
-      "inner_names": [ "Skybox" ]
-    }
-  ],
-  "programs": [
-    {
-      "name": "CubeMapProgram",
-      "input_texture_names": "skybox",
-      "output_texture_names": "albedo",
-      "input_scene_type": { "value": "CUBE" },
-      "shader": "cubemap",
-      "uniforms": [
+    "name": "SceneSimple",
+    "default_texture_name": "albedo",
+    "materials": [
         {
-          "name": "projection",
-          "uniform_enum": "PROJECTION_MAT4"
+            "name": "SceneSimpleMaterial",
+            "program_name": "SceneSimpleProgram",
+            "texture_names": [
+                "apple_texture"
+            ],
+            "inner_names": [
+                "Color"
+            ]
         },
         {
-          "name": "view",
-          "uniform_enum": "VIEW_MAT4"
-        },
-        {
-          "name": "model",
-          "uniform_enum": "MODEL_MAT4"
+            "name": "CubeMapMaterial",
+            "program_name": "CubeMapProgram",
+            "texture_names": [
+                "skybox"
+            ],
+            "inner_names": [
+                "Skybox"
+            ]
         }
-      ]
-    },
-    {
-      "name": "SceneSimpleProgram",
-      "output_texture_names": [
-        "albedo",
-        "zbuffer"
-      ],
-      "input_scene_type": { "value": "SCENE" },
-      "input_scene_root_name": "root",
-      "shader": "scene_simple",
-      "uniforms": [
-        {
-          "name": "projection",
-          "uniform_enum": "PROJECTION_MAT4"
-        },
-        {
-          "name": "view",
-          "uniform_enum": "VIEW_MAT4"
-        },
-        {
-          "name": "model",
-          "uniform_enum": "MODEL_MAT4"
-        },
-        {
-          "name": "time_s",
-          "uniform_enum": "FLOAT_TIME_S"
-        }
-      ]
-    }
-  ],
-  "textures": [
-    {
-      "name": "skybox",
-      "cubemap": "true",
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" },
-      "file_names": {
-        "positive_x": "asset/cubemap/negative_x.png",
-        "negative_x": "asset/cubemap/positive_x.png",
-        "positive_y": "asset/cubemap/negative_y.png",
-        "negative_y": "asset/cubemap/positive_y.png",
-        "positive_z": "asset/cubemap/negative_z.png",
-        "negative_z": "asset/cubemap/positive_z.png"
-      }
-    },
-    {
-      "name": "apple_texture",
-      "cubemap": "false",
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" },
-      "file_name": "asset/apple/color.jpg"
-    },
-    {
-      "name": "albedo",
-      "cubemap": "false",
-      "size": {
-        "x": "-1",
-        "y": "-1"
-      },
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    },
-    {
-      "name": "zbuffer",
-      "cubemap": "false",
-      "size": {
-        "x": "-1",
-        "y": "-1"
-      },
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    }
-  ],
-  "scene_tree": {
-    "default_camera_name": "camera",
-    "default_root_name": "root",
-    "node_matrices": [
-      {
-        "name": "root",
-        "matrix": {
-          "m11": 1,
-          "m22": 1,
-          "m33": 1,
-          "m44": 1
-        }
-      },
-      {
-        "name": "mesh_holder",
-        "parent": "root",
-        "quaternion": {
-          "x": 0.0,
-          "y": 0.1979232,
-          "z": 0.1484424,
-          "w": 0.9689124
-        }
-      },
-      {
-        "name": "skybox_holder",
-        "parent": "root",
-        "quaternion": {
-          "x": 0,
-          "y": 0.0499792,
-          "z": 0.0,
-          "w": 0.9987503
-        }
-      }
     ],
-    "node_static_meshes": [
-      {
-        "name": "InitCleanBuffer",
-        "clean_buffer": {
-          "values": [ "CLEAR_COLOR", "CLEAR_DEPTH" ]
+    "programs": [
+        {
+            "name": "CubeMapProgram",
+            "input_texture_names": "skybox",
+            "output_texture_names": "albedo",
+            "input_scene_type": {
+                "value": "CUBE"
+            },
+            "shader_vertex": "cubemap.vert",
+            "shader_fragment": "cubemap.frag",
+            "uniforms": [
+                {
+                    "name": "projection",
+                    "uniform_enum": "PROJECTION_MAT4"
+                },
+                {
+                    "name": "view",
+                    "uniform_enum": "VIEW_MAT4"
+                },
+                {
+                    "name": "model",
+                    "uniform_enum": "MODEL_MAT4"
+                }
+            ]
         },
-        "render_time_enum": "SKYBOX_RENDER_TIME"
-      },
-      {
-        "name": "CubeMapMesh",
-        "parent": "skybox_holder",
-        "material_name": "CubeMapMaterial",
-        "mesh_enum": "CUBE",
-        "render_time_enum": "SKYBOX_RENDER_TIME"
-      },
-      {
-        "name": "ClearDepthBuffer",
-        "clean_buffer": {
-          "values": [ "CLEAR_DEPTH" ]
-        },
-        "render_time_enum": "SKYBOX_RENDER_TIME"
-      },
-      {
-        "name": "AppleMesh",
-        "parent": "mesh_holder",
-        "file_name": "apple.obj",
-        "material_name": "SceneSimpleMaterial",
-        "render_time_enum": "SCENE_RENDER_TIME"
-      }
-    ],
-    "node_cameras": [
-      {
-        "name": "camera",
-        "parent": "root",
-        "fov_degrees": 65.0,
-        "near_clip": 0.01,
-        "far_clip": 1000,
-        "position": {
-          "x": 0,
-          "y": 0,
-          "z": -2
-        },
-        "target": {
-          "x": 0,
-          "y": 0,
-          "z": 1
-        },
-        "up": {
-          "x": 0,
-          "y": 1,
-          "z": 0
+        {
+            "name": "SceneSimpleProgram",
+            "output_texture_names": [
+                "albedo",
+                "zbuffer"
+            ],
+            "input_scene_type": {
+                "value": "SCENE"
+            },
+            "input_scene_root_name": "root",
+            "shader_vertex": "scene_simple.vert",
+            "shader_fragment": "scene_simple.frag",
+            "uniforms": [
+                {
+                    "name": "projection",
+                    "uniform_enum": "PROJECTION_MAT4"
+                },
+                {
+                    "name": "view",
+                    "uniform_enum": "VIEW_MAT4"
+                },
+                {
+                    "name": "model",
+                    "uniform_enum": "MODEL_MAT4"
+                },
+                {
+                    "name": "time_s",
+                    "uniform_enum": "FLOAT_TIME_S"
+                }
+            ]
         }
-      }
     ],
-    "node_lights": [
-      {
-        "name": "sun",
-        "parent": "root",
-        "light_type": "DIRECTIONAL_LIGHT",
-        "position": {
-          "x": "-1.0",
-          "y": "1.0",
-          "z": "1.0"
+    "textures": [
+        {
+            "name": "skybox",
+            "cubemap": "true",
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            },
+            "file_names": {
+                "positive_x": "asset/cubemap/negative_x.png",
+                "negative_x": "asset/cubemap/positive_x.png",
+                "positive_y": "asset/cubemap/negative_y.png",
+                "negative_y": "asset/cubemap/positive_y.png",
+                "positive_z": "asset/cubemap/negative_z.png",
+                "negative_z": "asset/cubemap/positive_z.png"
+            }
         },
-        "color": {
-          "x": "1.0",
-          "y": "1.0",
-          "z": "1.0"
+        {
+            "name": "apple_texture",
+            "cubemap": "false",
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            },
+            "file_name": "asset/apple/color.jpg"
+        },
+        {
+            "name": "albedo",
+            "cubemap": "false",
+            "size": {
+                "x": "-1",
+                "y": "-1"
+            },
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
+        },
+        {
+            "name": "zbuffer",
+            "cubemap": "false",
+            "size": {
+                "x": "-1",
+                "y": "-1"
+            },
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
         }
-      }
-    ]
-  }
+    ],
+    "scene_tree": {
+        "default_camera_name": "camera",
+        "default_root_name": "root",
+        "node_matrices": [
+            {
+                "name": "root",
+                "matrix": {
+                    "m11": 1,
+                    "m22": 1,
+                    "m33": 1,
+                    "m44": 1
+                }
+            },
+            {
+                "name": "mesh_holder",
+                "parent": "root",
+                "quaternion": {
+                    "x": 0.0,
+                    "y": 0.1979232,
+                    "z": 0.1484424,
+                    "w": 0.9689124
+                }
+            },
+            {
+                "name": "skybox_holder",
+                "parent": "root",
+                "quaternion": {
+                    "x": 0,
+                    "y": 0.0499792,
+                    "z": 0.0,
+                    "w": 0.9987503
+                }
+            }
+        ],
+        "node_static_meshes": [
+            {
+                "name": "InitCleanBuffer",
+                "clean_buffer": {
+                    "values": [
+                        "CLEAR_COLOR",
+                        "CLEAR_DEPTH"
+                    ]
+                },
+                "render_time_enum": "SKYBOX_RENDER_TIME"
+            },
+            {
+                "name": "CubeMapMesh",
+                "parent": "skybox_holder",
+                "material_name": "CubeMapMaterial",
+                "mesh_enum": "CUBE",
+                "render_time_enum": "SKYBOX_RENDER_TIME"
+            },
+            {
+                "name": "ClearDepthBuffer",
+                "clean_buffer": {
+                    "values": [
+                        "CLEAR_DEPTH"
+                    ]
+                },
+                "render_time_enum": "SKYBOX_RENDER_TIME"
+            },
+            {
+                "name": "AppleMesh",
+                "parent": "mesh_holder",
+                "file_name": "apple.obj",
+                "material_name": "SceneSimpleMaterial",
+                "render_time_enum": "SCENE_RENDER_TIME"
+            }
+        ],
+        "node_cameras": [
+            {
+                "name": "camera",
+                "parent": "root",
+                "fov_degrees": 65.0,
+                "near_clip": 0.01,
+                "far_clip": 1000,
+                "position": {
+                    "x": 0,
+                    "y": 0,
+                    "z": -2
+                },
+                "target": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 1
+                },
+                "up": {
+                    "x": 0,
+                    "y": 1,
+                    "z": 0
+                }
+            }
+        ],
+        "node_lights": [
+            {
+                "name": "sun",
+                "parent": "root",
+                "light_type": "DIRECTIONAL_LIGHT",
+                "position": {
+                    "x": "-1.0",
+                    "y": "1.0",
+                    "z": "1.0"
+                },
+                "color": {
+                    "x": "1.0",
+                    "y": "1.0",
+                    "z": "1.0"
+                }
+            }
+        ]
+    }
 }

--- a/asset/json/scene_tree_test.json
+++ b/asset/json/scene_tree_test.json
@@ -1,74 +1,89 @@
 {
-  "name": "SceneTreeTest",
-  "default_texture_name": "DefaultTexture",
-  "textures": [
-    {
-      "name": "DefaultTexture",
-      "size": {
-        "x": "640",
-        "y": "480"
-      },
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    },
-    {
-      "name": "texture",
-      "size": {
-        "x": "320",
-        "y": "200"
-      },
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    }
-  ],
-  "programs": [
-    {
-      "name": "program",
-      "input_texture_names": [ "texture" ],
-      "output_texture_names": [ "DefaultTexture" ],
-      "input_scene_type": { "value": "SCENE" },
-      "input_scene_root_name": "root",
-      "shader": "blur"
-    }
-  ],
-  "scene_tree": {
-    "default_root_name": "root",
-    "default_camera_name": "camera",
-    "node_matrices": [
-      {
-        "name": "root",
-        "quaternion": {
-          "w": 1,
-          "x": 0,
-          "y": 0,
-          "z": 0
+    "name": "SceneTreeTest",
+    "default_texture_name": "DefaultTexture",
+    "textures": [
+        {
+            "name": "DefaultTexture",
+            "size": {
+                "x": "640",
+                "y": "480"
+            },
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
+        },
+        {
+            "name": "texture",
+            "size": {
+                "x": "320",
+                "y": "200"
+            },
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
         }
-      }
     ],
-    "node_cameras": [
-      {
-        "name": "camera",
-        "parent": "root",
-        "position": {
-          "x": 0,
-          "y": 0,
-          "z": 0
-        },
-        "target": {
-          "x": 0,
-          "y": 0,
-          "z": 1
-        },
-        "up": {
-          "x": 0,
-          "y": 1,
-          "z": 0
-        },
-        "fov_degrees": 65.0,
-        "aspect_ratio": 1.6,
-        "near_clip": 0.1,
-        "far_clip": 10000.0
-      }
-    ]
-  }
+    "programs": [
+        {
+            "name": "program",
+            "input_texture_names": [
+                "texture"
+            ],
+            "output_texture_names": [
+                "DefaultTexture"
+            ],
+            "input_scene_type": {
+                "value": "SCENE"
+            },
+            "input_scene_root_name": "root",
+            "shader_vertex": "blur.vert",
+            "shader_fragment": "blur.frag"
+        }
+    ],
+    "scene_tree": {
+        "default_root_name": "root",
+        "default_camera_name": "camera",
+        "node_matrices": [
+            {
+                "name": "root",
+                "quaternion": {
+                    "w": 1,
+                    "x": 0,
+                    "y": 0,
+                    "z": 0
+                }
+            }
+        ],
+        "node_cameras": [
+            {
+                "name": "camera",
+                "parent": "root",
+                "position": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 0
+                },
+                "target": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 1
+                },
+                "up": {
+                    "x": 0,
+                    "y": 1,
+                    "z": 0
+                },
+                "fov_degrees": 65.0,
+                "aspect_ratio": 1.6,
+                "near_clip": 0.1,
+                "far_clip": 10000.0
+            }
+        ]
+    }
 }

--- a/asset/json/shadow.json
+++ b/asset/json/shadow.json
@@ -1,238 +1,291 @@
 {
-  "name": "Shadow",
-  "default_texture_name": "albedo",
-  "textures": [
-    {
-      "name": "albedo",
-      "size": {
-        "x": -1,
-        "y": -1
-      },
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" }
-    },
-    {
-      "name": "skybox",
-      "cubemap": true,
-      "pixel_element_size": { "value": "FLOAT" },
-      "pixel_structure": { "value": "RGB" },
-      "file_name": "asset/cubemap/shiodome.hdr"
-    },
-    {
-      "name": "shadow_map",
-      "size": {
-        "x": 1024,
-        "y": 1024
-      },
-      "pixel_element_size": { "value": "FLOAT" },
-      "pixel_structure": { "value": "DEPTH" }
-    },
-    {
-      "name": "apple_texture",
-      "cubemap": false,
-      "pixel_element_size": { "value": "BYTE" },
-      "pixel_structure": { "value": "RGB" },
-      "file_name": "asset/apple/color.jpg"
-    },
-    {
-      "name": "zbuffer",
-      "cubemap": false,
-      "size": {
-        "x": -1,
-        "y": -1
-      },
-      "pixel_element_size": { "value": "FLOAT" },
-      "pixel_structure": { "value": "DEPTH" }
-    }
-  ],
-  "materials": [
-    {
-      "name": "CubeMapMaterial",
-      "program_name": "CubeMapProgram",
-      "texture_names": [ "skybox" ],
-      "inner_names": [ "Skybox" ]
-    },
-    {
-      "name": "AppleMaterial",
-      "program_name": "AppleProgram",
-      "texture_names": [ "apple_texture", "zbuffer", "shadow" ],
-      "inner_names": [ "AppleTexture", "Zbuffer", "Shadow "]
-    }
-  ],
-  "programs": [
-    {
-      "name": "CubeMapProgram",
-      "input_texture_names": [ "skybox" ],
-      "output_texture_names": [ "albedo" ],
-      "input_scene_type": { "value": "CUBE" },
-      "shader": "cubemap",
-      "parameters": [
+    "name": "Shadow",
+    "default_texture_name": "albedo",
+    "textures": [
         {
-          "name": "projection",
-          "uniform_enum": "PROJECTION_MAT4"
+            "name": "albedo",
+            "size": {
+                "x": -1,
+                "y": -1
+            },
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
         },
         {
-          "name": "view",
-          "uniform_enum": "VIEW_MAT4"
+            "name": "skybox",
+            "cubemap": true,
+            "pixel_element_size": {
+                "value": "FLOAT"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            },
+            "file_name": "asset/cubemap/shiodome.hdr"
         },
         {
-          "name": "model",
-          "uniform_enum": "MODEL_MAT4"
+            "name": "shadow_map",
+            "size": {
+                "x": 1024,
+                "y": 1024
+            },
+            "pixel_element_size": {
+                "value": "FLOAT"
+            },
+            "pixel_structure": {
+                "value": "DEPTH"
+            }
+        },
+        {
+            "name": "apple_texture",
+            "cubemap": false,
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            },
+            "file_name": "asset/apple/color.jpg"
+        },
+        {
+            "name": "zbuffer",
+            "cubemap": false,
+            "size": {
+                "x": -1,
+                "y": -1
+            },
+            "pixel_element_size": {
+                "value": "FLOAT"
+            },
+            "pixel_structure": {
+                "value": "DEPTH"
+            }
         }
-      ]
-    },
-    {
-      "name": "ShadowProgram",
-      "input_texture_names": [],
-      "output_texture_names": [ "shadow_map" ],
-      "input_scene_type": { "value": "SCENE" },
-      "input_scene_root_name": "root",
-      "shader": "shadow"
-    },
-    {
-      "name": "AppleProgram",
-      "input_texture_names": [ "apple_texture", "skybox", "shadow_map" ],
-      "output_texture_names": [ "albedo" ],
-      "input_scene_type": { "value": "SCENE" },
-      "input_scene_root_name": "root",
-      "shader": "apple_shadow",
-      "parameters": [
+    ],
+    "materials": [
         {
-          "name": "projection",
-          "uniform_enum": "PROJECTION_MAT4"
-        },
-        {
-          "name": "view",
-          "uniform_enum": "VIEW_MAT4"
-        },
-        {
-          "name": "model",
-          "uniform_enum": "MODEL_MAT4"
-        },
-        {
-          "name": "light_projection_view",
-          "uniform_vec4s": {
-            "values": [
-              {
-                "x": 1.0,
-                "y": 0.0,
-                "z": 0.0,
-                "w": 0.0
-              },
-              {
-                "x": 0.0,
-                "y": 1.0,
-                "z": 0.0,
-                "w": 0.0
-              },
-              {
-                "x": 0.0,
-                "y": 0.0,
-                "z": 1.0,
-                "w": 0.0
-              },
-              {
-                "x": 0.0,
-                "y": 0.0,
-                "z": 0.0,
-                "w": 1.0
-              }
+            "name": "CubeMapMaterial",
+            "program_name": "CubeMapProgram",
+            "texture_names": [
+                "skybox"
+            ],
+            "inner_names": [
+                "Skybox"
             ]
-          }
+        },
+        {
+            "name": "AppleMaterial",
+            "program_name": "AppleProgram",
+            "texture_names": [
+                "apple_texture",
+                "zbuffer",
+                "shadow"
+            ],
+            "inner_names": [
+                "AppleTexture",
+                "Zbuffer",
+                "Shadow "
+            ]
         }
-      ]
+    ],
+    "programs": [
+        {
+            "name": "CubeMapProgram",
+            "input_texture_names": [
+                "skybox"
+            ],
+            "output_texture_names": [
+                "albedo"
+            ],
+            "input_scene_type": {
+                "value": "CUBE"
+            },
+            "shader_vertex": "cubemap.vert",
+            "shader_fragment": "cubemap.frag",
+            "parameters": [
+                {
+                    "name": "projection",
+                    "uniform_enum": "PROJECTION_MAT4"
+                },
+                {
+                    "name": "view",
+                    "uniform_enum": "VIEW_MAT4"
+                },
+                {
+                    "name": "model",
+                    "uniform_enum": "MODEL_MAT4"
+                }
+            ]
+        },
+        {
+            "name": "ShadowProgram",
+            "input_texture_names": [],
+            "output_texture_names": [
+                "shadow_map"
+            ],
+            "input_scene_type": {
+                "value": "SCENE"
+            },
+            "input_scene_root_name": "root",
+            "shader_vertex": "shadow.vert",
+            "shader_fragment": "shadow.frag"
+        },
+        {
+            "name": "AppleProgram",
+            "input_texture_names": [
+                "apple_texture",
+                "skybox",
+                "shadow_map"
+            ],
+            "output_texture_names": [
+                "albedo"
+            ],
+            "input_scene_type": {
+                "value": "SCENE"
+            },
+            "input_scene_root_name": "root",
+            "shader_vertex": "apple_shadow.vert",
+            "shader_fragment": "apple_shadow.frag",
+            "parameters": [
+                {
+                    "name": "projection",
+                    "uniform_enum": "PROJECTION_MAT4"
+                },
+                {
+                    "name": "view",
+                    "uniform_enum": "VIEW_MAT4"
+                },
+                {
+                    "name": "model",
+                    "uniform_enum": "MODEL_MAT4"
+                },
+                {
+                    "name": "light_projection_view",
+                    "uniform_vec4s": {
+                        "values": [
+                            {
+                                "x": 1.0,
+                                "y": 0.0,
+                                "z": 0.0,
+                                "w": 0.0
+                            },
+                            {
+                                "x": 0.0,
+                                "y": 1.0,
+                                "z": 0.0,
+                                "w": 0.0
+                            },
+                            {
+                                "x": 0.0,
+                                "y": 0.0,
+                                "z": 1.0,
+                                "w": 0.0
+                            },
+                            {
+                                "x": 0.0,
+                                "y": 0.0,
+                                "z": 0.0,
+                                "w": 1.0
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "scene_tree": {
+        "default_camera_name": "camera",
+        "default_root_name": "root",
+        "scene_matrices": [
+            {
+                "name": "root",
+                "matrix": {
+                    "m11": 1.0,
+                    "m22": 1.0,
+                    "m33": 1.0,
+                    "m44": 1.0
+                }
+            },
+            {
+                "name": "mesh_holder",
+                "parent": "root",
+                "quaternion": {
+                    "x": 0.0,
+                    "y": 0.1979232,
+                    "z": 0.1484424,
+                    "w": 0.9689124
+                }
+            },
+            {
+                "name": "camera_holder",
+                "parent": "root",
+                "quaternion": {
+                    "x": 0,
+                    "y": 0.0499792,
+                    "z": 0.0,
+                    "w": 0.9987503
+                }
+            }
+        ],
+        "scene_static_meshes": [
+            {
+                "name": "CubeMapMesh",
+                "parent": "root",
+                "material_name": "CubeMapMaterial",
+                "mesh_enum": "CUBE"
+            },
+            {
+                "name": "AppleMesh",
+                "parent": "mesh_holder",
+                "file_name": "apple.obj",
+                "material_name": "AppleMaterial"
+            }
+        ],
+        "scene_cameras": [
+            {
+                "name": "camera",
+                "parent": "camera_holder",
+                "fov_degrees": 65.0,
+                "near_clip": 0.01,
+                "far_clip": 1000.0,
+                "position": {
+                    "x": 0,
+                    "y": 0,
+                    "z": -2
+                },
+                "target": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 1
+                },
+                "up": {
+                    "x": 0,
+                    "y": 1,
+                    "z": 0
+                }
+            }
+        ],
+        "scene_lights": [
+            {
+                "name": "sun",
+                "parent": "root",
+                "light_type": "DIRECTIONAL_LIGHT",
+                "shadow_type": "SOFT_SHADOW",
+                "shadow_texture": "shadow_map",
+                "position": {
+                    "x": -1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                },
+                "color": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            }
+        ]
     }
-  ],
-  "scene_tree": {
-    "default_camera_name": "camera",
-    "default_root_name": "root",
-    "scene_matrices": [
-      {
-        "name": "root",
-        "matrix": {
-          "m11": 1.0,
-          "m22": 1.0,
-          "m33": 1.0,
-          "m44": 1.0
-        }
-      },
-      {
-        "name": "mesh_holder",
-        "parent": "root",
-        "quaternion": {
-          "x": 0.0,
-          "y": 0.1979232,
-          "z": 0.1484424,
-          "w": 0.9689124
-        }
-      },
-      {
-        "name": "camera_holder",
-        "parent": "root",
-        "quaternion": {
-          "x": 0,
-          "y": 0.0499792,
-          "z": 0.0,
-          "w": 0.9987503
-        }
-      }
-    ],
-    "scene_static_meshes": [
-      {
-        "name": "CubeMapMesh",
-        "parent": "root",
-        "material_name": "CubeMapMaterial",
-        "mesh_enum": "CUBE"
-      },
-      {
-        "name": "AppleMesh",
-        "parent": "mesh_holder",
-        "file_name": "apple.obj",
-        "material_name": "AppleMaterial"
-      }
-    ],
-    "scene_cameras": [
-      {
-        "name": "camera",
-        "parent": "camera_holder",
-        "fov_degrees": 65.0,
-        "near_clip": 0.01,
-        "far_clip": 1000.0,
-        "position": {
-          "x": 0,
-          "y": 0,
-          "z": -2
-        },
-        "target": {
-          "x": 0,
-          "y": 0,
-          "z": 1
-        },
-        "up": {
-          "x": 0,
-          "y": 1,
-          "z": 0
-        }
-      }
-    ],
-    "scene_lights": [
-      {
-        "name": "sun",
-        "parent": "root",
-        "light_type": "DIRECTIONAL_LIGHT",
-        "shadow_type": "SOFT_SHADOW",
-        "shadow_texture": "shadow_map",
-        "position": {
-          "x": -1.0,
-          "y": 1.0,
-          "z": 1.0
-        },
-        "color": {
-          "x": 1.0,
-          "y": 1.0,
-          "z": 1.0
-        }
-      }
-    ]
-  }
 }

--- a/include/frame/proto/program.pb.h
+++ b/include/frame/proto/program.pb.h
@@ -17,18 +17,18 @@
 #error "Protobuf C++ headers/runtime. See"
 #error "https://protobuf.dev/support/cross-version-runtime-guarantee/#cpp"
 #endif
-#include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/arena.h"
 #include "google/protobuf/arenastring.h"
+#include "google/protobuf/extension_set.h" // IWYU pragma: export
+#include "google/protobuf/generated_enum_reflection.h"
+#include "google/protobuf/generated_message_reflection.h"
 #include "google/protobuf/generated_message_tctable_decl.h"
 #include "google/protobuf/generated_message_util.h"
-#include "google/protobuf/metadata_lite.h"
-#include "google/protobuf/generated_message_reflection.h"
+#include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/message.h"
 #include "google/protobuf/message_lite.h"
-#include "google/protobuf/repeated_field.h"  // IWYU pragma: export
-#include "google/protobuf/extension_set.h"  // IWYU pragma: export
-#include "google/protobuf/generated_enum_reflection.h"
+#include "google/protobuf/metadata_lite.h"
+#include "google/protobuf/repeated_field.h" // IWYU pragma: export
 #include "google/protobuf/unknown_field_set.h"
 #include "uniform.pb.h"
 // @@protoc_insertion_point(includes)
@@ -38,642 +38,808 @@
 
 #define PROTOBUF_INTERNAL_EXPORT_program_2eproto
 
-namespace google {
-namespace protobuf {
-namespace internal {
-template <typename T>
-::absl::string_view GetAnyMessageName();
-}  // namespace internal
-}  // namespace protobuf
-}  // namespace google
+namespace google
+{
+namespace protobuf
+{
+namespace internal
+{
+template <typename T>::absl::string_view GetAnyMessageName();
+} // namespace internal
+} // namespace protobuf
+} // namespace google
 
 // Internal implementation detail -- do not use these members.
-struct TableStruct_program_2eproto {
-  static const ::uint32_t offsets[];
+struct TableStruct_program_2eproto
+{
+    static const ::uint32_t offsets[];
 };
 extern const ::google::protobuf::internal::DescriptorTable
     descriptor_table_program_2eproto;
-namespace frame {
-namespace proto {
+namespace frame
+{
+namespace proto
+{
 class Program;
 struct ProgramDefaultTypeInternal;
 extern ProgramDefaultTypeInternal _Program_default_instance_;
 class SceneType;
 struct SceneTypeDefaultTypeInternal;
 extern SceneTypeDefaultTypeInternal _SceneType_default_instance_;
-}  // namespace proto
-}  // namespace frame
-namespace google {
-namespace protobuf {
-}  // namespace protobuf
-}  // namespace google
+} // namespace proto
+} // namespace frame
+namespace google
+{
+namespace protobuf
+{
+} // namespace protobuf
+} // namespace google
 
-namespace frame {
-namespace proto {
-enum SceneType_Enum : int {
-  SceneType_Enum_NONE = 0,
-  SceneType_Enum_QUAD = 1,
-  SceneType_Enum_CUBE = 2,
-  SceneType_Enum_SCENE = 3,
-  SceneType_Enum_SceneType_Enum_INT_MIN_SENTINEL_DO_NOT_USE_ =
-      std::numeric_limits<::int32_t>::min(),
-  SceneType_Enum_SceneType_Enum_INT_MAX_SENTINEL_DO_NOT_USE_ =
-      std::numeric_limits<::int32_t>::max(),
+namespace frame
+{
+namespace proto
+{
+enum SceneType_Enum : int
+{
+    SceneType_Enum_NONE = 0,
+    SceneType_Enum_QUAD = 1,
+    SceneType_Enum_CUBE = 2,
+    SceneType_Enum_SCENE = 3,
+    SceneType_Enum_SceneType_Enum_INT_MIN_SENTINEL_DO_NOT_USE_ =
+        std::numeric_limits<::int32_t>::min(),
+    SceneType_Enum_SceneType_Enum_INT_MAX_SENTINEL_DO_NOT_USE_ =
+        std::numeric_limits<::int32_t>::max(),
 };
 
 bool SceneType_Enum_IsValid(int value);
 extern const uint32_t SceneType_Enum_internal_data_[];
-constexpr SceneType_Enum SceneType_Enum_Enum_MIN = static_cast<SceneType_Enum>(0);
-constexpr SceneType_Enum SceneType_Enum_Enum_MAX = static_cast<SceneType_Enum>(3);
+constexpr SceneType_Enum SceneType_Enum_Enum_MIN =
+    static_cast<SceneType_Enum>(0);
+constexpr SceneType_Enum SceneType_Enum_Enum_MAX =
+    static_cast<SceneType_Enum>(3);
 constexpr int SceneType_Enum_Enum_ARRAYSIZE = 3 + 1;
-const ::google::protobuf::EnumDescriptor*
-SceneType_Enum_descriptor();
-template <typename T>
-const std::string& SceneType_Enum_Name(T value) {
-  static_assert(std::is_same<T, SceneType_Enum>::value ||
-                    std::is_integral<T>::value,
-                "Incorrect type passed to Enum_Name().");
-  return SceneType_Enum_Name(static_cast<SceneType_Enum>(value));
+const ::google::protobuf::EnumDescriptor* SceneType_Enum_descriptor();
+template <typename T> const std::string& SceneType_Enum_Name(T value)
+{
+    static_assert(
+        std::is_same<T, SceneType_Enum>::value || std::is_integral<T>::value,
+        "Incorrect type passed to Enum_Name().");
+    return SceneType_Enum_Name(static_cast<SceneType_Enum>(value));
 }
-template <>
-inline const std::string& SceneType_Enum_Name(SceneType_Enum value) {
-  return ::google::protobuf::internal::NameOfDenseEnum<SceneType_Enum_descriptor,
-                                                 0, 3>(
-      static_cast<int>(value));
+template <> inline const std::string& SceneType_Enum_Name(SceneType_Enum value)
+{
+    return ::google::protobuf::internal::
+        NameOfDenseEnum<SceneType_Enum_descriptor, 0, 3>(
+            static_cast<int>(value));
 }
-inline bool SceneType_Enum_Parse(absl::string_view name, SceneType_Enum* value) {
-  return ::google::protobuf::internal::ParseNamedEnum<SceneType_Enum>(
-      SceneType_Enum_descriptor(), name, value);
+inline bool SceneType_Enum_Parse(absl::string_view name, SceneType_Enum* value)
+{
+    return ::google::protobuf::internal::ParseNamedEnum<SceneType_Enum>(
+        SceneType_Enum_descriptor(), name, value);
 }
 
 // ===================================================================
-
 
 // -------------------------------------------------------------------
 
 class SceneType final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:frame.proto.SceneType) */ {
- public:
-  inline SceneType() : SceneType(nullptr) {}
-  ~SceneType() PROTOBUF_FINAL;
+  public:
+    inline SceneType() : SceneType(nullptr)
+    {
+    }
+    ~SceneType() PROTOBUF_FINAL;
 
 #if defined(PROTOBUF_CUSTOM_VTABLE)
-  void operator delete(SceneType* msg, std::destroying_delete_t) {
-    SharedDtor(*msg);
-    ::google::protobuf::internal::SizedDelete(msg, sizeof(SceneType));
-  }
+    void operator delete(SceneType* msg, std::destroying_delete_t)
+    {
+        SharedDtor(*msg);
+        ::google::protobuf::internal::SizedDelete(msg, sizeof(SceneType));
+    }
 #endif
 
-  template <typename = void>
-  explicit PROTOBUF_CONSTEXPR SceneType(
-      ::google::protobuf::internal::ConstantInitialized);
+    template <typename = void>
+    explicit PROTOBUF_CONSTEXPR SceneType(
+        ::google::protobuf::internal::ConstantInitialized);
 
-  inline SceneType(const SceneType& from) : SceneType(nullptr, from) {}
-  inline SceneType(SceneType&& from) noexcept
-      : SceneType(nullptr, std::move(from)) {}
-  inline SceneType& operator=(const SceneType& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  inline SceneType& operator=(SceneType&& from) noexcept {
-    if (this == &from) return *this;
-    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
-      InternalSwap(&from);
-    } else {
-      CopyFrom(from);
+    inline SceneType(const SceneType& from) : SceneType(nullptr, from)
+    {
     }
-    return *this;
-  }
-
-  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
-      ABSL_ATTRIBUTE_LIFETIME_BOUND {
-    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
-  }
-  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
-      ABSL_ATTRIBUTE_LIFETIME_BOUND {
-    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
-  }
-
-  static const ::google::protobuf::Descriptor* descriptor() {
-    return GetDescriptor();
-  }
-  static const ::google::protobuf::Descriptor* GetDescriptor() {
-    return default_instance().GetMetadata().descriptor;
-  }
-  static const ::google::protobuf::Reflection* GetReflection() {
-    return default_instance().GetMetadata().reflection;
-  }
-  static const SceneType& default_instance() {
-    return *internal_default_instance();
-  }
-  static inline const SceneType* internal_default_instance() {
-    return reinterpret_cast<const SceneType*>(
-        &_SceneType_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages = 0;
-  friend void swap(SceneType& a, SceneType& b) { a.Swap(&b); }
-  inline void Swap(SceneType* other) {
-    if (other == this) return;
-    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
-      InternalSwap(other);
-    } else {
-      ::google::protobuf::internal::GenericSwap(this, other);
+    inline SceneType(SceneType&& from) noexcept
+        : SceneType(nullptr, std::move(from))
+    {
     }
-  }
-  void UnsafeArenaSwap(SceneType* other) {
-    if (other == this) return;
-    ABSL_DCHECK(GetArena() == other->GetArena());
-    InternalSwap(other);
-  }
+    inline SceneType& operator=(const SceneType& from)
+    {
+        CopyFrom(from);
+        return *this;
+    }
+    inline SceneType& operator=(SceneType&& from) noexcept
+    {
+        if (this == &from)
+            return *this;
+        if (::google::protobuf::internal::CanMoveWithInternalSwap(
+                GetArena(), from.GetArena()))
+        {
+            InternalSwap(&from);
+        }
+        else
+        {
+            CopyFrom(from);
+        }
+        return *this;
+    }
 
-  // implements Message ----------------------------------------------
+    inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+        ABSL_ATTRIBUTE_LIFETIME_BOUND
+    {
+        return _internal_metadata_
+            .unknown_fields<::google::protobuf::UnknownFieldSet>(
+                ::google::protobuf::UnknownFieldSet::default_instance);
+    }
+    inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+        ABSL_ATTRIBUTE_LIFETIME_BOUND
+    {
+        return _internal_metadata_
+            .mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+    }
 
-  SceneType* New(::google::protobuf::Arena* arena = nullptr) const {
-    return ::google::protobuf::Message::DefaultConstruct<SceneType>(arena);
-  }
-  using ::google::protobuf::Message::CopyFrom;
-  void CopyFrom(const SceneType& from);
-  using ::google::protobuf::Message::MergeFrom;
-  void MergeFrom(const SceneType& from) { SceneType::MergeImpl(*this, from); }
+    static const ::google::protobuf::Descriptor* descriptor()
+    {
+        return GetDescriptor();
+    }
+    static const ::google::protobuf::Descriptor* GetDescriptor()
+    {
+        return default_instance().GetMetadata().descriptor;
+    }
+    static const ::google::protobuf::Reflection* GetReflection()
+    {
+        return default_instance().GetMetadata().reflection;
+    }
+    static const SceneType& default_instance()
+    {
+        return *internal_default_instance();
+    }
+    static inline const SceneType* internal_default_instance()
+    {
+        return reinterpret_cast<const SceneType*>(
+            &_SceneType_default_instance_);
+    }
+    static constexpr int kIndexInFileMessages = 0;
+    friend void swap(SceneType& a, SceneType& b)
+    {
+        a.Swap(&b);
+    }
+    inline void Swap(SceneType* other)
+    {
+        if (other == this)
+            return;
+        if (::google::protobuf::internal::CanUseInternalSwap(
+                GetArena(), other->GetArena()))
+        {
+            InternalSwap(other);
+        }
+        else
+        {
+            ::google::protobuf::internal::GenericSwap(this, other);
+        }
+    }
+    void UnsafeArenaSwap(SceneType* other)
+    {
+        if (other == this)
+            return;
+        ABSL_DCHECK(GetArena() == other->GetArena());
+        InternalSwap(other);
+    }
+
+    // implements Message ----------------------------------------------
+
+    SceneType* New(::google::protobuf::Arena* arena = nullptr) const
+    {
+        return ::google::protobuf::Message::DefaultConstruct<SceneType>(arena);
+    }
+    using ::google::protobuf::Message::CopyFrom;
+    void CopyFrom(const SceneType& from);
+    using ::google::protobuf::Message::MergeFrom;
+    void MergeFrom(const SceneType& from)
+    {
+        SceneType::MergeImpl(*this, from);
+    }
 
   private:
-  static void MergeImpl(
-      ::google::protobuf::MessageLite& to_msg,
-      const ::google::protobuf::MessageLite& from_msg);
+    static void MergeImpl(
+        ::google::protobuf::MessageLite& to_msg,
+        const ::google::protobuf::MessageLite& from_msg);
 
   public:
-  bool IsInitialized() const {
-    return true;
-  }
-  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
-  #if defined(PROTOBUF_CUSTOM_VTABLE)
+    bool IsInitialized() const
+    {
+        return true;
+    }
+    ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+#if defined(PROTOBUF_CUSTOM_VTABLE)
   private:
-  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
-  static ::uint8_t* _InternalSerialize(
-      const MessageLite& msg, ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream);
+    static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+    static ::uint8_t* _InternalSerialize(
+        const MessageLite& msg,
+        ::uint8_t* target,
+        ::google::protobuf::io::EpsCopyOutputStream* stream);
 
   public:
-  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
-  ::uint8_t* _InternalSerialize(
-      ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
-    return _InternalSerialize(*this, target, stream);
-  }
-  #else   // PROTOBUF_CUSTOM_VTABLE
-  ::size_t ByteSizeLong() const final;
-  ::uint8_t* _InternalSerialize(
-      ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
-  #endif  // PROTOBUF_CUSTOM_VTABLE
-  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+    ::size_t ByteSizeLong() const
+    {
+        return ByteSizeLong(*this);
+    }
+    ::uint8_t* _InternalSerialize(
+        ::uint8_t* target,
+        ::google::protobuf::io::EpsCopyOutputStream* stream) const
+    {
+        return _InternalSerialize(*this, target, stream);
+    }
+#else  // PROTOBUF_CUSTOM_VTABLE
+    ::size_t ByteSizeLong() const final;
+    ::uint8_t* _InternalSerialize(
+        ::uint8_t* target,
+        ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+#endif // PROTOBUF_CUSTOM_VTABLE
+    int GetCachedSize() const
+    {
+        return _impl_._cached_size_.Get();
+    }
 
   private:
-  void SharedCtor(::google::protobuf::Arena* arena);
-  static void SharedDtor(MessageLite& self);
-  void InternalSwap(SceneType* other);
- private:
-  template <typename T>
-  friend ::absl::string_view(
-      ::google::protobuf::internal::GetAnyMessageName)();
-  static ::absl::string_view FullMessageName() { return "frame.proto.SceneType"; }
-
- protected:
-  explicit SceneType(::google::protobuf::Arena* arena);
-  SceneType(::google::protobuf::Arena* arena, const SceneType& from);
-  SceneType(::google::protobuf::Arena* arena, SceneType&& from) noexcept
-      : SceneType(arena) {
-    *this = ::std::move(from);
-  }
-  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
-  static void* PlacementNew_(const void*, void* mem,
-                             ::google::protobuf::Arena* arena);
-  static constexpr auto InternalNewImpl_();
-  static const ::google::protobuf::internal::ClassDataFull _class_data_;
-
- public:
-  ::google::protobuf::Metadata GetMetadata() const;
-  // nested types ----------------------------------------------------
-  using Enum = SceneType_Enum;
-  static constexpr Enum NONE = SceneType_Enum_NONE;
-  static constexpr Enum QUAD = SceneType_Enum_QUAD;
-  static constexpr Enum CUBE = SceneType_Enum_CUBE;
-  static constexpr Enum SCENE = SceneType_Enum_SCENE;
-  static inline bool Enum_IsValid(int value) {
-    return SceneType_Enum_IsValid(value);
-  }
-  static constexpr Enum Enum_MIN = SceneType_Enum_Enum_MIN;
-  static constexpr Enum Enum_MAX = SceneType_Enum_Enum_MAX;
-  static constexpr int Enum_ARRAYSIZE = SceneType_Enum_Enum_ARRAYSIZE;
-  static inline const ::google::protobuf::EnumDescriptor* Enum_descriptor() {
-    return SceneType_Enum_descriptor();
-  }
-  template <typename T>
-  static inline const std::string& Enum_Name(T value) {
-    return SceneType_Enum_Name(value);
-  }
-  static inline bool Enum_Parse(absl::string_view name, Enum* value) {
-    return SceneType_Enum_Parse(name, value);
-  }
-
-  // accessors -------------------------------------------------------
-  enum : int {
-    kValueFieldNumber = 1,
-  };
-  // .frame.proto.SceneType.Enum value = 1;
-  void clear_value() ;
-  ::frame::proto::SceneType_Enum value() const;
-  void set_value(::frame::proto::SceneType_Enum value);
+    void SharedCtor(::google::protobuf::Arena* arena);
+    static void SharedDtor(MessageLite& self);
+    void InternalSwap(SceneType* other);
 
   private:
-  ::frame::proto::SceneType_Enum _internal_value() const;
-  void _internal_set_value(::frame::proto::SceneType_Enum value);
+    template <typename T>
+    friend ::absl::string_view(
+        ::google::protobuf::internal::GetAnyMessageName)();
+    static ::absl::string_view FullMessageName()
+    {
+        return "frame.proto.SceneType";
+    }
+
+  protected:
+    explicit SceneType(::google::protobuf::Arena* arena);
+    SceneType(::google::protobuf::Arena* arena, const SceneType& from);
+    SceneType(::google::protobuf::Arena* arena, SceneType&& from) noexcept
+        : SceneType(arena)
+    {
+        *this = ::std::move(from);
+    }
+    const ::google::protobuf::internal::ClassData* GetClassData() const
+        PROTOBUF_FINAL;
+    static void* PlacementNew_(
+        const void*, void* mem, ::google::protobuf::Arena* arena);
+    static constexpr auto InternalNewImpl_();
+    static const ::google::protobuf::internal::ClassDataFull _class_data_;
 
   public:
-  // @@protoc_insertion_point(class_scope:frame.proto.SceneType)
- private:
-  class _Internal;
-  friend class ::google::protobuf::internal::TcParser;
-  static const ::google::protobuf::internal::TcParseTable<
-      0, 1, 0,
-      0, 2>
-      _table_;
+    ::google::protobuf::Metadata GetMetadata() const;
+    // nested types ----------------------------------------------------
+    using Enum = SceneType_Enum;
+    static constexpr Enum NONE = SceneType_Enum_NONE;
+    static constexpr Enum QUAD = SceneType_Enum_QUAD;
+    static constexpr Enum CUBE = SceneType_Enum_CUBE;
+    static constexpr Enum SCENE = SceneType_Enum_SCENE;
+    static inline bool Enum_IsValid(int value)
+    {
+        return SceneType_Enum_IsValid(value);
+    }
+    static constexpr Enum Enum_MIN = SceneType_Enum_Enum_MIN;
+    static constexpr Enum Enum_MAX = SceneType_Enum_Enum_MAX;
+    static constexpr int Enum_ARRAYSIZE = SceneType_Enum_Enum_ARRAYSIZE;
+    static inline const ::google::protobuf::EnumDescriptor* Enum_descriptor()
+    {
+        return SceneType_Enum_descriptor();
+    }
+    template <typename T> static inline const std::string& Enum_Name(T value)
+    {
+        return SceneType_Enum_Name(value);
+    }
+    static inline bool Enum_Parse(absl::string_view name, Enum* value)
+    {
+        return SceneType_Enum_Parse(name, value);
+    }
 
-  friend class ::google::protobuf::MessageLite;
-  friend class ::google::protobuf::Arena;
-  template <typename T>
-  friend class ::google::protobuf::Arena::InternalHelper;
-  using InternalArenaConstructable_ = void;
-  using DestructorSkippable_ = void;
-  struct Impl_ {
-    inline explicit constexpr Impl_(
-        ::google::protobuf::internal::ConstantInitialized) noexcept;
-    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
-                          ::google::protobuf::Arena* arena);
-    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
-                          ::google::protobuf::Arena* arena, const Impl_& from,
-                          const SceneType& from_msg);
-    int value_;
-    ::google::protobuf::internal::CachedSize _cached_size_;
-    PROTOBUF_TSAN_DECLARE_MEMBER
-  };
-  union { Impl_ _impl_; };
-  friend struct ::TableStruct_program_2eproto;
+    // accessors -------------------------------------------------------
+    enum : int
+    {
+        kValueFieldNumber = 1,
+    };
+    // .frame.proto.SceneType.Enum value = 1;
+    void clear_value();
+    ::frame::proto::SceneType_Enum value() const;
+    void set_value(::frame::proto::SceneType_Enum value);
+
+  private:
+    ::frame::proto::SceneType_Enum _internal_value() const;
+    void _internal_set_value(::frame::proto::SceneType_Enum value);
+
+  public:
+    // @@protoc_insertion_point(class_scope:frame.proto.SceneType)
+  private:
+    class _Internal;
+    friend class ::google::protobuf::internal::TcParser;
+    static const ::google::protobuf::internal::TcParseTable<0, 1, 0, 0, 2>
+        _table_;
+
+    friend class ::google::protobuf::MessageLite;
+    friend class ::google::protobuf::Arena;
+    template <typename T>
+    friend class ::google::protobuf::Arena::InternalHelper;
+    using InternalArenaConstructable_ = void;
+    using DestructorSkippable_ = void;
+    struct Impl_
+    {
+        inline explicit constexpr Impl_(
+            ::google::protobuf::internal::ConstantInitialized) noexcept;
+        inline explicit Impl_(
+            ::google::protobuf::internal::InternalVisibility visibility,
+            ::google::protobuf::Arena* arena);
+        inline explicit Impl_(
+            ::google::protobuf::internal::InternalVisibility visibility,
+            ::google::protobuf::Arena* arena,
+            const Impl_& from,
+            const SceneType& from_msg);
+        int value_;
+        ::google::protobuf::internal::CachedSize _cached_size_;
+        PROTOBUF_TSAN_DECLARE_MEMBER
+    };
+    union {
+        Impl_ _impl_;
+    };
+    friend struct ::TableStruct_program_2eproto;
 };
 // -------------------------------------------------------------------
 
 class Program final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:frame.proto.Program) */ {
- public:
-  inline Program() : Program(nullptr) {}
-  ~Program() PROTOBUF_FINAL;
+  public:
+    inline Program() : Program(nullptr)
+    {
+    }
+    ~Program() PROTOBUF_FINAL;
 
 #if defined(PROTOBUF_CUSTOM_VTABLE)
-  void operator delete(Program* msg, std::destroying_delete_t) {
-    SharedDtor(*msg);
-    ::google::protobuf::internal::SizedDelete(msg, sizeof(Program));
-  }
+    void operator delete(Program* msg, std::destroying_delete_t)
+    {
+        SharedDtor(*msg);
+        ::google::protobuf::internal::SizedDelete(msg, sizeof(Program));
+    }
 #endif
 
-  template <typename = void>
-  explicit PROTOBUF_CONSTEXPR Program(
-      ::google::protobuf::internal::ConstantInitialized);
+    template <typename = void>
+    explicit PROTOBUF_CONSTEXPR Program(
+        ::google::protobuf::internal::ConstantInitialized);
 
-  inline Program(const Program& from) : Program(nullptr, from) {}
-  inline Program(Program&& from) noexcept
-      : Program(nullptr, std::move(from)) {}
-  inline Program& operator=(const Program& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  inline Program& operator=(Program&& from) noexcept {
-    if (this == &from) return *this;
-    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
-      InternalSwap(&from);
-    } else {
-      CopyFrom(from);
+    inline Program(const Program& from) : Program(nullptr, from)
+    {
     }
-    return *this;
-  }
-
-  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
-      ABSL_ATTRIBUTE_LIFETIME_BOUND {
-    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
-  }
-  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
-      ABSL_ATTRIBUTE_LIFETIME_BOUND {
-    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
-  }
-
-  static const ::google::protobuf::Descriptor* descriptor() {
-    return GetDescriptor();
-  }
-  static const ::google::protobuf::Descriptor* GetDescriptor() {
-    return default_instance().GetMetadata().descriptor;
-  }
-  static const ::google::protobuf::Reflection* GetReflection() {
-    return default_instance().GetMetadata().reflection;
-  }
-  static const Program& default_instance() {
-    return *internal_default_instance();
-  }
-  static inline const Program* internal_default_instance() {
-    return reinterpret_cast<const Program*>(
-        &_Program_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages = 1;
-  friend void swap(Program& a, Program& b) { a.Swap(&b); }
-  inline void Swap(Program* other) {
-    if (other == this) return;
-    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
-      InternalSwap(other);
-    } else {
-      ::google::protobuf::internal::GenericSwap(this, other);
+    inline Program(Program&& from) noexcept : Program(nullptr, std::move(from))
+    {
     }
-  }
-  void UnsafeArenaSwap(Program* other) {
-    if (other == this) return;
-    ABSL_DCHECK(GetArena() == other->GetArena());
-    InternalSwap(other);
-  }
+    inline Program& operator=(const Program& from)
+    {
+        CopyFrom(from);
+        return *this;
+    }
+    inline Program& operator=(Program&& from) noexcept
+    {
+        if (this == &from)
+            return *this;
+        if (::google::protobuf::internal::CanMoveWithInternalSwap(
+                GetArena(), from.GetArena()))
+        {
+            InternalSwap(&from);
+        }
+        else
+        {
+            CopyFrom(from);
+        }
+        return *this;
+    }
 
-  // implements Message ----------------------------------------------
+    inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+        ABSL_ATTRIBUTE_LIFETIME_BOUND
+    {
+        return _internal_metadata_
+            .unknown_fields<::google::protobuf::UnknownFieldSet>(
+                ::google::protobuf::UnknownFieldSet::default_instance);
+    }
+    inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+        ABSL_ATTRIBUTE_LIFETIME_BOUND
+    {
+        return _internal_metadata_
+            .mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+    }
 
-  Program* New(::google::protobuf::Arena* arena = nullptr) const {
-    return ::google::protobuf::Message::DefaultConstruct<Program>(arena);
-  }
-  using ::google::protobuf::Message::CopyFrom;
-  void CopyFrom(const Program& from);
-  using ::google::protobuf::Message::MergeFrom;
-  void MergeFrom(const Program& from) { Program::MergeImpl(*this, from); }
+    static const ::google::protobuf::Descriptor* descriptor()
+    {
+        return GetDescriptor();
+    }
+    static const ::google::protobuf::Descriptor* GetDescriptor()
+    {
+        return default_instance().GetMetadata().descriptor;
+    }
+    static const ::google::protobuf::Reflection* GetReflection()
+    {
+        return default_instance().GetMetadata().reflection;
+    }
+    static const Program& default_instance()
+    {
+        return *internal_default_instance();
+    }
+    static inline const Program* internal_default_instance()
+    {
+        return reinterpret_cast<const Program*>(&_Program_default_instance_);
+    }
+    static constexpr int kIndexInFileMessages = 1;
+    friend void swap(Program& a, Program& b)
+    {
+        a.Swap(&b);
+    }
+    inline void Swap(Program* other)
+    {
+        if (other == this)
+            return;
+        if (::google::protobuf::internal::CanUseInternalSwap(
+                GetArena(), other->GetArena()))
+        {
+            InternalSwap(other);
+        }
+        else
+        {
+            ::google::protobuf::internal::GenericSwap(this, other);
+        }
+    }
+    void UnsafeArenaSwap(Program* other)
+    {
+        if (other == this)
+            return;
+        ABSL_DCHECK(GetArena() == other->GetArena());
+        InternalSwap(other);
+    }
+
+    // implements Message ----------------------------------------------
+
+    Program* New(::google::protobuf::Arena* arena = nullptr) const
+    {
+        return ::google::protobuf::Message::DefaultConstruct<Program>(arena);
+    }
+    using ::google::protobuf::Message::CopyFrom;
+    void CopyFrom(const Program& from);
+    using ::google::protobuf::Message::MergeFrom;
+    void MergeFrom(const Program& from)
+    {
+        Program::MergeImpl(*this, from);
+    }
 
   private:
-  static void MergeImpl(
-      ::google::protobuf::MessageLite& to_msg,
-      const ::google::protobuf::MessageLite& from_msg);
+    static void MergeImpl(
+        ::google::protobuf::MessageLite& to_msg,
+        const ::google::protobuf::MessageLite& from_msg);
 
   public:
-  bool IsInitialized() const {
-    return true;
-  }
-  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
-  #if defined(PROTOBUF_CUSTOM_VTABLE)
+    bool IsInitialized() const
+    {
+        return true;
+    }
+    ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+#if defined(PROTOBUF_CUSTOM_VTABLE)
   private:
-  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
-  static ::uint8_t* _InternalSerialize(
-      const MessageLite& msg, ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream);
+    static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+    static ::uint8_t* _InternalSerialize(
+        const MessageLite& msg,
+        ::uint8_t* target,
+        ::google::protobuf::io::EpsCopyOutputStream* stream);
 
   public:
-  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
-  ::uint8_t* _InternalSerialize(
-      ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
-    return _InternalSerialize(*this, target, stream);
-  }
-  #else   // PROTOBUF_CUSTOM_VTABLE
-  ::size_t ByteSizeLong() const final;
-  ::uint8_t* _InternalSerialize(
-      ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
-  #endif  // PROTOBUF_CUSTOM_VTABLE
-  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+    ::size_t ByteSizeLong() const
+    {
+        return ByteSizeLong(*this);
+    }
+    ::uint8_t* _InternalSerialize(
+        ::uint8_t* target,
+        ::google::protobuf::io::EpsCopyOutputStream* stream) const
+    {
+        return _InternalSerialize(*this, target, stream);
+    }
+#else  // PROTOBUF_CUSTOM_VTABLE
+    ::size_t ByteSizeLong() const final;
+    ::uint8_t* _InternalSerialize(
+        ::uint8_t* target,
+        ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+#endif // PROTOBUF_CUSTOM_VTABLE
+    int GetCachedSize() const
+    {
+        return _impl_._cached_size_.Get();
+    }
 
   private:
-  void SharedCtor(::google::protobuf::Arena* arena);
-  static void SharedDtor(MessageLite& self);
-  void InternalSwap(Program* other);
- private:
-  template <typename T>
-  friend ::absl::string_view(
-      ::google::protobuf::internal::GetAnyMessageName)();
-  static ::absl::string_view FullMessageName() { return "frame.proto.Program"; }
+    void SharedCtor(::google::protobuf::Arena* arena);
+    static void SharedDtor(MessageLite& self);
+    void InternalSwap(Program* other);
 
- protected:
-  explicit Program(::google::protobuf::Arena* arena);
-  Program(::google::protobuf::Arena* arena, const Program& from);
-  Program(::google::protobuf::Arena* arena, Program&& from) noexcept
-      : Program(arena) {
-    *this = ::std::move(from);
-  }
-  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
-  static void* PlacementNew_(const void*, void* mem,
-                             ::google::protobuf::Arena* arena);
-  static constexpr auto InternalNewImpl_();
-  static const ::google::protobuf::internal::ClassDataFull _class_data_;
-
- public:
-  ::google::protobuf::Metadata GetMetadata() const;
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-  enum : int {
-    kInputTextureNamesFieldNumber = 3,
-    kOutputTextureNamesFieldNumber = 4,
-    kUniformsFieldNumber = 7,
-    kNameFieldNumber = 1,
-    kInputSceneRootNameFieldNumber = 5,
-    kShaderFieldNumber = 6,
-    kInputSceneTypeFieldNumber = 9,
-  };
-  // repeated string input_texture_names = 3;
-  int input_texture_names_size() const;
   private:
-  int _internal_input_texture_names_size() const;
+    template <typename T>
+    friend ::absl::string_view(
+        ::google::protobuf::internal::GetAnyMessageName)();
+    static ::absl::string_view FullMessageName()
+    {
+        return "frame.proto.Program";
+    }
+
+  protected:
+    explicit Program(::google::protobuf::Arena* arena);
+    Program(::google::protobuf::Arena* arena, const Program& from);
+    Program(::google::protobuf::Arena* arena, Program&& from) noexcept
+        : Program(arena)
+    {
+        *this = ::std::move(from);
+    }
+    const ::google::protobuf::internal::ClassData* GetClassData() const
+        PROTOBUF_FINAL;
+    static void* PlacementNew_(
+        const void*, void* mem, ::google::protobuf::Arena* arena);
+    static constexpr auto InternalNewImpl_();
+    static const ::google::protobuf::internal::ClassDataFull _class_data_;
 
   public:
-  void clear_input_texture_names() ;
-  const std::string& input_texture_names(int index) const;
-  std::string* mutable_input_texture_names(int index);
-  template <typename Arg_ = const std::string&, typename... Args_>
-  void set_input_texture_names(int index, Arg_&& value, Args_... args);
-  std::string* add_input_texture_names();
-  template <typename Arg_ = const std::string&, typename... Args_>
-  void add_input_texture_names(Arg_&& value, Args_... args);
-  const ::google::protobuf::RepeatedPtrField<std::string>& input_texture_names() const;
-  ::google::protobuf::RepeatedPtrField<std::string>* mutable_input_texture_names();
+    ::google::protobuf::Metadata GetMetadata() const;
+    // nested types ----------------------------------------------------
+
+    // accessors -------------------------------------------------------
+    enum : int
+    {
+        kInputTextureNamesFieldNumber = 3,
+        kOutputTextureNamesFieldNumber = 4,
+        kUniformsFieldNumber = 7,
+        kNameFieldNumber = 1,
+        kInputSceneRootNameFieldNumber = 5,
+        kShaderVertexFieldNumber = 6,
+        kShaderFragmentFieldNumber = 8,
+        kInputSceneTypeFieldNumber = 9,
+    };
+    // repeated string input_texture_names = 3;
+    int input_texture_names_size() const;
 
   private:
-  const ::google::protobuf::RepeatedPtrField<std::string>& _internal_input_texture_names() const;
-  ::google::protobuf::RepeatedPtrField<std::string>* _internal_mutable_input_texture_names();
+    int _internal_input_texture_names_size() const;
 
   public:
-  // repeated string output_texture_names = 4;
-  int output_texture_names_size() const;
-  private:
-  int _internal_output_texture_names_size() const;
-
-  public:
-  void clear_output_texture_names() ;
-  const std::string& output_texture_names(int index) const;
-  std::string* mutable_output_texture_names(int index);
-  template <typename Arg_ = const std::string&, typename... Args_>
-  void set_output_texture_names(int index, Arg_&& value, Args_... args);
-  std::string* add_output_texture_names();
-  template <typename Arg_ = const std::string&, typename... Args_>
-  void add_output_texture_names(Arg_&& value, Args_... args);
-  const ::google::protobuf::RepeatedPtrField<std::string>& output_texture_names() const;
-  ::google::protobuf::RepeatedPtrField<std::string>* mutable_output_texture_names();
+    void clear_input_texture_names();
+    const std::string& input_texture_names(int index) const;
+    std::string* mutable_input_texture_names(int index);
+    template <typename Arg_ = const std::string&, typename... Args_>
+    void set_input_texture_names(int index, Arg_&& value, Args_... args);
+    std::string* add_input_texture_names();
+    template <typename Arg_ = const std::string&, typename... Args_>
+    void add_input_texture_names(Arg_&& value, Args_... args);
+    const ::google::protobuf::RepeatedPtrField<std::string>&
+    input_texture_names() const;
+    ::google::protobuf::RepeatedPtrField<std::string>*
+    mutable_input_texture_names();
 
   private:
-  const ::google::protobuf::RepeatedPtrField<std::string>& _internal_output_texture_names() const;
-  ::google::protobuf::RepeatedPtrField<std::string>* _internal_mutable_output_texture_names();
+    const ::google::protobuf::RepeatedPtrField<std::string>&
+    _internal_input_texture_names() const;
+    ::google::protobuf::RepeatedPtrField<std::string>*
+    _internal_mutable_input_texture_names();
 
   public:
-  // repeated .frame.proto.Uniform uniforms = 7;
-  int uniforms_size() const;
-  private:
-  int _internal_uniforms_size() const;
-
-  public:
-  void clear_uniforms() ;
-  ::frame::proto::Uniform* mutable_uniforms(int index);
-  ::google::protobuf::RepeatedPtrField<::frame::proto::Uniform>* mutable_uniforms();
+    // repeated string output_texture_names = 4;
+    int output_texture_names_size() const;
 
   private:
-  const ::google::protobuf::RepeatedPtrField<::frame::proto::Uniform>& _internal_uniforms() const;
-  ::google::protobuf::RepeatedPtrField<::frame::proto::Uniform>* _internal_mutable_uniforms();
+    int _internal_output_texture_names_size() const;
+
   public:
-  const ::frame::proto::Uniform& uniforms(int index) const;
-  ::frame::proto::Uniform* add_uniforms();
-  const ::google::protobuf::RepeatedPtrField<::frame::proto::Uniform>& uniforms() const;
-  // string name = 1;
-  void clear_name() ;
-  const std::string& name() const;
-  template <typename Arg_ = const std::string&, typename... Args_>
-  void set_name(Arg_&& arg, Args_... args);
-  std::string* mutable_name();
-  PROTOBUF_NODISCARD std::string* release_name();
-  void set_allocated_name(std::string* value);
+    void clear_output_texture_names();
+    const std::string& output_texture_names(int index) const;
+    std::string* mutable_output_texture_names(int index);
+    template <typename Arg_ = const std::string&, typename... Args_>
+    void set_output_texture_names(int index, Arg_&& value, Args_... args);
+    std::string* add_output_texture_names();
+    template <typename Arg_ = const std::string&, typename... Args_>
+    void add_output_texture_names(Arg_&& value, Args_... args);
+    const ::google::protobuf::RepeatedPtrField<std::string>&
+    output_texture_names() const;
+    ::google::protobuf::RepeatedPtrField<std::string>*
+    mutable_output_texture_names();
 
   private:
-  const std::string& _internal_name() const;
-  inline PROTOBUF_ALWAYS_INLINE void _internal_set_name(
-      const std::string& value);
-  std::string* _internal_mutable_name();
+    const ::google::protobuf::RepeatedPtrField<std::string>&
+    _internal_output_texture_names() const;
+    ::google::protobuf::RepeatedPtrField<std::string>*
+    _internal_mutable_output_texture_names();
 
   public:
-  // string input_scene_root_name = 5;
-  void clear_input_scene_root_name() ;
-  const std::string& input_scene_root_name() const;
-  template <typename Arg_ = const std::string&, typename... Args_>
-  void set_input_scene_root_name(Arg_&& arg, Args_... args);
-  std::string* mutable_input_scene_root_name();
-  PROTOBUF_NODISCARD std::string* release_input_scene_root_name();
-  void set_allocated_input_scene_root_name(std::string* value);
+    // repeated .frame.proto.Uniform uniforms = 7;
+    int uniforms_size() const;
 
   private:
-  const std::string& _internal_input_scene_root_name() const;
-  inline PROTOBUF_ALWAYS_INLINE void _internal_set_input_scene_root_name(
-      const std::string& value);
-  std::string* _internal_mutable_input_scene_root_name();
+    int _internal_uniforms_size() const;
 
   public:
-  // string shader = 6;
-  void clear_shader() ;
-  const std::string& shader() const;
-  template <typename Arg_ = const std::string&, typename... Args_>
-  void set_shader(Arg_&& arg, Args_... args);
-  std::string* mutable_shader();
-  PROTOBUF_NODISCARD std::string* release_shader();
-  void set_allocated_shader(std::string* value);
+    void clear_uniforms();
+    ::frame::proto::Uniform* mutable_uniforms(int index);
+    ::google::protobuf::RepeatedPtrField<::frame::proto::Uniform>*
+    mutable_uniforms();
 
   private:
-  const std::string& _internal_shader() const;
-  inline PROTOBUF_ALWAYS_INLINE void _internal_set_shader(
-      const std::string& value);
-  std::string* _internal_mutable_shader();
+    const ::google::protobuf::RepeatedPtrField<::frame::proto::Uniform>&
+    _internal_uniforms() const;
+    ::google::protobuf::RepeatedPtrField<::frame::proto::Uniform>*
+    _internal_mutable_uniforms();
 
   public:
-  // .frame.proto.SceneType input_scene_type = 9;
-  bool has_input_scene_type() const;
-  void clear_input_scene_type() ;
-  const ::frame::proto::SceneType& input_scene_type() const;
-  PROTOBUF_NODISCARD ::frame::proto::SceneType* release_input_scene_type();
-  ::frame::proto::SceneType* mutable_input_scene_type();
-  void set_allocated_input_scene_type(::frame::proto::SceneType* value);
-  void unsafe_arena_set_allocated_input_scene_type(::frame::proto::SceneType* value);
-  ::frame::proto::SceneType* unsafe_arena_release_input_scene_type();
+    const ::frame::proto::Uniform& uniforms(int index) const;
+    ::frame::proto::Uniform* add_uniforms();
+    const ::google::protobuf::RepeatedPtrField<::frame::proto::Uniform>&
+    uniforms() const;
+    // string name = 1;
+    void clear_name();
+    const std::string& name() const;
+    template <typename Arg_ = const std::string&, typename... Args_>
+    void set_name(Arg_&& arg, Args_... args);
+    std::string* mutable_name();
+    PROTOBUF_NODISCARD std::string* release_name();
+    void set_allocated_name(std::string* value);
 
   private:
-  const ::frame::proto::SceneType& _internal_input_scene_type() const;
-  ::frame::proto::SceneType* _internal_mutable_input_scene_type();
+    const std::string& _internal_name() const;
+    inline PROTOBUF_ALWAYS_INLINE void _internal_set_name(
+        const std::string& value);
+    std::string* _internal_mutable_name();
 
   public:
-  // @@protoc_insertion_point(class_scope:frame.proto.Program)
- private:
-  class _Internal;
-  friend class ::google::protobuf::internal::TcParser;
-  static const ::google::protobuf::internal::TcParseTable<
-      3, 7, 2,
-      98, 2>
-      _table_;
+    // string input_scene_root_name = 5;
+    void clear_input_scene_root_name();
+    const std::string& input_scene_root_name() const;
+    template <typename Arg_ = const std::string&, typename... Args_>
+    void set_input_scene_root_name(Arg_&& arg, Args_... args);
+    std::string* mutable_input_scene_root_name();
+    PROTOBUF_NODISCARD std::string* release_input_scene_root_name();
+    void set_allocated_input_scene_root_name(std::string* value);
 
-  friend class ::google::protobuf::MessageLite;
-  friend class ::google::protobuf::Arena;
-  template <typename T>
-  friend class ::google::protobuf::Arena::InternalHelper;
-  using InternalArenaConstructable_ = void;
-  using DestructorSkippable_ = void;
-  struct Impl_ {
-    inline explicit constexpr Impl_(
-        ::google::protobuf::internal::ConstantInitialized) noexcept;
-    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
-                          ::google::protobuf::Arena* arena);
-    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
-                          ::google::protobuf::Arena* arena, const Impl_& from,
-                          const Program& from_msg);
-    ::google::protobuf::internal::HasBits<1> _has_bits_;
-    ::google::protobuf::internal::CachedSize _cached_size_;
-    ::google::protobuf::RepeatedPtrField<std::string> input_texture_names_;
-    ::google::protobuf::RepeatedPtrField<std::string> output_texture_names_;
-    ::google::protobuf::RepeatedPtrField< ::frame::proto::Uniform > uniforms_;
-    ::google::protobuf::internal::ArenaStringPtr name_;
-    ::google::protobuf::internal::ArenaStringPtr input_scene_root_name_;
-    ::google::protobuf::internal::ArenaStringPtr shader_;
-    ::frame::proto::SceneType* input_scene_type_;
-    PROTOBUF_TSAN_DECLARE_MEMBER
-  };
-  union { Impl_ _impl_; };
-  friend struct ::TableStruct_program_2eproto;
+  private:
+    const std::string& _internal_input_scene_root_name() const;
+    inline PROTOBUF_ALWAYS_INLINE void _internal_set_input_scene_root_name(
+        const std::string& value);
+    std::string* _internal_mutable_input_scene_root_name();
+
+  public:
+    // string shader_vertex = 6;
+    void clear_shader_vertex();
+    const std::string& shader_vertex() const;
+    template <typename Arg_ = const std::string&, typename... Args_>
+    void set_shader_vertex(Arg_&& arg, Args_... args);
+    std::string* mutable_shader_vertex();
+    PROTOBUF_NODISCARD std::string* release_shader_vertex();
+    void set_allocated_shader_vertex(std::string* value);
+
+  private:
+    const std::string& _internal_shader_vertex() const;
+    inline PROTOBUF_ALWAYS_INLINE void _internal_set_shader_vertex(
+        const std::string& value);
+    std::string* _internal_mutable_shader_vertex();
+
+  public:
+    // string shader_fragment = 8;
+    void clear_shader_fragment();
+    const std::string& shader_fragment() const;
+    template <typename Arg_ = const std::string&, typename... Args_>
+    void set_shader_fragment(Arg_&& arg, Args_... args);
+    std::string* mutable_shader_fragment();
+    PROTOBUF_NODISCARD std::string* release_shader_fragment();
+    void set_allocated_shader_fragment(std::string* value);
+
+  private:
+    const std::string& _internal_shader_fragment() const;
+    inline PROTOBUF_ALWAYS_INLINE void _internal_set_shader_fragment(
+        const std::string& value);
+    std::string* _internal_mutable_shader_fragment();
+
+  public:
+    // .frame.proto.SceneType input_scene_type = 9;
+    bool has_input_scene_type() const;
+    void clear_input_scene_type();
+    const ::frame::proto::SceneType& input_scene_type() const;
+    PROTOBUF_NODISCARD ::frame::proto::SceneType* release_input_scene_type();
+    ::frame::proto::SceneType* mutable_input_scene_type();
+    void set_allocated_input_scene_type(::frame::proto::SceneType* value);
+    void unsafe_arena_set_allocated_input_scene_type(
+        ::frame::proto::SceneType* value);
+    ::frame::proto::SceneType* unsafe_arena_release_input_scene_type();
+
+  private:
+    const ::frame::proto::SceneType& _internal_input_scene_type() const;
+    ::frame::proto::SceneType* _internal_mutable_input_scene_type();
+
+  public:
+    // @@protoc_insertion_point(class_scope:frame.proto.Program)
+  private:
+    class _Internal;
+    friend class ::google::protobuf::internal::TcParser;
+    static const ::google::protobuf::internal::TcParseTable<3, 7, 2, 98, 2>
+        _table_;
+
+    friend class ::google::protobuf::MessageLite;
+    friend class ::google::protobuf::Arena;
+    template <typename T>
+    friend class ::google::protobuf::Arena::InternalHelper;
+    using InternalArenaConstructable_ = void;
+    using DestructorSkippable_ = void;
+    struct Impl_
+    {
+        inline explicit constexpr Impl_(
+            ::google::protobuf::internal::ConstantInitialized) noexcept;
+        inline explicit Impl_(
+            ::google::protobuf::internal::InternalVisibility visibility,
+            ::google::protobuf::Arena* arena);
+        inline explicit Impl_(
+            ::google::protobuf::internal::InternalVisibility visibility,
+            ::google::protobuf::Arena* arena,
+            const Impl_& from,
+            const Program& from_msg);
+        ::google::protobuf::internal::HasBits<1> _has_bits_;
+        ::google::protobuf::internal::CachedSize _cached_size_;
+        ::google::protobuf::RepeatedPtrField<std::string> input_texture_names_;
+        ::google::protobuf::RepeatedPtrField<std::string> output_texture_names_;
+        ::google::protobuf::RepeatedPtrField<::frame::proto::Uniform> uniforms_;
+        ::google::protobuf::internal::ArenaStringPtr name_;
+        ::google::protobuf::internal::ArenaStringPtr input_scene_root_name_;
+        ::google::protobuf::internal::ArenaStringPtr shader_vertex_;
+        ::google::protobuf::internal::ArenaStringPtr shader_fragment_;
+        ::frame::proto::SceneType* input_scene_type_;
+        PROTOBUF_TSAN_DECLARE_MEMBER
+    };
+    union {
+        Impl_ _impl_;
+    };
+    friend struct ::TableStruct_program_2eproto;
 };
 
 // ===================================================================
 
-
-
-
 // ===================================================================
-
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#endif  // __GNUC__
+#endif // __GNUC__
 // -------------------------------------------------------------------
 
 // SceneType
 
 // .frame.proto.SceneType.Enum value = 1;
-inline void SceneType::clear_value() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.value_ = 0;
+inline void SceneType::clear_value()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.value_ = 0;
 }
-inline ::frame::proto::SceneType_Enum SceneType::value() const {
-  // @@protoc_insertion_point(field_get:frame.proto.SceneType.value)
-  return _internal_value();
+inline ::frame::proto::SceneType_Enum SceneType::value() const
+{
+    // @@protoc_insertion_point(field_get:frame.proto.SceneType.value)
+    return _internal_value();
 }
-inline void SceneType::set_value(::frame::proto::SceneType_Enum value) {
-  _internal_set_value(value);
-  // @@protoc_insertion_point(field_set:frame.proto.SceneType.value)
+inline void SceneType::set_value(::frame::proto::SceneType_Enum value)
+{
+    _internal_set_value(value);
+    // @@protoc_insertion_point(field_set:frame.proto.SceneType.value)
 }
-inline ::frame::proto::SceneType_Enum SceneType::_internal_value() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return static_cast<::frame::proto::SceneType_Enum>(_impl_.value_);
+inline ::frame::proto::SceneType_Enum SceneType::_internal_value() const
+{
+    ::google::protobuf::internal::TSanRead(&_impl_);
+    return static_cast<::frame::proto::SceneType_Enum>(_impl_.value_);
 }
-inline void SceneType::_internal_set_value(::frame::proto::SceneType_Enum value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.value_ = value;
+inline void SceneType::_internal_set_value(::frame::proto::SceneType_Enum value)
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.value_ = value;
 }
 
 // -------------------------------------------------------------------
@@ -681,442 +847,625 @@ inline void SceneType::_internal_set_value(::frame::proto::SceneType_Enum value)
 // Program
 
 // string name = 1;
-inline void Program::clear_name() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.name_.ClearToEmpty();
+inline void Program::clear_name()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.name_.ClearToEmpty();
 }
-inline const std::string& Program::name() const
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:frame.proto.Program.name)
-  return _internal_name();
+inline const std::string& Program::name() const ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_get:frame.proto.Program.name)
+    return _internal_name();
 }
 template <typename Arg_, typename... Args_>
-inline PROTOBUF_ALWAYS_INLINE void Program::set_name(Arg_&& arg,
-                                                     Args_... args) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.name_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
-  // @@protoc_insertion_point(field_set:frame.proto.Program.name)
+inline PROTOBUF_ALWAYS_INLINE void Program::set_name(Arg_&& arg, Args_... args)
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.name_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+    // @@protoc_insertion_point(field_set:frame.proto.Program.name)
 }
-inline std::string* Program::mutable_name() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  std::string* _s = _internal_mutable_name();
-  // @@protoc_insertion_point(field_mutable:frame.proto.Program.name)
-  return _s;
+inline std::string* Program::mutable_name() ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    std::string* _s = _internal_mutable_name();
+    // @@protoc_insertion_point(field_mutable:frame.proto.Program.name)
+    return _s;
 }
-inline const std::string& Program::_internal_name() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.name_.Get();
+inline const std::string& Program::_internal_name() const
+{
+    ::google::protobuf::internal::TSanRead(&_impl_);
+    return _impl_.name_.Get();
 }
-inline void Program::_internal_set_name(const std::string& value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.name_.Set(value, GetArena());
+inline void Program::_internal_set_name(const std::string& value)
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.name_.Set(value, GetArena());
 }
-inline std::string* Program::_internal_mutable_name() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  return _impl_.name_.Mutable( GetArena());
+inline std::string* Program::_internal_mutable_name()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    return _impl_.name_.Mutable(GetArena());
 }
-inline std::string* Program::release_name() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  // @@protoc_insertion_point(field_release:frame.proto.Program.name)
-  return _impl_.name_.Release();
+inline std::string* Program::release_name()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    // @@protoc_insertion_point(field_release:frame.proto.Program.name)
+    return _impl_.name_.Release();
 }
-inline void Program::set_allocated_name(std::string* value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.name_.SetAllocated(value, GetArena());
-  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.name_.IsDefault()) {
-    _impl_.name_.Set("", GetArena());
-  }
-  // @@protoc_insertion_point(field_set_allocated:frame.proto.Program.name)
+inline void Program::set_allocated_name(std::string* value)
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.name_.SetAllocated(value, GetArena());
+    if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() &&
+        _impl_.name_.IsDefault())
+    {
+        _impl_.name_.Set("", GetArena());
+    }
+    // @@protoc_insertion_point(field_set_allocated:frame.proto.Program.name)
 }
 
 // repeated string input_texture_names = 3;
-inline int Program::_internal_input_texture_names_size() const {
-  return _internal_input_texture_names().size();
+inline int Program::_internal_input_texture_names_size() const
+{
+    return _internal_input_texture_names().size();
 }
-inline int Program::input_texture_names_size() const {
-  return _internal_input_texture_names_size();
+inline int Program::input_texture_names_size() const
+{
+    return _internal_input_texture_names_size();
 }
-inline void Program::clear_input_texture_names() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.input_texture_names_.Clear();
+inline void Program::clear_input_texture_names()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.input_texture_names_.Clear();
 }
-inline std::string* Program::add_input_texture_names() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  std::string* _s = _internal_mutable_input_texture_names()->Add();
-  // @@protoc_insertion_point(field_add_mutable:frame.proto.Program.input_texture_names)
-  return _s;
+inline std::string* Program::add_input_texture_names()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    std::string* _s = _internal_mutable_input_texture_names()->Add();
+    // @@protoc_insertion_point(field_add_mutable:frame.proto.Program.input_texture_names)
+    return _s;
 }
 inline const std::string& Program::input_texture_names(int index) const
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:frame.proto.Program.input_texture_names)
-  return _internal_input_texture_names().Get(index);
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_get:frame.proto.Program.input_texture_names)
+    return _internal_input_texture_names().Get(index);
 }
 inline std::string* Program::mutable_input_texture_names(int index)
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_mutable:frame.proto.Program.input_texture_names)
-  return _internal_mutable_input_texture_names()->Mutable(index);
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_mutable:frame.proto.Program.input_texture_names)
+    return _internal_mutable_input_texture_names()->Mutable(index);
 }
 template <typename Arg_, typename... Args_>
-inline void Program::set_input_texture_names(int index, Arg_&& value, Args_... args) {
-  ::google::protobuf::internal::AssignToString(
-      *_internal_mutable_input_texture_names()->Mutable(index),
-      std::forward<Arg_>(value), args... );
-  // @@protoc_insertion_point(field_set:frame.proto.Program.input_texture_names)
+inline void Program::set_input_texture_names(
+    int index, Arg_&& value, Args_... args)
+{
+    ::google::protobuf::internal::AssignToString(
+        *_internal_mutable_input_texture_names()->Mutable(index),
+        std::forward<Arg_>(value),
+        args...);
+    // @@protoc_insertion_point(field_set:frame.proto.Program.input_texture_names)
 }
 template <typename Arg_, typename... Args_>
-inline void Program::add_input_texture_names(Arg_&& value, Args_... args) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  ::google::protobuf::internal::AddToRepeatedPtrField(*_internal_mutable_input_texture_names(),
-                               std::forward<Arg_>(value),
-                               args... );
-  // @@protoc_insertion_point(field_add:frame.proto.Program.input_texture_names)
+inline void Program::add_input_texture_names(Arg_&& value, Args_... args)
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    ::google::protobuf::internal::AddToRepeatedPtrField(
+        *_internal_mutable_input_texture_names(),
+        std::forward<Arg_>(value),
+        args...);
+    // @@protoc_insertion_point(field_add:frame.proto.Program.input_texture_names)
 }
-inline const ::google::protobuf::RepeatedPtrField<std::string>&
-Program::input_texture_names() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_list:frame.proto.Program.input_texture_names)
-  return _internal_input_texture_names();
+inline const ::google::protobuf::RepeatedPtrField<std::string>& Program::
+    input_texture_names() const ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_list:frame.proto.Program.input_texture_names)
+    return _internal_input_texture_names();
 }
-inline ::google::protobuf::RepeatedPtrField<std::string>*
-Program::mutable_input_texture_names() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_mutable_list:frame.proto.Program.input_texture_names)
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  return _internal_mutable_input_texture_names();
+inline ::google::protobuf::RepeatedPtrField<std::string>* Program::
+    mutable_input_texture_names() ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_mutable_list:frame.proto.Program.input_texture_names)
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    return _internal_mutable_input_texture_names();
 }
-inline const ::google::protobuf::RepeatedPtrField<std::string>&
-Program::_internal_input_texture_names() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.input_texture_names_;
+inline const ::google::protobuf::RepeatedPtrField<std::string>& Program::
+    _internal_input_texture_names() const
+{
+    ::google::protobuf::internal::TSanRead(&_impl_);
+    return _impl_.input_texture_names_;
 }
-inline ::google::protobuf::RepeatedPtrField<std::string>*
-Program::_internal_mutable_input_texture_names() {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return &_impl_.input_texture_names_;
+inline ::google::protobuf::RepeatedPtrField<std::string>* Program::
+    _internal_mutable_input_texture_names()
+{
+    ::google::protobuf::internal::TSanRead(&_impl_);
+    return &_impl_.input_texture_names_;
 }
 
 // repeated string output_texture_names = 4;
-inline int Program::_internal_output_texture_names_size() const {
-  return _internal_output_texture_names().size();
+inline int Program::_internal_output_texture_names_size() const
+{
+    return _internal_output_texture_names().size();
 }
-inline int Program::output_texture_names_size() const {
-  return _internal_output_texture_names_size();
+inline int Program::output_texture_names_size() const
+{
+    return _internal_output_texture_names_size();
 }
-inline void Program::clear_output_texture_names() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.output_texture_names_.Clear();
+inline void Program::clear_output_texture_names()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.output_texture_names_.Clear();
 }
-inline std::string* Program::add_output_texture_names() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  std::string* _s = _internal_mutable_output_texture_names()->Add();
-  // @@protoc_insertion_point(field_add_mutable:frame.proto.Program.output_texture_names)
-  return _s;
+inline std::string* Program::add_output_texture_names()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    std::string* _s = _internal_mutable_output_texture_names()->Add();
+    // @@protoc_insertion_point(field_add_mutable:frame.proto.Program.output_texture_names)
+    return _s;
 }
 inline const std::string& Program::output_texture_names(int index) const
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:frame.proto.Program.output_texture_names)
-  return _internal_output_texture_names().Get(index);
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_get:frame.proto.Program.output_texture_names)
+    return _internal_output_texture_names().Get(index);
 }
 inline std::string* Program::mutable_output_texture_names(int index)
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_mutable:frame.proto.Program.output_texture_names)
-  return _internal_mutable_output_texture_names()->Mutable(index);
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_mutable:frame.proto.Program.output_texture_names)
+    return _internal_mutable_output_texture_names()->Mutable(index);
 }
 template <typename Arg_, typename... Args_>
-inline void Program::set_output_texture_names(int index, Arg_&& value, Args_... args) {
-  ::google::protobuf::internal::AssignToString(
-      *_internal_mutable_output_texture_names()->Mutable(index),
-      std::forward<Arg_>(value), args... );
-  // @@protoc_insertion_point(field_set:frame.proto.Program.output_texture_names)
+inline void Program::set_output_texture_names(
+    int index, Arg_&& value, Args_... args)
+{
+    ::google::protobuf::internal::AssignToString(
+        *_internal_mutable_output_texture_names()->Mutable(index),
+        std::forward<Arg_>(value),
+        args...);
+    // @@protoc_insertion_point(field_set:frame.proto.Program.output_texture_names)
 }
 template <typename Arg_, typename... Args_>
-inline void Program::add_output_texture_names(Arg_&& value, Args_... args) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  ::google::protobuf::internal::AddToRepeatedPtrField(*_internal_mutable_output_texture_names(),
-                               std::forward<Arg_>(value),
-                               args... );
-  // @@protoc_insertion_point(field_add:frame.proto.Program.output_texture_names)
+inline void Program::add_output_texture_names(Arg_&& value, Args_... args)
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    ::google::protobuf::internal::AddToRepeatedPtrField(
+        *_internal_mutable_output_texture_names(),
+        std::forward<Arg_>(value),
+        args...);
+    // @@protoc_insertion_point(field_add:frame.proto.Program.output_texture_names)
 }
-inline const ::google::protobuf::RepeatedPtrField<std::string>&
-Program::output_texture_names() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_list:frame.proto.Program.output_texture_names)
-  return _internal_output_texture_names();
+inline const ::google::protobuf::RepeatedPtrField<std::string>& Program::
+    output_texture_names() const ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_list:frame.proto.Program.output_texture_names)
+    return _internal_output_texture_names();
 }
-inline ::google::protobuf::RepeatedPtrField<std::string>*
-Program::mutable_output_texture_names() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_mutable_list:frame.proto.Program.output_texture_names)
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  return _internal_mutable_output_texture_names();
+inline ::google::protobuf::RepeatedPtrField<std::string>* Program::
+    mutable_output_texture_names() ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_mutable_list:frame.proto.Program.output_texture_names)
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    return _internal_mutable_output_texture_names();
 }
-inline const ::google::protobuf::RepeatedPtrField<std::string>&
-Program::_internal_output_texture_names() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.output_texture_names_;
+inline const ::google::protobuf::RepeatedPtrField<std::string>& Program::
+    _internal_output_texture_names() const
+{
+    ::google::protobuf::internal::TSanRead(&_impl_);
+    return _impl_.output_texture_names_;
 }
-inline ::google::protobuf::RepeatedPtrField<std::string>*
-Program::_internal_mutable_output_texture_names() {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return &_impl_.output_texture_names_;
+inline ::google::protobuf::RepeatedPtrField<std::string>* Program::
+    _internal_mutable_output_texture_names()
+{
+    ::google::protobuf::internal::TSanRead(&_impl_);
+    return &_impl_.output_texture_names_;
 }
 
 // .frame.proto.SceneType input_scene_type = 9;
-inline bool Program::has_input_scene_type() const {
-  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
-  PROTOBUF_ASSUME(!value || _impl_.input_scene_type_ != nullptr);
-  return value;
+inline bool Program::has_input_scene_type() const
+{
+    bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+    PROTOBUF_ASSUME(!value || _impl_.input_scene_type_ != nullptr);
+    return value;
 }
-inline void Program::clear_input_scene_type() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (_impl_.input_scene_type_ != nullptr) _impl_.input_scene_type_->Clear();
-  _impl_._has_bits_[0] &= ~0x00000001u;
-}
-inline const ::frame::proto::SceneType& Program::_internal_input_scene_type() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  const ::frame::proto::SceneType* p = _impl_.input_scene_type_;
-  return p != nullptr ? *p : reinterpret_cast<const ::frame::proto::SceneType&>(::frame::proto::_SceneType_default_instance_);
-}
-inline const ::frame::proto::SceneType& Program::input_scene_type() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:frame.proto.Program.input_scene_type)
-  return _internal_input_scene_type();
-}
-inline void Program::unsafe_arena_set_allocated_input_scene_type(::frame::proto::SceneType* value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (GetArena() == nullptr) {
-    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.input_scene_type_);
-  }
-  _impl_.input_scene_type_ = reinterpret_cast<::frame::proto::SceneType*>(value);
-  if (value != nullptr) {
-    _impl_._has_bits_[0] |= 0x00000001u;
-  } else {
+inline void Program::clear_input_scene_type()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    if (_impl_.input_scene_type_ != nullptr)
+        _impl_.input_scene_type_->Clear();
     _impl_._has_bits_[0] &= ~0x00000001u;
-  }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:frame.proto.Program.input_scene_type)
 }
-inline ::frame::proto::SceneType* Program::release_input_scene_type() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-
-  _impl_._has_bits_[0] &= ~0x00000001u;
-  ::frame::proto::SceneType* released = _impl_.input_scene_type_;
-  _impl_.input_scene_type_ = nullptr;
-  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
-    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
-    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
-    if (GetArena() == nullptr) {
-      delete old;
+inline const ::frame::proto::SceneType& Program::_internal_input_scene_type()
+    const
+{
+    ::google::protobuf::internal::TSanRead(&_impl_);
+    const ::frame::proto::SceneType* p = _impl_.input_scene_type_;
+    return p != nullptr ? *p
+                        : reinterpret_cast<const ::frame::proto::SceneType&>(
+                              ::frame::proto::_SceneType_default_instance_);
+}
+inline const ::frame::proto::SceneType& Program::input_scene_type() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_get:frame.proto.Program.input_scene_type)
+    return _internal_input_scene_type();
+}
+inline void Program::unsafe_arena_set_allocated_input_scene_type(
+    ::frame::proto::SceneType* value)
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    if (GetArena() == nullptr)
+    {
+        delete reinterpret_cast<::google::protobuf::MessageLite*>(
+            _impl_.input_scene_type_);
     }
-  } else {
-    if (GetArena() != nullptr) {
-      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    _impl_.input_scene_type_ =
+        reinterpret_cast<::frame::proto::SceneType*>(value);
+    if (value != nullptr)
+    {
+        _impl_._has_bits_[0] |= 0x00000001u;
     }
-  }
-  return released;
-}
-inline ::frame::proto::SceneType* Program::unsafe_arena_release_input_scene_type() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  // @@protoc_insertion_point(field_release:frame.proto.Program.input_scene_type)
-
-  _impl_._has_bits_[0] &= ~0x00000001u;
-  ::frame::proto::SceneType* temp = _impl_.input_scene_type_;
-  _impl_.input_scene_type_ = nullptr;
-  return temp;
-}
-inline ::frame::proto::SceneType* Program::_internal_mutable_input_scene_type() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (_impl_.input_scene_type_ == nullptr) {
-    auto* p = ::google::protobuf::Message::DefaultConstruct<::frame::proto::SceneType>(GetArena());
-    _impl_.input_scene_type_ = reinterpret_cast<::frame::proto::SceneType*>(p);
-  }
-  return _impl_.input_scene_type_;
-}
-inline ::frame::proto::SceneType* Program::mutable_input_scene_type() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  _impl_._has_bits_[0] |= 0x00000001u;
-  ::frame::proto::SceneType* _msg = _internal_mutable_input_scene_type();
-  // @@protoc_insertion_point(field_mutable:frame.proto.Program.input_scene_type)
-  return _msg;
-}
-inline void Program::set_allocated_input_scene_type(::frame::proto::SceneType* value) {
-  ::google::protobuf::Arena* message_arena = GetArena();
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (message_arena == nullptr) {
-    delete (_impl_.input_scene_type_);
-  }
-
-  if (value != nullptr) {
-    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
-    if (message_arena != submessage_arena) {
-      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    else
+    {
+        _impl_._has_bits_[0] &= ~0x00000001u;
     }
-    _impl_._has_bits_[0] |= 0x00000001u;
-  } else {
+    // @@protoc_insertion_point(field_unsafe_arena_set_allocated:frame.proto.Program.input_scene_type)
+}
+inline ::frame::proto::SceneType* Program::release_input_scene_type()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+
     _impl_._has_bits_[0] &= ~0x00000001u;
-  }
+    ::frame::proto::SceneType* released = _impl_.input_scene_type_;
+    _impl_.input_scene_type_ = nullptr;
+    if (::google::protobuf::internal::DebugHardenForceCopyInRelease())
+    {
+        auto* old =
+            reinterpret_cast<::google::protobuf::MessageLite*>(released);
+        released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+        if (GetArena() == nullptr)
+        {
+            delete old;
+        }
+    }
+    else
+    {
+        if (GetArena() != nullptr)
+        {
+            released =
+                ::google::protobuf::internal::DuplicateIfNonNull(released);
+        }
+    }
+    return released;
+}
+inline ::frame::proto::SceneType* Program::
+    unsafe_arena_release_input_scene_type()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    // @@protoc_insertion_point(field_release:frame.proto.Program.input_scene_type)
 
-  _impl_.input_scene_type_ = reinterpret_cast<::frame::proto::SceneType*>(value);
-  // @@protoc_insertion_point(field_set_allocated:frame.proto.Program.input_scene_type)
+    _impl_._has_bits_[0] &= ~0x00000001u;
+    ::frame::proto::SceneType* temp = _impl_.input_scene_type_;
+    _impl_.input_scene_type_ = nullptr;
+    return temp;
+}
+inline ::frame::proto::SceneType* Program::_internal_mutable_input_scene_type()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    if (_impl_.input_scene_type_ == nullptr)
+    {
+        auto* p = ::google::protobuf::Message::DefaultConstruct<
+            ::frame::proto::SceneType>(GetArena());
+        _impl_.input_scene_type_ =
+            reinterpret_cast<::frame::proto::SceneType*>(p);
+    }
+    return _impl_.input_scene_type_;
+}
+inline ::frame::proto::SceneType* Program::mutable_input_scene_type()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    _impl_._has_bits_[0] |= 0x00000001u;
+    ::frame::proto::SceneType* _msg = _internal_mutable_input_scene_type();
+    // @@protoc_insertion_point(field_mutable:frame.proto.Program.input_scene_type)
+    return _msg;
+}
+inline void Program::set_allocated_input_scene_type(
+    ::frame::proto::SceneType* value)
+{
+    ::google::protobuf::Arena* message_arena = GetArena();
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    if (message_arena == nullptr)
+    {
+        delete (_impl_.input_scene_type_);
+    }
+
+    if (value != nullptr)
+    {
+        ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+        if (message_arena != submessage_arena)
+        {
+            value = ::google::protobuf::internal::GetOwnedMessage(
+                message_arena, value, submessage_arena);
+        }
+        _impl_._has_bits_[0] |= 0x00000001u;
+    }
+    else
+    {
+        _impl_._has_bits_[0] &= ~0x00000001u;
+    }
+
+    _impl_.input_scene_type_ =
+        reinterpret_cast<::frame::proto::SceneType*>(value);
+    // @@protoc_insertion_point(field_set_allocated:frame.proto.Program.input_scene_type)
 }
 
 // string input_scene_root_name = 5;
-inline void Program::clear_input_scene_root_name() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.input_scene_root_name_.ClearToEmpty();
+inline void Program::clear_input_scene_root_name()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.input_scene_root_name_.ClearToEmpty();
 }
 inline const std::string& Program::input_scene_root_name() const
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:frame.proto.Program.input_scene_root_name)
-  return _internal_input_scene_root_name();
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_get:frame.proto.Program.input_scene_root_name)
+    return _internal_input_scene_root_name();
 }
 template <typename Arg_, typename... Args_>
-inline PROTOBUF_ALWAYS_INLINE void Program::set_input_scene_root_name(Arg_&& arg,
-                                                     Args_... args) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.input_scene_root_name_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
-  // @@protoc_insertion_point(field_set:frame.proto.Program.input_scene_root_name)
+inline PROTOBUF_ALWAYS_INLINE void Program::set_input_scene_root_name(
+    Arg_&& arg, Args_... args)
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.input_scene_root_name_.Set(
+        static_cast<Arg_&&>(arg), args..., GetArena());
+    // @@protoc_insertion_point(field_set:frame.proto.Program.input_scene_root_name)
 }
-inline std::string* Program::mutable_input_scene_root_name() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  std::string* _s = _internal_mutable_input_scene_root_name();
-  // @@protoc_insertion_point(field_mutable:frame.proto.Program.input_scene_root_name)
-  return _s;
+inline std::string* Program::mutable_input_scene_root_name()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    std::string* _s = _internal_mutable_input_scene_root_name();
+    // @@protoc_insertion_point(field_mutable:frame.proto.Program.input_scene_root_name)
+    return _s;
 }
-inline const std::string& Program::_internal_input_scene_root_name() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.input_scene_root_name_.Get();
+inline const std::string& Program::_internal_input_scene_root_name() const
+{
+    ::google::protobuf::internal::TSanRead(&_impl_);
+    return _impl_.input_scene_root_name_.Get();
 }
-inline void Program::_internal_set_input_scene_root_name(const std::string& value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.input_scene_root_name_.Set(value, GetArena());
+inline void Program::_internal_set_input_scene_root_name(
+    const std::string& value)
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.input_scene_root_name_.Set(value, GetArena());
 }
-inline std::string* Program::_internal_mutable_input_scene_root_name() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  return _impl_.input_scene_root_name_.Mutable( GetArena());
+inline std::string* Program::_internal_mutable_input_scene_root_name()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    return _impl_.input_scene_root_name_.Mutable(GetArena());
 }
-inline std::string* Program::release_input_scene_root_name() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  // @@protoc_insertion_point(field_release:frame.proto.Program.input_scene_root_name)
-  return _impl_.input_scene_root_name_.Release();
+inline std::string* Program::release_input_scene_root_name()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    // @@protoc_insertion_point(field_release:frame.proto.Program.input_scene_root_name)
+    return _impl_.input_scene_root_name_.Release();
 }
-inline void Program::set_allocated_input_scene_root_name(std::string* value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.input_scene_root_name_.SetAllocated(value, GetArena());
-  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.input_scene_root_name_.IsDefault()) {
-    _impl_.input_scene_root_name_.Set("", GetArena());
-  }
-  // @@protoc_insertion_point(field_set_allocated:frame.proto.Program.input_scene_root_name)
+inline void Program::set_allocated_input_scene_root_name(std::string* value)
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.input_scene_root_name_.SetAllocated(value, GetArena());
+    if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() &&
+        _impl_.input_scene_root_name_.IsDefault())
+    {
+        _impl_.input_scene_root_name_.Set("", GetArena());
+    }
+    // @@protoc_insertion_point(field_set_allocated:frame.proto.Program.input_scene_root_name)
 }
 
-// string shader = 6;
-inline void Program::clear_shader() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.shader_.ClearToEmpty();
+// string shader_vertex = 6;
+inline void Program::clear_shader_vertex()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.shader_vertex_.ClearToEmpty();
 }
-inline const std::string& Program::shader() const
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:frame.proto.Program.shader)
-  return _internal_shader();
+inline const std::string& Program::shader_vertex() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_get:frame.proto.Program.shader_vertex)
+    return _internal_shader_vertex();
 }
 template <typename Arg_, typename... Args_>
-inline PROTOBUF_ALWAYS_INLINE void Program::set_shader(Arg_&& arg,
-                                                     Args_... args) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.shader_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
-  // @@protoc_insertion_point(field_set:frame.proto.Program.shader)
+inline PROTOBUF_ALWAYS_INLINE void Program::set_shader_vertex(
+    Arg_&& arg, Args_... args)
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.shader_vertex_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+    // @@protoc_insertion_point(field_set:frame.proto.Program.shader_vertex)
 }
-inline std::string* Program::mutable_shader() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  std::string* _s = _internal_mutable_shader();
-  // @@protoc_insertion_point(field_mutable:frame.proto.Program.shader)
-  return _s;
+inline std::string* Program::mutable_shader_vertex()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    std::string* _s = _internal_mutable_shader_vertex();
+    // @@protoc_insertion_point(field_mutable:frame.proto.Program.shader_vertex)
+    return _s;
 }
-inline const std::string& Program::_internal_shader() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.shader_.Get();
+inline const std::string& Program::_internal_shader_vertex() const
+{
+    ::google::protobuf::internal::TSanRead(&_impl_);
+    return _impl_.shader_vertex_.Get();
 }
-inline void Program::_internal_set_shader(const std::string& value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.shader_.Set(value, GetArena());
+inline void Program::_internal_set_shader_vertex(const std::string& value)
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.shader_vertex_.Set(value, GetArena());
 }
-inline std::string* Program::_internal_mutable_shader() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  return _impl_.shader_.Mutable( GetArena());
+inline std::string* Program::_internal_mutable_shader_vertex()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    return _impl_.shader_vertex_.Mutable(GetArena());
 }
-inline std::string* Program::release_shader() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  // @@protoc_insertion_point(field_release:frame.proto.Program.shader)
-  return _impl_.shader_.Release();
+inline std::string* Program::release_shader_vertex()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    // @@protoc_insertion_point(field_release:frame.proto.Program.shader_vertex)
+    return _impl_.shader_vertex_.Release();
 }
-inline void Program::set_allocated_shader(std::string* value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.shader_.SetAllocated(value, GetArena());
-  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.shader_.IsDefault()) {
-    _impl_.shader_.Set("", GetArena());
-  }
-  // @@protoc_insertion_point(field_set_allocated:frame.proto.Program.shader)
+inline void Program::set_allocated_shader_vertex(std::string* value)
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.shader_vertex_.SetAllocated(value, GetArena());
+    if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() &&
+        _impl_.shader_vertex_.IsDefault())
+    {
+        _impl_.shader_vertex_.Set("", GetArena());
+    }
+    // @@protoc_insertion_point(field_set_allocated:frame.proto.Program.shader_vertex)
+}
+
+// string shader_fragment = 8;
+inline void Program::clear_shader_fragment()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.shader_fragment_.ClearToEmpty();
+}
+inline const std::string& Program::shader_fragment() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_get:frame.proto.Program.shader_fragment)
+    return _internal_shader_fragment();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void Program::set_shader_fragment(
+    Arg_&& arg, Args_... args)
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.shader_fragment_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+    // @@protoc_insertion_point(field_set:frame.proto.Program.shader_fragment)
+}
+inline std::string* Program::mutable_shader_fragment()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    std::string* _s = _internal_mutable_shader_fragment();
+    // @@protoc_insertion_point(field_mutable:frame.proto.Program.shader_fragment)
+    return _s;
+}
+inline const std::string& Program::_internal_shader_fragment() const
+{
+    ::google::protobuf::internal::TSanRead(&_impl_);
+    return _impl_.shader_fragment_.Get();
+}
+inline void Program::_internal_set_shader_fragment(const std::string& value)
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.shader_fragment_.Set(value, GetArena());
+}
+inline std::string* Program::_internal_mutable_shader_fragment()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    return _impl_.shader_fragment_.Mutable(GetArena());
+}
+inline std::string* Program::release_shader_fragment()
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    // @@protoc_insertion_point(field_release:frame.proto.Program.shader_fragment)
+    return _impl_.shader_fragment_.Release();
+}
+inline void Program::set_allocated_shader_fragment(std::string* value)
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    _impl_.shader_fragment_.SetAllocated(value, GetArena());
+    if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() &&
+        _impl_.shader_fragment_.IsDefault())
+    {
+        _impl_.shader_fragment_.Set("", GetArena());
+    }
+    // @@protoc_insertion_point(field_set_allocated:frame.proto.Program.shader_fragment)
 }
 
 // repeated .frame.proto.Uniform uniforms = 7;
-inline int Program::_internal_uniforms_size() const {
-  return _internal_uniforms().size();
+inline int Program::_internal_uniforms_size() const
+{
+    return _internal_uniforms().size();
 }
-inline int Program::uniforms_size() const {
-  return _internal_uniforms_size();
+inline int Program::uniforms_size() const
+{
+    return _internal_uniforms_size();
 }
 inline ::frame::proto::Uniform* Program::mutable_uniforms(int index)
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_mutable:frame.proto.Program.uniforms)
-  return _internal_mutable_uniforms()->Mutable(index);
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_mutable:frame.proto.Program.uniforms)
+    return _internal_mutable_uniforms()->Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField<::frame::proto::Uniform>* Program::mutable_uniforms()
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_mutable_list:frame.proto.Program.uniforms)
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  return _internal_mutable_uniforms();
+inline ::google::protobuf::RepeatedPtrField<::frame::proto::Uniform>* Program::
+    mutable_uniforms() ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_mutable_list:frame.proto.Program.uniforms)
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    return _internal_mutable_uniforms();
 }
 inline const ::frame::proto::Uniform& Program::uniforms(int index) const
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:frame.proto.Program.uniforms)
-  return _internal_uniforms().Get(index);
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_get:frame.proto.Program.uniforms)
+    return _internal_uniforms().Get(index);
 }
-inline ::frame::proto::Uniform* Program::add_uniforms() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  ::frame::proto::Uniform* _add = _internal_mutable_uniforms()->Add();
-  // @@protoc_insertion_point(field_add:frame.proto.Program.uniforms)
-  return _add;
-}
-inline const ::google::protobuf::RepeatedPtrField<::frame::proto::Uniform>& Program::uniforms() const
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_list:frame.proto.Program.uniforms)
-  return _internal_uniforms();
+inline ::frame::proto::Uniform* Program::add_uniforms()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    ::google::protobuf::internal::TSanWrite(&_impl_);
+    ::frame::proto::Uniform* _add = _internal_mutable_uniforms()->Add();
+    // @@protoc_insertion_point(field_add:frame.proto.Program.uniforms)
+    return _add;
 }
 inline const ::google::protobuf::RepeatedPtrField<::frame::proto::Uniform>&
-Program::_internal_uniforms() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.uniforms_;
+Program::uniforms() const ABSL_ATTRIBUTE_LIFETIME_BOUND
+{
+    // @@protoc_insertion_point(field_list:frame.proto.Program.uniforms)
+    return _internal_uniforms();
 }
-inline ::google::protobuf::RepeatedPtrField<::frame::proto::Uniform>*
-Program::_internal_mutable_uniforms() {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return &_impl_.uniforms_;
+inline const ::google::protobuf::RepeatedPtrField<::frame::proto::Uniform>&
+Program::_internal_uniforms() const
+{
+    ::google::protobuf::internal::TSanRead(&_impl_);
+    return _impl_.uniforms_;
+}
+inline ::google::protobuf::RepeatedPtrField<::frame::proto::Uniform>* Program::
+    _internal_mutable_uniforms()
+{
+    ::google::protobuf::internal::TSanRead(&_impl_);
+    return &_impl_.uniforms_;
 }
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
-#endif  // __GNUC__
+#endif // __GNUC__
 
 // @@protoc_insertion_point(namespace_scope)
-}  // namespace proto
-}  // namespace frame
+} // namespace proto
+} // namespace frame
 
-
-namespace google {
-namespace protobuf {
+namespace google
+{
+namespace protobuf
+{
 
 template <>
-struct is_proto_enum<::frame::proto::SceneType_Enum> : std::true_type {};
+struct is_proto_enum<::frame::proto::SceneType_Enum> : std::true_type
+{
+};
 template <>
-inline const EnumDescriptor* GetEnumDescriptor<::frame::proto::SceneType_Enum>() {
-  return ::frame::proto::SceneType_Enum_descriptor();
+inline const EnumDescriptor* GetEnumDescriptor<::frame::proto::SceneType_Enum>()
+{
+    return ::frame::proto::SceneType_Enum_descriptor();
 }
 
-}  // namespace protobuf
-}  // namespace google
+} // namespace protobuf
+} // namespace google
 
 // @@protoc_insertion_point(global_scope)
 
 #include "google/protobuf/port_undef.inc"
 
-#endif  // program_2eproto_2epb_2eh
+#endif // program_2eproto_2epb_2eh

--- a/src/frame/json/serialize_program.cpp
+++ b/src/frame/json/serialize_program.cpp
@@ -14,7 +14,10 @@ proto::Program SerializeProgram(
 {
     proto::Program proto_program;
     proto_program.set_name(program_interface.GetName());
-    proto_program.set_shader(program_interface.GetData().shader());
+    proto_program.set_shader_vertex(
+        program_interface.GetData().shader_vertex());
+    proto_program.set_shader_fragment(
+        program_interface.GetData().shader_fragment());
     for (const auto& input_texture_id : program_interface.GetInputTextureIds())
     {
         *proto_program.add_input_texture_names() =

--- a/src/frame/opengl/file/load_program.cpp
+++ b/src/frame/opengl/file/load_program.cpp
@@ -14,9 +14,9 @@ std::unique_ptr<frame::ProgramInterface> LoadProgram(
     const proto::Program& proto_program)
 {
     std::string vertex_file =
-        std::string("asset/shader/opengl/" + proto_program.shader() + ".vert");
+        std::string("asset/shader/opengl/" + proto_program.shader_vertex());
     std::string fragment_file =
-        std::string("asset/shader/opengl/" + proto_program.shader() + ".frag");
+        std::string("asset/shader/opengl/" + proto_program.shader_fragment());
     return LoadProgram(proto_program, vertex_file, fragment_file);
 }
 

--- a/src/frame/opengl/program.cpp
+++ b/src/frame/opengl/program.cpp
@@ -219,8 +219,7 @@ void Program::UploadUniform(const UniformInterface& uniform_interface) const
         break;
     }
     case proto::Uniform::FLOAT:
-        glUniform1f(
-            GetMemoizeUniformLocation(name), data.uniform_float());
+        glUniform1f(GetMemoizeUniformLocation(name), data.uniform_float());
         break;
     case proto::Uniform::FLOATS: {
         auto& uniform_floats = data.uniform_floats();
@@ -238,8 +237,7 @@ void Program::UploadUniform(const UniformInterface& uniform_interface) const
     }
     case proto::Uniform::FLOAT_VECTOR3: {
         glm::vec3 value = json::ParseUniform(data.uniform_vec3());
-        glUniform3f(
-            GetMemoizeUniformLocation(name), value.x, value.y, value.z);
+        glUniform3f(GetMemoizeUniformLocation(name), value.x, value.y, value.z);
         break;
     }
     case proto::Uniform::FLOAT_VECTOR4: {
@@ -259,10 +257,11 @@ void Program::UploadUniform(const UniformInterface& uniform_interface) const
         break;
     }
     default:
-        logger_->error(std::format(
-            "Unknown uniform type [{}] for uniform [{}].",
-            static_cast<int>(data.type()),
-            name));
+        logger_->error(
+            std::format(
+                "Unknown uniform type [{}] for uniform [{}].",
+                static_cast<int>(data.type()),
+                name));
         break;
     }
 }
@@ -511,7 +510,8 @@ void Program::SetTemporarySceneRoot(const std::string& name)
 
 std::unique_ptr<ProgramInterface> CreateProgram(
     const std::string& name,
-    const std::string& shader_name,
+    const std::string& vertex_shader_name,
+    const std::string& fragment_shader_name,
     std::istream& vertex_shader_code,
     std::istream& pixel_shader_code)
 {
@@ -537,7 +537,8 @@ std::unique_ptr<ProgramInterface> CreateProgram(
     program->AddShader(vertex);
     program->AddShader(fragment);
     program->LinkShader();
-    program->GetData().set_shader(shader_name);
+    program->GetData().set_shader_vertex(vertex_shader_name);
+    program->GetData().set_shader_fragment(fragment_shader_name);
 #ifdef _DEBUG
     logger->info("with pointer := {}", static_cast<void*>(program.get()));
 #endif // _DEBUG
@@ -588,7 +589,8 @@ std::unique_ptr<ProgramInterface> CreateProgram(
             program->AddUniform(std::move(uniform_interface));
         }
     }
-    program->GetData().set_shader(proto_program.shader());
+    program->GetData().set_shader_vertex(proto_program.shader_vertex());
+    program->GetData().set_shader_fragment(proto_program.shader_fragment());
 #ifdef _DEBUG
     logger->info("with pointer := {}", static_cast<void*>(program.get()));
 #endif // _DEBUG

--- a/src/frame/opengl/program.h
+++ b/src/frame/opengl/program.h
@@ -196,7 +196,8 @@ class Program : public ProgramInterface
  */
 std::unique_ptr<frame::ProgramInterface> CreateProgram(
     const std::string& name,
-    const std::string& shader_name,
+    const std::string& vertex_shader_name,
+    const std::string& fragment_shader_name,
     std::istream& vertex_shader_code,
     std::istream& pixel_shader_code);
 /**

--- a/src/frame/opengl/renderer.cpp
+++ b/src/frame/opengl/renderer.cpp
@@ -32,7 +32,8 @@ Renderer::Renderer(LevelInterface& level, glm::uvec4 viewport)
     frame_buffer_->AttachRender(*render_buffer_);
     proto::Program proto_program;
     proto_program.set_name("display");
-    proto_program.set_shader("display");
+    proto_program.set_shader_vertex("display.vert");
+    proto_program.set_shader_fragment("display.frag");
     auto program = file::LoadProgram(proto_program);
     if (!program)
         throw std::runtime_error("No program!");

--- a/src/frame/proto/program.proto
+++ b/src/frame/proto/program.proto
@@ -7,33 +7,38 @@ package frame.proto;
 // This is the description of a Scene type this will define witch rendering
 // technique will be used with the current program.
 // Next 2
-message SceneType {
-	enum Enum {
-		NONE			= 0;
-		QUAD			= 1;
-		CUBE			= 2;
-		SCENE			= 3;
-	}
-	Enum value = 1;
+message SceneType
+{
+    enum Enum
+    {
+        NONE = 0;
+        QUAD = 1;
+        CUBE = 2;
+        SCENE = 3;
+    }
+    Enum value = 1;
 }
 
 // Description of an effect that can be used as a 2D effect on a rendering or
 // as a shader for material.
 // Next 10
-message Program {
-	// Name of the effect.
-	string name = 1;
-	// Input texture names (this should come from scene?).
-	repeated string input_texture_names = 3;
-	// Output texture names.
-	repeated string output_texture_names = 4;
-	// Input Scene type (this should come from scene?).
-	// In case you select 'SCENE' you'll have to set the input_scene_root_name.
-	SceneType input_scene_type = 9;
-	// Input Scenes name.
-	string input_scene_root_name = 5;
-	// Shader name (used to find the shader).
-	string shader = 6;
-	// Additionnal uniforms for the shader.
-	repeated Uniform uniforms = 7;
+message Program
+{
+    // Name of the effect.
+    string name = 1;
+    // Input texture names (this should come from scene?).
+    repeated string input_texture_names = 3;
+    // Output texture names.
+    repeated string output_texture_names = 4;
+    // Input Scene type (this should come from scene?).
+    // In case you select 'SCENE' you'll have to set the input_scene_root_name.
+    SceneType input_scene_type = 9;
+    // Input Scenes name.
+    string input_scene_root_name = 5;
+    // Vertex shader file name (including the extension).
+    string shader_vertex = 6;
+    // Fragment shader file name (including the extension).
+    string shader_fragment = 8;
+    // Additionnal uniforms for the shader.
+    repeated Uniform uniforms = 7;
 }

--- a/tests/frame/opengl/file/load_program_test.cpp
+++ b/tests/frame/opengl/file/load_program_test.cpp
@@ -9,7 +9,8 @@ TEST_F(LoadProgramTest, LoadFromNameTest)
 {
     frame::proto::Program proto_program;
     proto_program.set_name("blur");
-    proto_program.set_shader("blur");
+    proto_program.set_shader_vertex("blur.vert");
+    proto_program.set_shader_fragment("blur.frag");
     ASSERT_TRUE(frame::opengl::file::LoadProgram(proto_program));
 }
 
@@ -17,7 +18,8 @@ TEST_F(LoadProgramTest, LoadFromFileTest)
 {
     frame::proto::Program proto_program;
     proto_program.set_name("blur");
-    proto_program.set_shader("blur");
+    proto_program.set_shader_vertex("blur.vert");
+    proto_program.set_shader_fragment("blur.frag");
     ASSERT_TRUE(
         frame::opengl::file::LoadProgram(
             proto_program,

--- a/tests/frame/opengl/program_test.cpp
+++ b/tests/frame/opengl/program_test.cpp
@@ -51,8 +51,8 @@ TEST_F(ProgramTest, CreateSimpleProgramProgramTest)
     EXPECT_FALSE(program_);
     std::istringstream iss_vertex(GetVertexSource());
     std::istringstream iss_fragment(GetFragmentSource());
-    auto program =
-        frame::opengl::CreateProgram("test", "test", iss_vertex, iss_fragment);
+    auto program = frame::opengl::CreateProgram(
+        "test", "test_vert", "test_frag", iss_vertex, iss_fragment);
     ASSERT_TRUE(program);
 }
 
@@ -61,8 +61,8 @@ TEST_F(ProgramTest, UniformTest)
     EXPECT_FALSE(program_);
     std::istringstream iss_vertex(GetVertexSource());
     std::istringstream iss_fragment(GetFragmentSource());
-    auto program =
-        frame::opengl::CreateProgram("test", "test", iss_vertex, iss_fragment);
+    auto program = frame::opengl::CreateProgram(
+        "test", "test_vert", "test_frag", iss_vertex, iss_fragment);
     ASSERT_TRUE(program);
     program_ = std::move(program);
     auto uniform_list = program_->GetUniformNameList();


### PR DESCRIPTION
## Summary
- split shader path in `program.proto` for vertex and fragment
- use full filenames with extension for shaders
- update program loader, renderer and unit tests
- revise all level JSON assets to specify vertex/fragment files

## Testing
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68592e153a7c832980d1e1ba58888e1a