### PR TITLE
Remove fmt library use

### DIFF
--- a/src/frame/file/CMakeLists.txt
+++ b/src/frame/file/CMakeLists.txt
@@ -28,7 +28,6 @@ target_link_libraries(FrameFile
     Frame
     FrameJson
     FrameOpenGL
-    fmt::fmt
     glm::glm
     protobuf::libprotobuf
     spdlog::spdlog

--- a/src/frame/file/image.cpp
+++ b/src/frame/file/image.cpp
@@ -92,7 +92,7 @@ Image::Image(
     if (!image_)
     {
         std::string stbi_error = stbi_failure_reason();
-        throw std::runtime_error(fmt::format(
+        throw std::runtime_error(std::format(
             "unsupported file: [{}], reason: {}", file.string(), stbi_error));
     }
     free_ = true;

--- a/src/frame/file/obj.cpp
+++ b/src/frame/file/obj.cpp
@@ -3,7 +3,7 @@
 #include <fstream>
 #include <numeric>
 #define TINYOBJLOADER_IMPLEMENTATION // define this in only *one* .cc
-#include <fmt/core.h>
+#include <format>
 #include <tiny_obj_loader.h>
 
 #include "frame/file/file_system.h"
@@ -26,7 +26,7 @@ Obj::Obj(std::filesystem::path file_name)
             throw std::runtime_error(reader.Error());
         }
         throw std::runtime_error(
-            fmt::format("Unknown error parsing file [{}].", total_path));
+            std::format("Unknown error parsing file [{}].", total_path));
     }
 
     logger_->info("Opening OBJ File [{}].", total_path);
@@ -106,7 +106,7 @@ Obj::Obj(std::filesystem::path file_name)
                 if (fv != 3)
                 {
                     throw std::runtime_error(
-                        fmt::format(
+                        std::format(
                             "The face should be 3 in size now {}.", fv));
                 }
                 // Loop over vertices in the face.

--- a/src/frame/file/ply.cpp
+++ b/src/frame/file/ply.cpp
@@ -71,7 +71,7 @@ void GetElementFloat(
 {
     if (result.size() != SIZE)
         throw std::runtime_error(
-            fmt::format(
+            std::format(
                 "Result size is incorrect should be {} is {}",
                 SIZE,
                 result.size()));

--- a/src/frame/gui/CMakeLists.txt
+++ b/src/frame/gui/CMakeLists.txt
@@ -42,7 +42,6 @@ target_include_directories(FrameGui
 
 target_link_libraries(FrameGui
   PRIVATE
-    fmt::fmt
     glm::glm
     imgui::imgui
     spdlog::spdlog

--- a/src/frame/gui/window_camera.cpp
+++ b/src/frame/gui/window_camera.cpp
@@ -1,6 +1,6 @@
 #include "frame/gui/window_camera.h"
 
-#include <fmt/core.h>
+#include <format>
 #include <imgui.h>
 
 #include <glm/gtc/type_ptr.hpp>
@@ -30,7 +30,7 @@ bool WindowCamera::DrawCallback()
     }
     ImGui::Text(
         "%s",
-        fmt::format("Aspect ratio: {}", camera_ptr_->GetAspectRatio()).c_str());
+        std::format("Aspect ratio: {}", camera_ptr_->GetAspectRatio()).c_str());
     ImGui::Separator();
     ImGui::DragFloat3("Position", glm::value_ptr(position_));
     ImGui::DragFloat3("Front", glm::value_ptr(front_));

--- a/src/frame/gui/window_resolution.cpp
+++ b/src/frame/gui/window_resolution.cpp
@@ -1,6 +1,6 @@
 #include "frame/gui/window_resolution.h"
 
-#include <fmt/core.h>
+#include <format>
 #include <imgui.h>
 
 #include <glm/gtc/type_ptr.hpp>
@@ -29,7 +29,7 @@ WindowResolution::WindowResolution(
     }
     for (const auto& value : resolutions_)
     {
-        resolution_items_.push_back(fmt::format(
+        resolution_items_.push_back(std::format(
             "{} - {}x{}", value.name, value.values.x, value.values.y));
     }
     fullscreen_items_.push_back("Windowed");
@@ -105,8 +105,8 @@ bool WindowResolution::DrawCallback()
         ImGui::Checkbox("Invert Left and Right", &invert_left_right_);
     }
     ImGui::Separator();
-    ImGui::Text("%s", fmt::format("Horizontal PPI: {}", hppi_).c_str());
-    ImGui::Text("%s", fmt::format("Vertical PPI: {}", vppi_).c_str());
+    ImGui::Text("%s", std::format("Horizontal PPI: {}", hppi_).c_str());
+    ImGui::Text("%s", std::format("Vertical PPI: {}", vppi_).c_str());
     ImGui::Separator();
     if (ImGui::Button("Change"))
     {

--- a/src/frame/json/parse_level.cpp
+++ b/src/frame/json/parse_level.cpp
@@ -46,18 +46,18 @@ std::unique_ptr<LevelInterface> LevelProto(
         std::string texture_name = proto_texture.name();
         if (!texture)
         {
-            throw std::runtime_error(fmt::format(
+            throw std::runtime_error(std::format(
                 "Could not load texture: {}", proto_texture.file_name()));
         }
         texture->SetName(texture_name);
         texture_id = level->AddTexture(std::move(texture));
-        logger->info(fmt::format(
+        logger->info(std::format(
             "Add a new texture {}, with id [{}].",
             proto_texture.name(),
             texture_id));
         if (!texture_id)
         {
-            throw std::runtime_error(fmt::format(
+            throw std::runtime_error(std::format(
                 "Coudn't save texture {} to level.", proto_texture.name()));
         }
     }
@@ -74,12 +74,12 @@ std::unique_ptr<LevelInterface> LevelProto(
         if (!program)
         {
             throw std::runtime_error(
-                fmt::format("invalid program: {}", proto_program.name()));
+                std::format("invalid program: {}", proto_program.name()));
         }
         program->SetName(proto_program.name());
         if (!level->AddProgram(std::move(program)))
         {
-            throw std::runtime_error(fmt::format(
+            throw std::runtime_error(std::format(
                 "Couldn't save program {} to level.", proto_program.name()));
         }
     }
@@ -91,11 +91,11 @@ std::unique_ptr<LevelInterface> LevelProto(
         if (!material)
         {
             throw std::runtime_error(
-                fmt::format("invalid material : {}", proto_material.name()));
+                std::format("invalid material : {}", proto_material.name()));
         }
         if (!level->AddMaterial(std::move(material)))
         {
-            throw std::runtime_error(fmt::format(
+            throw std::runtime_error(std::format(
                 "Couldn't save material {} to level.", proto_material.name()));
         }
     }

--- a/src/frame/json/parse_material.cpp
+++ b/src/frame/json/parse_material.cpp
@@ -17,7 +17,7 @@ std::unique_ptr<frame::MaterialInterface> ParseMaterialOpenGL(
     if (texture_size != inner_size)
     {
         throw std::runtime_error(
-            fmt::format(
+            std::format(
                 "Not the same size for texture and inner names: {} != {}.",
                 texture_size,
                 inner_size));
@@ -28,7 +28,7 @@ std::unique_ptr<frame::MaterialInterface> ParseMaterialOpenGL(
     if (proto_material.program_name().empty())
     {
         throw std::runtime_error(
-            fmt::format("No program name in {}.", proto_material.name()));
+            std::format("No program name in {}.", proto_material.name()));
     }
     material->GetData().set_program_name(proto_material.program_name());
     auto maybe_program_id = level.GetIdFromName(proto_material.program_name());

--- a/src/frame/json/parse_program.cpp
+++ b/src/frame/json/parse_program.cpp
@@ -67,7 +67,7 @@ std::unique_ptr<frame::ProgramInterface> ParseProgramOpenGL(
     case proto::SceneType::NONE:
     default:
         throw std::runtime_error(
-            fmt::format(
+            std::format(
                 "No way {}?",
                 static_cast<int>(proto_program.input_scene_type().value())));
     }

--- a/src/frame/json/parse_scene_tree.cpp
+++ b/src/frame/json/parse_scene_tree.cpp
@@ -1,6 +1,6 @@
 #include "frame/json/parse_scene_tree.h"
 
-#include <fmt/core.h>
+#include <format>
 
 #include "frame/file/file_system.h"
 #include "frame/file/obj.h"
@@ -26,7 +26,7 @@ std::function<NodeInterface*(const std::string& name)> GetFunctor(
         auto maybe_id = level.GetIdFromName(name);
         if (!maybe_id)
         {
-            throw std::runtime_error(fmt::format("No id from name: {}", name));
+            throw std::runtime_error(std::format("No id from name: {}", name));
         }
         EntityId id = maybe_id;
         return &level.GetSceneNodeFromId(id);
@@ -122,7 +122,7 @@ std::function<NodeInterface*(const std::string& name)> GetFunctor(
     }
     default: {
         throw std::runtime_error(
-            fmt::format(
+            std::format(
                 "unknown mesh enum value: {}",
                 static_cast<int>(proto_scene_static_mesh.mesh_enum())));
     }
@@ -169,7 +169,7 @@ std::function<NodeInterface*(const std::string& name)> GetFunctor(
         mesh.GetData().set_file_name(proto_scene_static_mesh.file_name());
         mesh.GetData().set_render_primitive_enum(
             proto_scene_static_mesh.render_primitive_enum());
-        auto str = fmt::format("{}.{}", proto_scene_static_mesh.name(), i);
+        auto str = std::format("{}.{}", proto_scene_static_mesh.name(), i);
         mesh.SetName(str);
         auto& static_mesh_node = dynamic_cast<NodeStaticMesh&>(node);
         static_mesh_node.GetData().set_file_name(
@@ -377,7 +377,7 @@ std::function<NodeInterface*(const std::string& name)> GetFunctor(
         [[fallthrough]];
     default:
         throw std::runtime_error(
-            fmt::format(
+            std::format(
                 "Unknown scene light type {}",
                 static_cast<int>(proto_scene_light.light_type())));
     }

--- a/src/frame/level.cpp
+++ b/src/frame/level.cpp
@@ -211,7 +211,7 @@ void Level::RemoveBuffer(EntityId buffer_id)
     if (!id_buffer_map_.count(buffer_id))
     {
         throw std::runtime_error(
-            fmt::format("No buffer with id #{}.", buffer_id));
+            std::format("No buffer with id #{}.", buffer_id));
     }
     std::string name = id_name_map_.at(buffer_id);
     id_buffer_map_.erase(buffer_id);
@@ -360,7 +360,7 @@ void Level::ReplaceTexture(
     if (!texture)
     {
         throw std::runtime_error(
-            fmt::format("Invalid texture tried to be updated {}.", id));
+            std::format("Invalid texture tried to be updated {}.", id));
     }
     texture->Update(std::move(vector), size, bytes_per_pixel);
 }
@@ -371,7 +371,7 @@ void Level::ReplaceMesh(
     if (!id_static_mesh_map_.count(id))
     {
         throw std::runtime_error(
-            fmt::format(
+            std::format(
                 "trying to replace {} by {} but no mesh there yet?",
                 mesh->GetName(),
                 id));

--- a/src/frame/node_camera.cpp
+++ b/src/frame/node_camera.cpp
@@ -1,6 +1,6 @@
 #include "frame/node_camera.h"
 
-#include <fmt/core.h>
+#include <format>
 #include <stdexcept>
 
 namespace frame
@@ -16,7 +16,7 @@ glm::mat4 NodeCamera::GetLocalModel(const double dt) const
         if (!parent_node)
         {
             throw std::runtime_error(
-                fmt::format(
+                std::format(
                     "SceneCamera func({}) returned nullptr", GetParentName()));
         }
         return parent_node->GetLocalModel(dt);

--- a/src/frame/node_light.cpp
+++ b/src/frame/node_light.cpp
@@ -2,7 +2,7 @@
 
 #include "frame/json/serialize_uniform.h"
 
-#include <fmt/core.h>
+#include <format>
 #include <stdexcept>
 
 namespace frame
@@ -141,7 +141,7 @@ glm::mat4 NodeLight::GetLocalModel(const double dt) const
         if (!parent_node)
         {
             throw std::runtime_error(
-                fmt::format(
+                std::format(
                     "SceneLight func({}) returned nullptr", GetParentName()));
         }
         return parent_node->GetLocalModel(dt);

--- a/src/frame/node_matrix.cpp
+++ b/src/frame/node_matrix.cpp
@@ -1,6 +1,6 @@
 #include "frame/node_matrix.h"
 
-#include <fmt/core.h>
+#include <format>
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/quaternion.hpp>
@@ -94,7 +94,7 @@ glm::mat4 NodeMatrix::GetLocalModel(const double dt) const
         auto parent_node = func_(GetParentName());
         if (!parent_node)
         {
-            throw std::runtime_error(fmt::format(
+            throw std::runtime_error(std::format(
                 "SceneMatrix func({}) returned nullptr", GetParentName()));
         }
         return parent_node->GetLocalModel(dt) * ComputeLocalRotation(dt);

--- a/src/frame/node_static_mesh.cpp
+++ b/src/frame/node_static_mesh.cpp
@@ -1,6 +1,6 @@
 #include "frame/node_static_mesh.h"
 
-#include <fmt/core.h>
+#include <format>
 
 #include <stdexcept>
 
@@ -17,7 +17,7 @@ glm::mat4 NodeStaticMesh::GetLocalModel(const double dt) const
         if (!parent_node)
         {
             throw std::runtime_error(
-                fmt::format(
+                std::format(
                     "SceneStaticMesh func({}) returned nullptr",
                     GetParentName()));
         }

--- a/src/frame/opengl/cubemap.cpp
+++ b/src/frame/opengl/cubemap.cpp
@@ -628,7 +628,7 @@ proto::TextureFrame Cubemap::GetTextureFrameFromPosition(int i)
         texture_frame.set_value(proto::TextureFrame::CUBE_MAP_NEGATIVE_Z);
         break;
     default:
-        throw std::runtime_error(fmt::format("Invalid entry {}.", i));
+        throw std::runtime_error(std::format("Invalid entry {}.", i));
     }
     return texture_frame;
 }

--- a/src/frame/opengl/device.cpp
+++ b/src/frame/opengl/device.cpp
@@ -254,7 +254,7 @@ void Device::Display(double dt /*= 0.0*/)
             dt);
         break;
     default:
-        throw std::runtime_error(fmt::format(
+        throw std::runtime_error(std::format(
             "Unknown StereoEnum type {}.", static_cast<int>(stereo_enum_)));
     }
     // Reset viewport.

--- a/src/frame/opengl/file/load_static_mesh.cpp
+++ b/src/frame/opengl/file/load_static_mesh.cpp
@@ -84,10 +84,10 @@ std::optional<EntityId> LoadMaterialFromObj(
     if (!metallic)
         return std::nullopt;
     // Create names for textures.
-    auto color_name = fmt::format("{}.Color", material_obj.name);
-    auto normal_name = fmt::format("{}.Normal", material_obj.name);
-    auto roughness_name = fmt::format("{}.Roughness", material_obj.name);
-    auto metallic_name = fmt::format("{}.Metallic", material_obj.name);
+    auto color_name = std::format("{}.Color", material_obj.name);
+    auto normal_name = std::format("{}.Normal", material_obj.name);
+    auto roughness_name = std::format("{}.Roughness", material_obj.name);
+    auto metallic_name = std::format("{}.Metallic", material_obj.name);
     // Add texture to the level.
     color->SetName(color_name);
     auto color_id = level.AddTexture(std::move(color));
@@ -145,21 +145,21 @@ std::pair<EntityId, EntityId> LoadStaticMeshFromObj(
 
     // Point buffer initialization.
     auto maybe_point_buffer_id = CreateBufferInLevel(
-        level, points, fmt::format("{}.{}.point", name, counter));
+        level, points, std::format("{}.{}.point", name, counter));
     if (!maybe_point_buffer_id)
         return {NullId, NullId};
     EntityId point_buffer_id = maybe_point_buffer_id.value();
 
     // Normal buffer initialization.
     auto maybe_normal_buffer_id = CreateBufferInLevel(
-        level, normals, fmt::format("{}.{}.normal", name, counter));
+        level, normals, std::format("{}.{}.normal", name, counter));
     if (!maybe_normal_buffer_id)
         return {NullId, NullId};
     EntityId normal_buffer_id = maybe_normal_buffer_id.value();
 
     // Texture coordinates buffer initialization.
     auto maybe_tex_coord_buffer_id = CreateBufferInLevel(
-        level, textures, fmt::format("{}.{}.texture", name, counter));
+        level, textures, std::format("{}.{}.texture", name, counter));
     if (!maybe_tex_coord_buffer_id)
         return {NullId, NullId};
     EntityId tex_coord_buffer_id = maybe_tex_coord_buffer_id.value();
@@ -168,7 +168,7 @@ std::pair<EntityId, EntityId> LoadStaticMeshFromObj(
     auto maybe_index_buffer_id = CreateBufferInLevel(
         level,
         indices,
-        fmt::format("{}.{}.index", name, counter),
+        std::format("{}.{}.index", name, counter),
         opengl::BufferTypeEnum::ELEMENT_ARRAY_BUFFER);
     if (!maybe_index_buffer_id)
         return {NullId, NullId};
@@ -188,7 +188,7 @@ std::pair<EntityId, EntityId> LoadStaticMeshFromObj(
         }
         material_id = material_ids[0];
     }
-    std::string mesh_name = fmt::format("{}.{}", name, counter);
+    std::string mesh_name = std::format("{}.{}", name, counter);
     static_mesh->SetName(mesh_name);
     auto maybe_mesh_id = level.AddStaticMesh(std::move(static_mesh));
     if (!maybe_mesh_id)
@@ -231,28 +231,28 @@ EntityId LoadStaticMeshFromPly(
 
     // Point buffer initialization.
     auto maybe_point_buffer_id =
-        CreateBufferInLevel(level, points, fmt::format("{}.point", name));
+        CreateBufferInLevel(level, points, std::format("{}.point", name));
     if (!maybe_point_buffer_id)
         return NullId;
     EntityId point_buffer_id = maybe_point_buffer_id.value();
 
     // Color buffer initialization.
     auto maybe_color_buffer_id =
-        CreateBufferInLevel(level, colors, fmt::format("{}.color", name));
+        CreateBufferInLevel(level, colors, std::format("{}.color", name));
     if (!maybe_color_buffer_id)
         return NullId;
     EntityId color_buffer_id = maybe_color_buffer_id.value();
 
     // Normal buffer initialization.
     auto maybe_normal_buffer_id =
-        CreateBufferInLevel(level, normals, fmt::format("{}.normal", name));
+        CreateBufferInLevel(level, normals, std::format("{}.normal", name));
     if (!maybe_normal_buffer_id)
         return NullId;
     EntityId normal_buffer_id = maybe_normal_buffer_id.value();
 
     // Texture coordinates buffer initialization.
     auto maybe_tex_coord_buffer_id =
-        CreateBufferInLevel(level, textures, fmt::format("{}.texture", name));
+        CreateBufferInLevel(level, textures, std::format("{}.texture", name));
     if (!maybe_tex_coord_buffer_id)
         return NullId;
     EntityId tex_coord_buffer_id = maybe_tex_coord_buffer_id.value();
@@ -261,7 +261,7 @@ EntityId LoadStaticMeshFromPly(
     auto maybe_index_buffer_id = CreateBufferInLevel(
         level,
         indices,
-        fmt::format("{}.index", name),
+        std::format("{}.index", name),
         opengl::BufferTypeEnum::ELEMENT_ARRAY_BUFFER);
     if (!maybe_index_buffer_id)
         return NullId;
@@ -288,7 +288,7 @@ EntityId LoadStaticMeshFromPly(
     }
 
     static_mesh = std::make_unique<opengl::StaticMesh>(level, parameter);
-    std::string mesh_name = fmt::format("{}", name);
+    std::string mesh_name = std::format("{}", name);
     static_mesh->SetName(mesh_name);
     auto maybe_mesh_id = level.AddStaticMesh(std::move(static_mesh));
     if (!maybe_mesh_id)
@@ -328,12 +328,12 @@ std::vector<EntityId> LoadStaticMeshesFromObjFile(
             if (!maybe_id)
             {
                 throw std::runtime_error(
-                    fmt::format("no id for name: {}", name));
+                    std::format("no id for name: {}", name));
             }
             return &level.GetSceneNodeFromId(maybe_id);
         };
         auto ptr = std::make_unique<NodeStaticMesh>(func, static_mesh_id);
-        ptr->SetName(fmt::format("Node.{}.{}", name, mesh_counter));
+        ptr->SetName(std::format("Node.{}.{}", name, mesh_counter));
         auto maybe_id = level.AddSceneNode(std::move(ptr));
         if (!maybe_id)
         {
@@ -369,12 +369,12 @@ EntityId LoadStaticMeshFromPlyFile(
         auto maybe_id = level.GetIdFromName(name);
         if (!maybe_id)
         {
-            throw std::runtime_error(fmt::format("no id for name: {}", name));
+            throw std::runtime_error(std::format("no id for name: {}", name));
         }
         return &level.GetSceneNodeFromId(maybe_id);
     };
     auto ptr = std::make_unique<NodeStaticMesh>(func, static_mesh_id);
-    ptr->SetName(fmt::format("Node.{}", name));
+    ptr->SetName(std::format("Node.{}", name));
     auto maybe_id = level.AddSceneNode(std::move(ptr));
     if (!maybe_id)
         return NullId;

--- a/src/frame/opengl/frame_buffer.cpp
+++ b/src/frame/opengl/frame_buffer.cpp
@@ -46,7 +46,7 @@ void FrameBuffer::AttachRender(const RenderBuffer& render) const
     {
         auto error_pair = GetError();
         throw std::runtime_error(
-            fmt::format("{} - {}", error_pair.first, error_pair.second));
+            std::format("{} - {}", error_pair.first, error_pair.second));
     }
     render.UnBind();
     UnBind();

--- a/src/frame/opengl/gui/CMakeLists.txt
+++ b/src/frame/opengl/gui/CMakeLists.txt
@@ -16,7 +16,6 @@ target_include_directories(FrameOpenGLGui
 
 target_link_libraries(FrameOpenGLGui
   PRIVATE
-    fmt::fmt
     Frame
     FrameGui
     FrameOpenGL

--- a/src/frame/opengl/message_callback.cpp
+++ b/src/frame/opengl/message_callback.cpp
@@ -92,7 +92,7 @@ void GLAPIENTRY MessageCallback(
     const void* userParam)
 {
     Logger& logger = Logger::GetInstance();
-    std::string str_message = fmt::format(
+    std::string str_message = std::format(
         "GL: {} (source [{}], type [{}], severity [{}])",
         message,
         Source2String(source),

--- a/src/frame/opengl/program.cpp
+++ b/src/frame/opengl/program.cpp
@@ -86,7 +86,7 @@ const UniformInterface& Program::GetUniform(const std::string& name) const
     if (!HasUniform(name))
     {
         throw std::runtime_error(
-            fmt::format(
+            std::format(
                 "Uniform [{}] not found in program [{}].", name, name_));
     }
     auto it = uniform_map_.find(name);
@@ -190,7 +190,7 @@ void Program::AddUniformInternal(
     }
     default:
         logger_->error(
-            fmt::format(
+            std::format(
                 "Unknown uniform type [{}] for uniform [{}].",
                 static_cast<int>(uniform_ptr->GetData().type()),
                 name));
@@ -293,7 +293,7 @@ int Program::GetMemoizeUniformLocation(const std::string& name) const
         {
             GLenum error = glGetError();
             throw std::runtime_error(
-                fmt::format(
+                std::format(
                     "Could not get a location for uniform [{}] error: {}.",
                     name,
                     error));

--- a/src/frame/opengl/renderer.cpp
+++ b/src/frame/opengl/renderer.cpp
@@ -1,7 +1,7 @@
 #include "renderer.h"
 
 #include <GL/glew.h>
-#include <fmt/core.h>
+#include <format>
 #include <glm/gtc/type_ptr.hpp>
 
 #include <format>
@@ -411,7 +411,7 @@ void Renderer::RenderShadows(const CameraInterface& camera)
         if (texture_id == NullId)
         {
             throw std::runtime_error(
-                fmt::format(
+                std::format(
                     "Couldn't find texture {} for light {}",
                     texture_name,
                     light.GetName()));

--- a/src/frame/opengl/sdl_opengl_none.cpp
+++ b/src/frame/opengl/sdl_opengl_none.cpp
@@ -49,7 +49,7 @@ SDLOpenGLNone::SDLOpenGLNone(glm::uvec2 size) : size_(size)
     if (!gl_context_)
     {
         throw std::runtime_error(
-            fmt::format("Failed to create GL context: {}", SDL_GetError()));
+            std::format("Failed to create GL context: {}", SDL_GetError()));
     }
 
     // Set as current
@@ -116,7 +116,7 @@ void* SDLOpenGLNone::GetGraphicContext() const
     auto result = glewInit();
     if (result != GLEW_OK)
     {
-        throw std::runtime_error(fmt::format(
+        throw std::runtime_error(std::format(
             "GLEW problems : {}",
             reinterpret_cast<const char*>(glewGetErrorString(result))));
     }

--- a/src/frame/opengl/sdl_opengl_none.h
+++ b/src/frame/opengl/sdl_opengl_none.h
@@ -3,7 +3,7 @@
 #define NOMINMAX
 #include <GL/glew.h>
 #include <SDL3/SDL.h>
-#include <fmt/core.h>
+#include <format>
 
 #include <stdexcept>
 

--- a/src/frame/opengl/sdl_opengl_window.cpp
+++ b/src/frame/opengl/sdl_opengl_window.cpp
@@ -62,7 +62,7 @@ SDLOpenGLWindow::SDLOpenGLWindow(glm::uvec2 size) : size_(size)
     if (!gl_context_)
     {
         throw std::runtime_error(
-            fmt::format("Failed to create GL context: {}", SDL_GetError()));
+            std::format("Failed to create GL context: {}", SDL_GetError()));
     }
 
     // Set as current
@@ -353,14 +353,14 @@ void SDLOpenGLWindow::Resize(glm::uvec2 size, FullScreenEnum fullscreen_enum)
             SDL_DisplayID display = SDL_GetDisplayForWindow(sdl_window_);
             if (!display)
             {
-                throw std::runtime_error(fmt::format(
+                throw std::runtime_error(std::format(
                     "SDL_GetDisplayForWindow failed: {}", SDL_GetError()));
             }
 
             SDL_Rect bounds;
             if (!SDL_GetDisplayBounds(display, &bounds))
             {
-                throw std::runtime_error(fmt::format(
+                throw std::runtime_error(std::format(
                     "SDL_GetDisplayBounds failed: {}", SDL_GetError()));
             }
 

--- a/src/frame/opengl/static_mesh.cpp
+++ b/src/frame/opengl/static_mesh.cpp
@@ -71,7 +71,7 @@ StaticMesh::StaticMesh(
         std::fill(color.begin(), color.end(), 1.0f);
         std::unique_ptr<BufferInterface> gl_color_buffer =
             std::make_unique<Buffer>();
-        gl_color_buffer->SetName(fmt::format("Mesh.Buffer.Color.{}", count));
+        gl_color_buffer->SetName(std::format("Mesh.Buffer.Color.{}", count));
         gl_color_buffer->Copy(color);
         color_buffer_id_ = level_.AddBuffer(std::move(gl_color_buffer));
         auto& color_buffer_ref =
@@ -116,7 +116,7 @@ StaticMesh::StaticMesh(
         }
         std::unique_ptr<BufferInterface> gl_normal_buffer =
             std::make_unique<Buffer>();
-        gl_normal_buffer->SetName(fmt::format("Mesh.Buffer.Normal.{}", count));
+        gl_normal_buffer->SetName(std::format("Mesh.Buffer.Normal.{}", count));
         gl_normal_buffer->Copy(normal);
         normal_buffer_id_ = level_.AddBuffer(std::move(gl_normal_buffer));
         auto& normal_buffer_ref =
@@ -161,7 +161,7 @@ StaticMesh::StaticMesh(
         std::unique_ptr<BufferInterface> gl_texture_coordinate =
             std::make_unique<Buffer>();
         gl_texture_coordinate->SetName(
-            fmt::format("Mesh.Buffer.TexCoord.{}", count));
+            std::format("Mesh.Buffer.TexCoord.{}", count));
         gl_texture_coordinate->Copy(texture_coordinate);
         texture_buffer_id_ = level_.AddBuffer(std::move(gl_texture_coordinate));
         auto& texture_buffer_ref =
@@ -202,7 +202,7 @@ StaticMesh::StaticMesh(
             std::make_unique<Buffer>(
                 BufferTypeEnum::ELEMENT_ARRAY_BUFFER,
                 BufferUsageEnum::STREAM_DRAW);
-        gl_index_buffer->SetName(fmt::format("Mesh.Buffer.Index.{}", count));
+        gl_index_buffer->SetName(std::format("Mesh.Buffer.Index.{}", count));
         gl_index_buffer->Copy(index);
         index_buffer_id_ = level_.AddBuffer(std::move(gl_index_buffer));
     }
@@ -321,10 +321,10 @@ EntityId CreateQuadStaticMesh(LevelInterface& level)
     index_buffer->Copy(indices);
     static std::int64_t count = 0;
     count++;
-    point_buffer->SetName(fmt::format("QuadPoint.{}", count));
-    normal_buffer->SetName(fmt::format("QuadNormal.{}", count));
-    texture_buffer->SetName(fmt::format("QuadTexture.{}", count));
-    index_buffer->SetName(fmt::format("QuadIndex.{}", count));
+    point_buffer->SetName(std::format("QuadPoint.{}", count));
+    normal_buffer->SetName(std::format("QuadNormal.{}", count));
+    texture_buffer->SetName(std::format("QuadTexture.{}", count));
+    index_buffer->SetName(std::format("QuadIndex.{}", count));
     auto maybe_point_buffer_id = level.AddBuffer(std::move(point_buffer));
     if (!maybe_point_buffer_id)
         return NullId;
@@ -345,7 +345,7 @@ EntityId CreateQuadStaticMesh(LevelInterface& level)
     parameter.render_primitive_enum =
         proto::NodeStaticMesh::TRIANGLE_PRIMITIVE;
     auto mesh = std::make_unique<StaticMesh>(level, parameter);
-    mesh->SetName(fmt::format("QuadMesh.{}", count));
+    mesh->SetName(std::format("QuadMesh.{}", count));
     return level.AddStaticMesh(std::move(mesh));
 }
 
@@ -504,10 +504,10 @@ EntityId CreateCubeStaticMesh(LevelInterface& level)
     index_buffer->Copy(indices);
     static std::int64_t count = 0;
     count++;
-    point_buffer->SetName(fmt::format("CubePoint.{}", count));
-    normal_buffer->SetName(fmt::format("CubeNormal.{}", count));
-    texture_buffer->SetName(fmt::format("CubeTexture.{}", count));
-    index_buffer->SetName(fmt::format("CubeIndex.{}", count));
+    point_buffer->SetName(std::format("CubePoint.{}", count));
+    normal_buffer->SetName(std::format("CubeNormal.{}", count));
+    texture_buffer->SetName(std::format("CubeTexture.{}", count));
+    index_buffer->SetName(std::format("CubeIndex.{}", count));
     auto maybe_point_buffer_id = level.AddBuffer(std::move(point_buffer));
     if (!maybe_point_buffer_id)
         return NullId;
@@ -528,7 +528,7 @@ EntityId CreateCubeStaticMesh(LevelInterface& level)
     parameter.render_primitive_enum =
         proto::NodeStaticMesh::TRIANGLE_PRIMITIVE;
     auto mesh = std::make_unique<StaticMesh>(level, parameter);
-    mesh->SetName(fmt::format("CubeMesh.{}", count));
+    mesh->SetName(std::format("CubeMesh.{}", count));
     return level.AddStaticMesh(std::move(mesh));
 }
 

--- a/src/frame/opengl/win32_opengl_none.cpp
+++ b/src/frame/opengl/win32_opengl_none.cpp
@@ -120,11 +120,11 @@ void* Win32OpenGLNone::GetGraphicContext() const
 
     // Check OpenGL versions.
     const char* version = (const char*)glGetString(GL_VERSION);
-    logger_->info(fmt::format("Version  : {}", version));
+    logger_->info(std::format("Version  : {}", version));
     const char* vendor = (const char*)glGetString(GL_VENDOR);
-    logger_->info(fmt::format("Vendor   : {}", vendor));
+    logger_->info(std::format("Vendor   : {}", vendor));
     const char* renderer = (const char*)glGetString(GL_RENDERER);
-    logger_->info(fmt::format("Renderer : {}", renderer));
+    logger_->info(std::format("Renderer : {}", renderer));
 
 #if defined(_WIN32) || defined(_WIN64)
     if (wglewIsSupported("WGL_ARB_create_context"))

--- a/src/frame/vulkan/sdl_vulkan_none.cpp
+++ b/src/frame/vulkan/sdl_vulkan_none.cpp
@@ -15,7 +15,7 @@ SDLVulkanNone::SDLVulkanNone(glm::uvec2 size) : size_(size)
     if (SDL_Init(SDL_INIT_VIDEO) != 0)
     {
         throw std::runtime_error(
-            fmt::format("Couldn't initialize SDL: {}", SDL_GetError()));
+            std::format("Couldn't initialize SDL: {}", SDL_GetError()));
     }
 
     // Create an SDL window to use as a surface for Vulkan.
@@ -27,7 +27,7 @@ SDLVulkanNone::SDLVulkanNone(glm::uvec2 size) : size_(size)
     if (!sdl_window_)
     {
         throw std::runtime_error(
-            fmt::format("Couldn't initialize window: {}", SDL_GetError()));
+            std::format("Couldn't initialize window: {}", SDL_GetError()));
     }
 
     // Get the required extensions for creating a Vulkan surface.
@@ -41,7 +41,7 @@ SDLVulkanNone::SDLVulkanNone(glm::uvec2 size) : size_(size)
     }
     if (extension_count == 0)
     {
-        throw std::runtime_error(fmt::format(
+        throw std::runtime_error(std::format(
             "Could not get the extension count: {}", SDL_GetError()));
     }
 
@@ -91,7 +91,7 @@ SDLVulkanNone::SDLVulkanNone(glm::uvec2 size) : size_(size)
     if (!SDL_Vulkan_CreateSurface(
             sdl_window_, *vk_unique_instance_, nullptr, &vk_surface))
     {
-        throw std::runtime_error(fmt::format(
+        throw std::runtime_error(std::format(
             "Error while create vulkan surface: {}", SDL_GetError()));
     }
     vk_surface_ = vk::UniqueSurfaceKHR(vk_surface);

--- a/src/frame/vulkan/sdl_vulkan_window.cpp
+++ b/src/frame/vulkan/sdl_vulkan_window.cpp
@@ -16,13 +16,13 @@ SDLVulkanWindow::SDLVulkanWindow(glm::uvec2 size) : size_(size)
     if (!SDL_Init(SDL_INIT_VIDEO))
     {
         throw std::runtime_error(
-            fmt::format("Couldn't initialize SDL: {}", SDL_GetError()));
+            std::format("Couldn't initialize SDL: {}", SDL_GetError()));
     }
 
     if (!SDL_Vulkan_LoadLibrary(nullptr))
     {
         throw std::runtime_error(
-            fmt::format("Couldn't load Vulkan library: {}", SDL_GetError()));
+            std::format("Couldn't load Vulkan library: {}", SDL_GetError()));
     }
 
     // Create an SDL window to use as a surface for Vulkan.
@@ -34,7 +34,7 @@ SDLVulkanWindow::SDLVulkanWindow(glm::uvec2 size) : size_(size)
     if (!sdl_window_)
     {
         throw std::runtime_error(
-            fmt::format("Couldn't initialize window: {}", SDL_GetError()));
+            std::format("Couldn't initialize window: {}", SDL_GetError()));
     }
 
     // Get the required extensions for creating a Vulkan surface.
@@ -48,7 +48,7 @@ SDLVulkanWindow::SDLVulkanWindow(glm::uvec2 size) : size_(size)
     }
     if (extension_count == 0)
     {
-        throw std::runtime_error(fmt::format(
+        throw std::runtime_error(std::format(
             "Could not get the extension count: {}", SDL_GetError()));
     }
 #ifdef VK_EXT_ENABLE_DEBUG_EXTENSION
@@ -94,7 +94,7 @@ SDLVulkanWindow::SDLVulkanWindow(glm::uvec2 size) : size_(size)
     if (!SDL_Vulkan_CreateSurface(
             sdl_window_, *vk_unique_instance_, nullptr, &vk_surface))
     {
-        throw std::runtime_error(fmt::format(
+        throw std::runtime_error(std::format(
             "Error while create vulkan surface: {}", SDL_GetError()));
     }
     vk_surface_ = vk::UniqueSurfaceKHR(vk_surface);
@@ -210,14 +210,14 @@ void SDLVulkanWindow::Resize(glm::uvec2 size, FullScreenEnum fullscreen_enum)
             SDL_DisplayID display = SDL_GetDisplayForWindow(sdl_window_);
             if (!display)
             {
-                throw std::runtime_error(fmt::format(
+                throw std::runtime_error(std::format(
                     "SDL_GetDisplayForWindow failed: {}", SDL_GetError()));
             }
 
             SDL_Rect bounds;
             if (!SDL_GetDisplayBounds(display, &bounds))
             {
-                throw std::runtime_error(fmt::format(
+                throw std::runtime_error(std::format(
                     "SDL_GetDisplayBounds failed: {}", SDL_GetError()));
             }
 
@@ -236,7 +236,7 @@ void SDLVulkanWindow::Resize(glm::uvec2 size, FullScreenEnum fullscreen_enum)
 
         if (!SDL_SetWindowFullscreenMode(sdl_window_, mode_ptr))
         {
-            throw std::runtime_error(fmt::format(
+            throw std::runtime_error(std::format(
                 "Error switching fullscreen mode: {}", SDL_GetError()));
         }
 

--- a/tests/frame/opengl/device_test.cpp
+++ b/tests/frame/opengl/device_test.cpp
@@ -70,14 +70,14 @@ TEST_F(DeviceTest, AddManyDifferentPluginTest)
     {
         auto plugin = std::make_unique<test::PluginMock>();
         EXPECT_CALL(*plugin, GetName)
-            .WillRepeatedly(Return(fmt::format("test{}", i)));
+            .WillRepeatedly(Return(std::format("test{}", i)));
         device.AddPlugin(std::move(plugin));
     }
     EXPECT_EQ(8, device.GetPluginPtrs().size());
     std::vector<std::string> vec;
     for (int i = 0; i < 8; ++i)
     {
-        vec.push_back(fmt::format("test{}", i));
+        vec.push_back(std::format("test{}", i));
     }
     EXPECT_EQ(vec, device.GetPluginNames());
     for (int i = 0; i < 8; ++i)


### PR DESCRIPTION
## Summary
- drop fmt::fmt linkage in CMake
- replace `fmt::format` with `std::format`
- switch all `#include <fmt/core.h>` to `<format>`

## Testing
- `cmake --preset linux-debug` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_68594d80a9148329afc970a311e0c233