### PR TITLE
Fix Windows build error

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,6 @@
   "description": "Frame graphic library.",
   "dependencies": [
     "abseil",
-    "boost-regex",
     "glm",
     "glew",
     "gtest",


### PR DESCRIPTION
## Summary
- remove unused boost-regex dependency

## Testing
- `git submodule update --init --recursive` *(fails: network unreachable)*
- `cmake --preset linux-debug` *(fails: vcpkg install failed)*

------
https://chatgpt.com/codex/tasks/task_e_685da44aa7fc8329afb553306922a4af