### PR TITLE
Fix missing Boost regex on Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package(protobuf CONFIG REQUIRED)
 find_package(SDL3 CONFIG REQUIRED)
 find_package(spdlog CONFIG REQUIRED)
 find_package(tinyobjloader CONFIG REQUIRED)
+find_package(boost_regex CONFIG REQUIRED)
 find_package(imgui CONFIG REQUIRED)
 find_package(Vulkan REQUIRED)
 

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(FrameEditor
     FrameOpenGLFile
     FrameProto
     imgui::imgui
+    ImGuiColorTextEdit
 )
 
 set_property(TARGET FrameEditor PROPERTY FOLDER "FrameEditor")

--- a/src/frame/gui/CMakeLists.txt
+++ b/src/frame/gui/CMakeLists.txt
@@ -43,12 +43,13 @@ target_include_directories(FrameGui
 )
 
 target_link_libraries(FrameGui
+  PUBLIC
+    ImGuiColorTextEdit
   PRIVATE
     glm::glm
     imgui::imgui
     spdlog::spdlog
     protobuf::libprotobuf
-    ImGuiColorTextEdit
 )
 
 set_property(TARGET FrameGui PROPERTY FOLDER "Frame")

--- a/src/frame/gui/CMakeLists.txt
+++ b/src/frame/gui/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries(FrameGui
     glm::glm
     imgui::imgui
     spdlog::spdlog
+    boost_regex
     protobuf::libprotobuf
     ImGuiColorTextEdit
 )

--- a/src/frame/gui/CMakeLists.txt
+++ b/src/frame/gui/CMakeLists.txt
@@ -38,12 +38,12 @@ target_include_directories(FrameGui
   PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../src
-  ${CMAME_CURRENT_BINARY_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../external/ImGuiColorTextEdit
 )
 
 target_link_libraries(FrameGui
-  PRIVATE
+  PUBLIC
     glm::glm
     imgui::imgui
     spdlog::spdlog

--- a/src/frame/gui/CMakeLists.txt
+++ b/src/frame/gui/CMakeLists.txt
@@ -43,11 +43,10 @@ target_include_directories(FrameGui
 )
 
 target_link_libraries(FrameGui
-  PUBLIC
+  PRIVATE
     glm::glm
     imgui::imgui
     spdlog::spdlog
-    boost_regex
     protobuf::libprotobuf
     ImGuiColorTextEdit
 )


### PR DESCRIPTION
## Summary
- update `FrameGui` library to propagate dependencies
- correct typo in include directory path

Linking with Visual Studio failed because `boost_regex.lib` was missing for
executables that depend on `FrameGui`. The `ImGuiColorTextEdit` target, which
requires Boost Regex, was linked privately so its dependencies were not passed to
consumers. Making the link public resolves this and also fixes an include path
typo.

## Testing
- `cmake --preset linux-debug` *(fails: vcpkg install failed, Ninja not found)*

------
https://chatgpt.com/codex/tasks/task_e_685daeff9f608329b6658bcab5b092e6