### PR TITLE
Add BOOST_REGEX_NO_LIB definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ find_package(Vulkan REQUIRED)
 
 # Sources.
 add_subdirectory(external/ImGuiColorTextEdit)
+target_compile_definitions(ImGuiColorTextEdit PUBLIC BOOST_REGEX_NO_LIB)
 add_subdirectory(asset/shader/opengl)
 add_subdirectory(asset/json)
 add_subdirectory(src/frame)


### PR DESCRIPTION
## Summary
- add BOOST_REGEX_NO_LIB to ImGuiColorTextEdit target

## Testing
- `cmake --preset windows` *(fails: Could not create named generator Visual Studio 17 2022)*
- `cmake --preset linux-debug` *(fails: CMAKE_MAKE_PROGRAM is not set)*

------
https://chatgpt.com/codex/tasks/task_e_685e3a663e0083298153e666560649d9