### PR TITLE
Fix text input when regaining focus

### DIFF
--- a/src/frame/opengl/sdl_opengl_window.cpp
+++ b/src/frame/opengl/sdl_opengl_window.cpp
@@ -112,7 +112,6 @@ SDLOpenGLWindow::~SDLOpenGLWindow()
 
 WindowReturnEnum SDLOpenGLWindow::Run(std::function<bool()> lambda)
 {
-    SDL_StartTextInput(sdl_window_);
     // Called only once at the beginning.
     for (const auto& plugin_interface : device_->GetPluginPtrs())
     {
@@ -199,7 +198,7 @@ bool SDLOpenGLWindow::RunEvent(const SDL_Event& event, const double dt)
     }
     if (event.type == SDL_EVENT_WINDOW_FOCUS_LOST)
     {
-        SDL_StopTextInput();
+        SDL_StopTextInput(sdl_window_);
     }
     bool has_window_plugin = false;
     for (PluginInterface* plugin : device_->GetPluginPtrs())

--- a/src/frame/opengl/sdl_opengl_window.cpp
+++ b/src/frame/opengl/sdl_opengl_window.cpp
@@ -193,6 +193,14 @@ bool SDLOpenGLWindow::RunEvent(const SDL_Event& event, const double dt)
     {
         return false;
     }
+    if (event.type == SDL_EVENT_WINDOW_FOCUS_GAINED)
+    {
+        SDL_StartTextInput(sdl_window_);
+    }
+    if (event.type == SDL_EVENT_WINDOW_FOCUS_LOST)
+    {
+        SDL_StopTextInput();
+    }
     bool has_window_plugin = false;
     for (PluginInterface* plugin : device_->GetPluginPtrs())
     {

--- a/src/frame/vulkan/sdl_vulkan_window.cpp
+++ b/src/frame/vulkan/sdl_vulkan_window.cpp
@@ -266,7 +266,7 @@ bool SDLVulkanWindow::RunEvent(const SDL_Event& event, const double dt)
     }
     if (event.type == SDL_EVENT_WINDOW_FOCUS_LOST)
     {
-        SDL_StopTextInput();
+        SDL_StopTextInput(sdl_window_);
     }
     bool has_window_plugin = false;
     for (PluginInterface* plugin : device_->GetPluginPtrs())

--- a/src/frame/vulkan/sdl_vulkan_window.cpp
+++ b/src/frame/vulkan/sdl_vulkan_window.cpp
@@ -260,6 +260,14 @@ bool SDLVulkanWindow::RunEvent(const SDL_Event& event, const double dt)
 {
     if (event.type == SDL_EVENT_QUIT)
         return false;
+    if (event.type == SDL_EVENT_WINDOW_FOCUS_GAINED)
+    {
+        SDL_StartTextInput(sdl_window_);
+    }
+    if (event.type == SDL_EVENT_WINDOW_FOCUS_LOST)
+    {
+        SDL_StopTextInput();
+    }
     bool has_window_plugin = false;
     for (PluginInterface* plugin : device_->GetPluginPtrs())
     {


### PR DESCRIPTION
## Summary
- restart SDL text input whenever the window regains focus
- stop text input when focus is lost

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "absl")*

------
https://chatgpt.com/codex/tasks/task_e_685eb922fa048329ba6b958308b4b5fc