### PR TITLE
Fix SDL text input focus with multiple windows

### DIFF
--- a/src/frame/opengl/sdl_opengl_window.cpp
+++ b/src/frame/opengl/sdl_opengl_window.cpp
@@ -192,11 +192,14 @@ bool SDLOpenGLWindow::RunEvent(const SDL_Event& event, const double dt)
     {
         return false;
     }
-    if (event.type == SDL_EVENT_WINDOW_FOCUS_GAINED)
+    const Uint32 this_window_id = SDL_GetWindowID(sdl_window_);
+    if (event.type == SDL_EVENT_WINDOW_FOCUS_GAINED &&
+        event.window.windowID == this_window_id)
     {
         SDL_StartTextInput(sdl_window_);
     }
-    if (event.type == SDL_EVENT_WINDOW_FOCUS_LOST)
+    if (event.type == SDL_EVENT_WINDOW_FOCUS_LOST &&
+        event.window.windowID == this_window_id)
     {
         SDL_StopTextInput(sdl_window_);
     }
@@ -208,7 +211,8 @@ bool SDLOpenGLWindow::RunEvent(const SDL_Event& event, const double dt)
             has_window_plugin = true;
         }
     }
-    if (event.type == SDL_EVENT_KEY_DOWN)
+    if (event.type == SDL_EVENT_KEY_DOWN &&
+        event.key.windowID == this_window_id)
     {
         switch (event.key.key)
         {
@@ -241,32 +245,38 @@ bool SDLOpenGLWindow::RunEvent(const SDL_Event& event, const double dt)
     }
     if (input_interface_)
     {
-        if (event.type == SDL_EVENT_KEY_DOWN)
+        if (event.type == SDL_EVENT_KEY_DOWN &&
+            event.key.windowID == this_window_id)
         {
             return input_interface_->KeyPressed(event.key.key, dt);
         }
-        if (event.type == SDL_EVENT_KEY_UP)
+        if (event.type == SDL_EVENT_KEY_UP &&
+            event.key.windowID == this_window_id)
         {
             return input_interface_->KeyReleased(event.key.key, dt);
         }
-        if (event.type == SDL_EVENT_MOUSE_MOTION)
+        if (event.type == SDL_EVENT_MOUSE_MOTION &&
+            event.motion.windowID == this_window_id)
         {
             return input_interface_->MouseMoved(
                 glm::vec2(event.motion.x, event.motion.y),
                 glm::vec2(event.motion.xrel, event.motion.yrel),
                 dt);
         }
-        if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN)
+        if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN &&
+            event.button.windowID == this_window_id)
         {
             return input_interface_->MousePressed(
                 SDLButtonToChar(event.button.button), dt);
         }
-        if (event.type == SDL_EVENT_MOUSE_BUTTON_UP)
+        if (event.type == SDL_EVENT_MOUSE_BUTTON_UP &&
+            event.button.windowID == this_window_id)
         {
             return input_interface_->MouseReleased(
                 SDLButtonToChar(event.button.button), dt);
         }
-        if (event.type == SDL_EVENT_MOUSE_WHEEL && event.wheel.y != 0)
+        if (event.type == SDL_EVENT_MOUSE_WHEEL &&
+            event.wheel.windowID == this_window_id && event.wheel.y != 0)
         {
             return input_interface_->WheelMoved(
                 static_cast<float>(event.wheel.y), dt);

--- a/src/frame/vulkan/sdl_vulkan_window.cpp
+++ b/src/frame/vulkan/sdl_vulkan_window.cpp
@@ -260,11 +260,14 @@ bool SDLVulkanWindow::RunEvent(const SDL_Event& event, const double dt)
 {
     if (event.type == SDL_EVENT_QUIT)
         return false;
-    if (event.type == SDL_EVENT_WINDOW_FOCUS_GAINED)
+    const Uint32 this_window_id = SDL_GetWindowID(sdl_window_);
+    if (event.type == SDL_EVENT_WINDOW_FOCUS_GAINED &&
+        event.window.windowID == this_window_id)
     {
         SDL_StartTextInput(sdl_window_);
     }
-    if (event.type == SDL_EVENT_WINDOW_FOCUS_LOST)
+    if (event.type == SDL_EVENT_WINDOW_FOCUS_LOST &&
+        event.window.windowID == this_window_id)
     {
         SDL_StopTextInput(sdl_window_);
     }
@@ -274,7 +277,8 @@ bool SDLVulkanWindow::RunEvent(const SDL_Event& event, const double dt)
         if (dynamic_cast<frame::gui::DrawGuiInterface*>(plugin))
             has_window_plugin = true;
     }
-    if (event.type == SDL_EVENT_KEY_DOWN)
+    if (event.type == SDL_EVENT_KEY_DOWN &&
+        event.key.windowID == this_window_id)
     {
         switch (event.key.key)
         {
@@ -302,33 +306,38 @@ bool SDLVulkanWindow::RunEvent(const SDL_Event& event, const double dt)
     }
     if (input_interface_)
     {
-        if (event.type == SDL_EVENT_KEY_DOWN)
+        if (event.type == SDL_EVENT_KEY_DOWN &&
+            event.key.windowID == this_window_id)
         {
             return input_interface_->KeyPressed(event.key.key, dt);
         }
-        if (event.type == SDL_EVENT_KEY_UP)
+        if (event.type == SDL_EVENT_KEY_UP &&
+            event.key.windowID == this_window_id)
         {
             return input_interface_->KeyReleased(event.key.key, dt);
         }
-        if (event.type == SDL_EVENT_MOUSE_MOTION)
+        if (event.type == SDL_EVENT_MOUSE_MOTION &&
+            event.motion.windowID == this_window_id)
         {
             return input_interface_->MouseMoved(
                 glm::vec2(event.motion.x, event.motion.y),
                 glm::vec2(event.motion.xrel, event.motion.yrel),
                 dt);
         }
-        if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN)
+        if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN &&
+            event.button.windowID == this_window_id)
         {
             return input_interface_->MousePressed(
                 SDLButtonToChar(event.button.button), dt);
         }
-        if (event.type == SDL_EVENT_MOUSE_BUTTON_UP)
+        if (event.type == SDL_EVENT_MOUSE_BUTTON_UP &&
+            event.button.windowID == this_window_id)
         {
             return input_interface_->MouseReleased(
                 SDLButtonToChar(event.button.button), dt);
         }
-
-        if (event.type == SDL_EVENT_MOUSE_WHEEL && event.wheel.y != 0)
+        if (event.type == SDL_EVENT_MOUSE_WHEEL &&
+            event.wheel.windowID == this_window_id && event.wheel.y != 0)
         {
             return input_interface_->WheelMoved(
                 static_cast<float>(event.wheel.y), dt);


### PR DESCRIPTION
## Summary
- update SDL window event handlers to check `windowID`
- ensure text input and input events target the correct window

## Testing
- `git submodule update --init --recursive`
- `cmake --preset linux-debug` *(fails: vcpkg install failed and build tool not set)*

------
https://chatgpt.com/codex/tasks/task_e_685f83817ef08329878b8fd46a174887