### PR TITLE
Add file name to window title

### DIFF
--- a/include/frame/window_interface.h
+++ b/include/frame/window_interface.h
@@ -99,6 +99,16 @@ struct WindowInterface
      */
     virtual void SetWindowTitle(const std::string& title) const = 0;
     /**
+     * @brief Set the file name used in the window title.
+     * @param file_name: The opened file name.
+     */
+    virtual void SetOpenFileName(const std::string& file_name) = 0;
+    /**
+     * @brief Get the current file name used in the window title.
+     * @return The opened file name.
+     */
+    virtual const std::string& GetOpenFileName() const = 0;
+    /**
      * @brief Resize the window.
      * @param fullscreen_enum: Is it full screen or not?
      * @param size: The new window size.

--- a/src/frame/common/application.cpp
+++ b/src/frame/common/application.cpp
@@ -21,6 +21,7 @@ void Application::Startup(std::filesystem::path path)
 {
     assert(window_);
     auto& device = window_->GetDevice();
+    window_->SetOpenFileName(path.filename().string());
     if (!plugin_name_.empty())
     {
         device.RemovePluginByName(plugin_name_);
@@ -35,6 +36,7 @@ void Application::Startup(std::unique_ptr<frame::LevelInterface> level)
 {
     assert(window_);
     auto& device = window_->GetDevice();
+    window_->SetOpenFileName("");
     if (!plugin_name_.empty())
     {
         device.RemovePluginByName(plugin_name_);

--- a/src/frame/opengl/sdl_opengl_none.h
+++ b/src/frame/opengl/sdl_opengl_none.h
@@ -4,6 +4,7 @@
 #include <GL/glew.h>
 #include <SDL3/SDL.h>
 #include <format>
+#include <string>
 
 #include <stdexcept>
 
@@ -64,6 +65,14 @@ class SDLOpenGLNone : public WindowInterface
     void SetWindowTitle(const std::string& title) const override
     {
     }
+    void SetOpenFileName(const std::string& file_name) override
+    {
+        open_file_name_ = file_name;
+    }
+    const std::string& GetOpenFileName() const override
+    {
+        return open_file_name_;
+    }
     void Resize(glm::uvec2 size, FullScreenEnum fullscreen_enum) override
     {
         size_ = size;
@@ -84,6 +93,7 @@ class SDLOpenGLNone : public WindowInterface
     std::unique_ptr<InputInterface> input_interface_ = nullptr;
     SDL_Window* sdl_window_ = nullptr;
     SDL_GLContext gl_context_;
+    std::string open_file_name_ = "";
     frame::Logger& logger_ = frame::Logger::GetInstance();
 };
 

--- a/src/frame/opengl/sdl_opengl_window.cpp
+++ b/src/frame/opengl/sdl_opengl_window.cpp
@@ -9,6 +9,7 @@
 #endif
 #include <SDL3/SDL_video.h>
 #include <format>
+#include <string>
 
 #include "frame/gui/draw_gui_interface.h"
 #include "frame/opengl/gui/sdl_opengl_draw_gui.h"
@@ -169,8 +170,13 @@ WindowReturnEnum SDLOpenGLWindow::Run(std::function<bool()> lambda)
 
         SDL_GL_MakeCurrent(sdl_window_, gl_context_);
 
-        SetWindowTitle(
-            "SDL OpenGL - " + std::to_string(static_cast<float>(GetFPS(dt))));
+        std::string title = "SDL OpenGL";
+        if (!open_file_name_.empty())
+        {
+            title += " - " + open_file_name_;
+        }
+        title += " - " + std::to_string(static_cast<float>(GetFPS(dt)));
+        SetWindowTitle(title);
         previous_count = time.count();
         if (!lambda())
         {

--- a/src/frame/opengl/sdl_opengl_window.h
+++ b/src/frame/opengl/sdl_opengl_window.h
@@ -3,6 +3,7 @@
 #include <GL/glew.h>
 #include <SDL3/SDL.h>
 #include <stdexcept>
+#include <string>
 #if defined(_WIN32) || defined(_WIN64)
 #define NOMINMAX
 #include <windows.h>
@@ -62,6 +63,14 @@ class SDLOpenGLWindow : public WindowInterface
     {
         SDL_SetWindowTitle(sdl_window_, title.c_str());
     }
+    void SetOpenFileName(const std::string& file_name) override
+    {
+        open_file_name_ = file_name;
+    }
+    const std::string& GetOpenFileName() const override
+    {
+        return open_file_name_;
+    }
 
   public:
     WindowReturnEnum Run(std::function<bool()> lambda) override;
@@ -94,6 +103,7 @@ class SDLOpenGLWindow : public WindowInterface
 #if defined(_WIN32) || defined(_WIN64)
     HWND hwnd_ = nullptr;
 #endif
+    std::string open_file_name_ = "";
     frame::Logger& logger_ = frame::Logger::GetInstance();
 };
 

--- a/src/frame/opengl/win32_opengl_none.h
+++ b/src/frame/opengl/win32_opengl_none.h
@@ -5,6 +5,7 @@
 #define WINDOWS_LEAN_AND_MEAN
 #include <windows.h>
 #endif
+#include <string>
 
 #include "frame/device_interface.h"
 #include "frame/input_interface.h"
@@ -57,6 +58,14 @@ class Win32OpenGLNone : public WindowInterface
     void SetWindowTitle(const std::string& title) const override
     {
     }
+    void SetOpenFileName(const std::string& file_name) override
+    {
+        open_file_name_ = file_name;
+    }
+    const std::string& GetOpenFileName() const override
+    {
+        return open_file_name_;
+    }
     void Resize(glm::uvec2 size, FullScreenEnum fullscreen_enum)
     {
         size_ = size;
@@ -75,6 +84,7 @@ class Win32OpenGLNone : public WindowInterface
     glm::uvec2 size_;
     std::unique_ptr<DeviceInterface> device_ = nullptr;
     std::unique_ptr<InputInterface> input_interface_ = nullptr;
+    std::string open_file_name_ = "";
     frame::Logger& logger_ = frame::Logger::GetInstance();
 #if defined(_WIN32) || defined(_WIN64)
     HWND hwnd_dummy_; //< The dummy window.

--- a/src/frame/vulkan/sdl_vulkan_none.h
+++ b/src/frame/vulkan/sdl_vulkan_none.h
@@ -2,6 +2,7 @@
 
 #include <SDL3/SDL.h>
 #include <vulkan/vulkan.hpp>
+#include <string>
 #if defined(_WIN32) || defined(_WIN64)
 #define NOMINMAX
 #include <Windows.h>
@@ -65,6 +66,14 @@ class SDLVulkanNone : public WindowInterface
     void SetWindowTitle(const std::string& title) const override
     {
     }
+    void SetOpenFileName(const std::string& file_name) override
+    {
+        open_file_name_ = file_name;
+    }
+    const std::string& GetOpenFileName() const override
+    {
+        return open_file_name_;
+    }
     void Resize(glm::uvec2 size, FullScreenEnum fullscreen_enum) override
     {
         size_ = size;
@@ -90,6 +99,7 @@ class SDLVulkanNone : public WindowInterface
     std::unique_ptr<DeviceInterface> device_ = nullptr;
     std::unique_ptr<InputInterface> input_interface_ = nullptr;
     SDL_Window* sdl_window_ = nullptr;
+    std::string open_file_name_ = "";
     frame::Logger& logger_ = frame::Logger::GetInstance();
     vk::UniqueInstance vk_unique_instance_;
     vk::UniqueSurfaceKHR vk_surface_;

--- a/src/frame/vulkan/sdl_vulkan_window.cpp
+++ b/src/frame/vulkan/sdl_vulkan_window.cpp
@@ -3,6 +3,7 @@
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_vulkan.h>
 #include <vulkan/vulkan.hpp>
+#include <string>
 
 #include "frame/gui/draw_gui_interface.h"
 #include "frame/vulkan/debug_callback.h"
@@ -174,8 +175,13 @@ WindowReturnEnum SDLVulkanWindow::Run(
             }
         }
 
-        SetWindowTitle(
-            "SDL Vulkan - " + std::to_string(static_cast<float>(GetFPS(dt))));
+        std::string title = "SDL Vulkan";
+        if (!open_file_name_.empty())
+        {
+            title += " - " + open_file_name_;
+        }
+        title += " - " + std::to_string(static_cast<float>(GetFPS(dt)));
+        SetWindowTitle(title);
         if (!lambda())
         {
             window_return_enum = WindowReturnEnum::RESTART;

--- a/src/frame/vulkan/sdl_vulkan_window.h
+++ b/src/frame/vulkan/sdl_vulkan_window.h
@@ -2,6 +2,7 @@
 
 #include <SDL3/SDL.h>
 #include <vulkan/vulkan.hpp>
+#include <string>
 #if defined(_WIN32) || defined(_WIN64)
 #define NOMINMAX
 #include <Windows.h>
@@ -62,6 +63,14 @@ class SDLVulkanWindow : public WindowInterface
     {
         SDL_SetWindowTitle(sdl_window_, title.c_str());
     }
+    void SetOpenFileName(const std::string& file_name) override
+    {
+        open_file_name_ = file_name;
+    }
+    const std::string& GetOpenFileName() const override
+    {
+        return open_file_name_;
+    }
     DrawingTargetEnum GetDrawingTargetEnum() const override
     {
         return DrawingTargetEnum::WINDOW;
@@ -102,6 +111,7 @@ class SDLVulkanWindow : public WindowInterface
 #if defined(_WIN32) || defined(_WIN64)
     HWND hwnd_ = nullptr;
 #endif
+    std::string open_file_name_ = "";
     frame::Logger& logger_ = frame::Logger::GetInstance();
     vk::UniqueInstance vk_unique_instance_;
     vk::UniqueSurfaceKHR vk_surface_;


### PR DESCRIPTION
## Summary
- extend `WindowInterface` with methods to manage an open file name
- expose file name setting in `Application` startup
- show loaded file name in SDL window titles

## Testing
- `cmake -S . -B build` *(fails: Could not find package `absl`)*

------
https://chatgpt.com/codex/tasks/task_e_685fc058f8848329975318c4e27a4a33