### PR TITLE
Fix text input focusing for secondary windows

### DIFF
--- a/src/frame/opengl/sdl_opengl_window.cpp
+++ b/src/frame/opengl/sdl_opengl_window.cpp
@@ -200,11 +200,13 @@ bool SDLOpenGLWindow::RunEvent(const SDL_Event& event, const double dt)
     }
     if (event.type == SDL_EVENT_WINDOW_FOCUS_GAINED)
     {
-        SDL_StartTextInput(sdl_window_);
+        SDL_Window* window = SDL_GetWindowFromID(event.window.windowID);
+        SDL_StartTextInput(window);
     }
     if (event.type == SDL_EVENT_WINDOW_FOCUS_LOST)
     {
-        SDL_StopTextInput(sdl_window_);
+        SDL_Window* window = SDL_GetWindowFromID(event.window.windowID);
+        SDL_StopTextInput(window);
     }
     bool has_window_plugin = false;
     for (PluginInterface* plugin : device_->GetPluginPtrs())


### PR DESCRIPTION
## Summary
- ensure text input works when ImGui viewport windows gain focus
- start/stop text input based on the SDL window that triggered the focus event

## Testing
- `cmake --preset linux-debug` *(fails: vcpkg install failed)*

------
https://chatgpt.com/codex/tasks/task_e_685fc6f536f88329bd57a65bfb5cc70c