### PR TITLE
Hide Display shaders in editor list

### DIFF
--- a/editor/menubar.cpp
+++ b/editor/menubar.cpp
@@ -84,6 +84,8 @@ void Menubar::MenuEdit()
             for (auto program_id : level.GetPrograms())
             {
                 auto& program = level.GetProgramFromId(program_id);
+                if (!program.SerializeEnable())
+                    continue; // Skip internal programs such as DisplayProgram
                 shader_names.insert(program.GetData().shader_vertex());
                 shader_names.insert(program.GetData().shader_fragment());
             }


### PR DESCRIPTION
## Summary
- skip internal DisplayProgram when building the shader edit menu

## Testing
- `cmake -B build -S . -GNinja` *(fails: Could not find abslConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_685fd3178b488329a946d8015a899c2b