### PR TITLE
Add start window with template project

### DIFF
--- a/asset/json/CMakeLists.txt
+++ b/asset/json/CMakeLists.txt
@@ -5,6 +5,7 @@ add_custom_target(AssetJson
     depth_normal.json
     device_test.json
     editor.json
+    new_project_template.json
     equirectangular.json
     image_based_lighting.json
     japanese_flag.json

--- a/asset/json/new_project_template.json
+++ b/asset/json/new_project_template.json
@@ -1,0 +1,57 @@
+{
+  "name": "DeviceTest",
+  "default_texture_name": "DefaultTexture",
+  "textures": [
+    {
+      "name": "DefaultTexture",
+      "size": {
+        "x": "640",
+        "y": "480"
+      },
+      "pixel_element_size": { "value": "BYTE" },
+      "pixel_structure": { "value": "RGB" }
+    }
+  ],
+  "programs": [],
+  "scene_tree": {
+    "default_root_name": "DeviceScene",
+    "default_camera_name": "camera",
+    "node_matrices": [
+      {
+        "name": "root",
+        "quaternion": {
+          "w": 1,
+          "x": 0,
+          "y": 0,
+          "z": 0
+        }
+      }
+    ],
+    "node_cameras": [
+      {
+        "name": "camera",
+        "parent": "root",
+        "position": {
+          "x": 0,
+          "y": 0,
+          "z": 0
+        },
+        "target": {
+          "x": 0,
+          "y": 0,
+          "z": 1
+        },
+        "up": {
+          "x": 0,
+          "y": 1,
+          "z": 0
+        },
+        "fov_degrees": 65.0,
+        "aspect_ratio": 1.6,
+        "near_clip": 0.1,
+        "far_clip": 10000.0
+      }
+    ]
+  },
+  "materials": []
+}

--- a/asset/json/new_project_template.json
+++ b/asset/json/new_project_template.json
@@ -5,8 +5,8 @@
     {
       "name": "DefaultTexture",
       "size": {
-        "x": "640",
-        "y": "480"
+        "x": -1,
+        "y": -1
       },
       "pixel_element_size": { "value": "BYTE" },
       "pixel_structure": { "value": "RGB" }

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -1,35 +1,18 @@
-# Frame Editor.
+#Frame Editor.
 
-add_executable(FrameEditor
-  WIN32
-    main.cpp
-    menubar.cpp
-    menubar.h
-    menubar_view.cpp
-    menubar_view.h
-    menubar_file.cpp
-    menubar_file.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/../asset/json/editor.json
-)
+add_executable(
+    FrameEditor WIN32 main.cpp menubar.cpp menubar.h menubar_view
+        .cpp menubar_view.h menubar_file.cpp menubar_file.h window_start
+        .cpp window_start.h ${CMAKE_CURRENT_SOURCE_DIR} /
+        ../ asset / json / editor.json)
 
-target_include_directories(FrameEditor
-  PUBLIC
-    editor/
-    ${CMAKE_CURRENT_SOURCE_DIR}/../..
-    ${CMAKE_CURRENT_BINARY_DIR}
-)
+    target_include_directories(
+        FrameEditor PUBLIC editor /
+        ${CMAKE_CURRENT_SOURCE_DIR} /../..${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(FrameEditor
-  PUBLIC
-    Frame
-    FrameCommon
-    FrameGui
-    FrameOpenGL
-    FrameOpenGLGui
-    FrameOpenGLFile
-    FrameProto
-    imgui::imgui
-    ImGuiColorTextEdit
-)
+        target_link_libraries(
+            FrameEditor PUBLIC Frame FrameCommon FrameGui FrameOpenGL
+                FrameOpenGLGui FrameOpenGLFile FrameProto
+                    imgui::imgui ImGuiColorTextEdit)
 
-set_property(TARGET FrameEditor PROPERTY FOLDER "FrameEditor")
+            set_property(TARGET FrameEditor PROPERTY FOLDER "FrameEditor")

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -1,18 +1,37 @@
-#Frame Editor.
+# Frame Editor.
 
-add_executable(
-    FrameEditor WIN32 main.cpp menubar.cpp menubar.h menubar_view
-        .cpp menubar_view.h menubar_file.cpp menubar_file.h window_start
-        .cpp window_start.h ${CMAKE_CURRENT_SOURCE_DIR} /
-        ../ asset / json / editor.json)
+add_executable(FrameEditor
+  WIN32
+    main.cpp
+    menubar.cpp
+    menubar.h
+    menubar_view.cpp
+    menubar_view.h
+    menubar_file.cpp
+    menubar_file.h
+    window_start.cpp
+    window_start.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../asset/json/new_project_template.json
+)
 
-    target_include_directories(
-        FrameEditor PUBLIC editor /
-        ${CMAKE_CURRENT_SOURCE_DIR} /../..${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(FrameEditor
+  PUBLIC
+    editor/
+    ${CMAKE_CURRENT_SOURCE_DIR}/../..
+    ${CMAKE_CURRENT_BINARY_DIR}
+)
 
-        target_link_libraries(
-            FrameEditor PUBLIC Frame FrameCommon FrameGui FrameOpenGL
-                FrameOpenGLGui FrameOpenGLFile FrameProto
-                    imgui::imgui ImGuiColorTextEdit)
+target_link_libraries(FrameEditor
+  PUBLIC
+    Frame
+    FrameCommon
+    FrameGui
+    FrameOpenGL
+    FrameOpenGLGui
+    FrameOpenGLFile
+    FrameProto
+    imgui::imgui
+    ImGuiColorTextEdit
+)
 
-            set_property(TARGET FrameEditor PROPERTY FOLDER "FrameEditor")
+set_property(TARGET FrameEditor PROPERTY FOLDER "FrameEditor")

--- a/editor/main.cpp
+++ b/editor/main.cpp
@@ -19,6 +19,8 @@
 #include "menubar.h"
 #include "menubar_file.h"
 #include "menubar_view.h"
+#include "window_start.h"
+#include <filesystem>
 
 // From: https://sourceforge.net/p/predef/wiki/OperatingSystems/
 #if defined(_WIN32) || defined(_WIN64)
@@ -47,10 +49,12 @@ try
         win->GetDesktopSize(),
         win->GetPixelPerInch());
     frame::gui::MenubarFile menubar_file(
-        device, *gui_window.get(), "asset/json/editor.json");
+        device, *gui_window.get(), "asset/json/new_project_template.json");
     gui_window->SetMenuBar(
         std::make_unique<frame::gui::Menubar>(
             "Menu", menubar_file, menubar_view, gui_window->GetDevice()));
+    gui_window->AddModalWindow(
+        std::make_unique<frame::gui::WindowStart>(menubar_file));
     // Set the main window in full.
     device.AddPlugin(std::move(gui_window));
     frame::common::Application app(std::move(win));
@@ -73,6 +77,15 @@ try
             else
             {
                 menubar_view.Reset();
+                if (menubar_file.GetFileDialogEnum() ==
+                    frame::gui::FileDialogEnum::NEW)
+                {
+                    std::filesystem::copy_file(
+                        frame::file::FindFile(
+                            "asset/json/new_project_template.json"),
+                        menubar_file.GetFileName(),
+                        std::filesystem::copy_options::overwrite_existing);
+                }
                 menubar_file.TrySaveFile();
             }
             break;

--- a/editor/window_start.cpp
+++ b/editor/window_start.cpp
@@ -12,19 +12,23 @@ WindowStart::WindowStart(MenubarFile& menubar_file)
 
 bool WindowStart::DrawCallback()
 {
+    ImGui::Dummy(ImVec2(0.0f, 10.0f));
     ImGui::Text("Welcome to Frame Editor");
+    ImGui::Dummy(ImVec2(0.0f, 10.0f));
     if (ImGui::Button("Create New Project"))
     {
         ImGui::CloseCurrentPopup();
         menubar_file_.ShowNewProject();
         end_ = true;
     }
+    ImGui::Dummy(ImVec2(0.0f, 10.0f));
     if (ImGui::Button("Open Existing Project"))
     {
         ImGui::CloseCurrentPopup();
         menubar_file_.ShowOpenProject();
         end_ = true;
     }
+    ImGui::Dummy(ImVec2(0.0f, 10.0f));
     return true;
 }
 

--- a/editor/window_start.cpp
+++ b/editor/window_start.cpp
@@ -15,11 +15,13 @@ bool WindowStart::DrawCallback()
     ImGui::Text("Welcome to Frame Editor");
     if (ImGui::Button("Create New Project"))
     {
+        ImGui::CloseCurrentPopup();
         menubar_file_.ShowNewProject();
         end_ = true;
     }
     if (ImGui::Button("Open Existing Project"))
     {
+        ImGui::CloseCurrentPopup();
         menubar_file_.ShowOpenProject();
         end_ = true;
     }

--- a/editor/window_start.cpp
+++ b/editor/window_start.cpp
@@ -1,0 +1,44 @@
+#include "window_start.h"
+
+#include <imgui.h>
+
+namespace frame::gui
+{
+
+WindowStart::WindowStart(MenubarFile& menubar_file)
+    : menubar_file_(menubar_file)
+{
+}
+
+bool WindowStart::DrawCallback()
+{
+    ImGui::Text("Welcome to Frame Editor");
+    if (ImGui::Button("Create New Project"))
+    {
+        menubar_file_.ShowNewProject();
+        end_ = true;
+    }
+    if (ImGui::Button("Open Existing Project"))
+    {
+        menubar_file_.ShowOpenProject();
+        end_ = true;
+    }
+    return true;
+}
+
+bool WindowStart::End() const
+{
+    return end_;
+}
+
+std::string WindowStart::GetName() const
+{
+    return name_;
+}
+
+void WindowStart::SetName(const std::string& name)
+{
+    name_ = name;
+}
+
+} // namespace frame::gui

--- a/editor/window_start.cpp
+++ b/editor/window_start.cpp
@@ -12,6 +12,10 @@ WindowStart::WindowStart(MenubarFile& menubar_file)
 
 bool WindowStart::DrawCallback()
 {
+    constexpr float side_space = 20.0f;
+    ImGui::Dummy(ImVec2(side_space, 0.0f));
+    ImGui::SameLine();
+    ImGui::BeginGroup();
     ImGui::Dummy(ImVec2(0.0f, 10.0f));
     ImGui::Text("Welcome to Frame Editor");
     ImGui::Dummy(ImVec2(0.0f, 10.0f));
@@ -29,6 +33,9 @@ bool WindowStart::DrawCallback()
         end_ = true;
     }
     ImGui::Dummy(ImVec2(0.0f, 10.0f));
+    ImGui::EndGroup();
+    ImGui::SameLine();
+    ImGui::Dummy(ImVec2(side_space, 0.0f));
     return true;
 }
 

--- a/editor/window_start.h
+++ b/editor/window_start.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "frame/gui/gui_window_interface.h"
+#include "menubar_file.h"
+
+namespace frame::gui
+{
+
+class WindowStart : public GuiWindowInterface
+{
+  public:
+    explicit WindowStart(MenubarFile& menubar_file);
+    ~WindowStart() override = default;
+
+    bool DrawCallback() override;
+    bool End() const override;
+    std::string GetName() const override;
+    void SetName(const std::string& name) override;
+
+  private:
+    MenubarFile& menubar_file_;
+    std::string name_ = "Start";
+    bool end_ = false;
+};
+
+} // namespace frame::gui

--- a/src/frame/opengl/gui/sdl_opengl_draw_gui.cpp
+++ b/src/frame/opengl/gui/sdl_opengl_draw_gui.cpp
@@ -316,6 +316,7 @@ void SDLOpenGLDrawGui::AddModalWindow(
     std::unique_ptr<frame::gui::GuiWindowInterface> callback)
 {
     modal_callback_ = std::move(callback);
+    start_modal_ = false;
 }
 
 std::vector<std::string> SDLOpenGLDrawGui::GetWindowTitles() const

--- a/src/frame/opengl/gui/sdl_opengl_draw_gui.h
+++ b/src/frame/opengl/gui/sdl_opengl_draw_gui.h
@@ -140,8 +140,9 @@ class SDLOpenGLDrawGui : public frame::gui::DrawGuiInterface
      * removed. This will trigger an internal boolean that will decide if the
      * modal is active or not.
      */
+    /** Set the modal window. Replaces any current modal and opens it next frame. */
     void AddModalWindow(
-		std::unique_ptr<frame::gui::GuiWindowInterface> callback) override;
+                std::unique_ptr<frame::gui::GuiWindowInterface> callback) override;
     /**
      * @brief Get a specific window (associated with a name).
      * @param name: The name of the window.

--- a/src/frame/opengl/gui/sdl_opengl_draw_gui.h
+++ b/src/frame/opengl/gui/sdl_opengl_draw_gui.h
@@ -138,11 +138,11 @@ class SDLOpenGLDrawGui : public frame::gui::DrawGuiInterface
      *
      * If the callback return is 0 the callback stay and if it is other it is
      * removed. This will trigger an internal boolean that will decide if the
-     * modal is active or not.
+     * modal is active or not. Set the modal window. Replaces any current modal
+     * and opens it next frame.
      */
-    /** Set the modal window. Replaces any current modal and opens it next frame. */
     void AddModalWindow(
-                std::unique_ptr<frame::gui::GuiWindowInterface> callback) override;
+        std::unique_ptr<frame::gui::GuiWindowInterface> callback) override;
     /**
      * @brief Get a specific window (associated with a name).
      * @param name: The name of the window.


### PR DESCRIPTION
## Summary
- add a simple start modal so users can create or open a project when launching
- include a minimal project template JSON
- default editor startup uses the template project
- copy the template when creating a new project

## Testing
- `cmake --preset linux-debug` *(fails: Could not find toolchain file)*


------
https://chatgpt.com/codex/tasks/task_e_6862437be9d48329b64a19eae1331ca8