### PR TITLE
Remove redundant close buttons

### DIFF
--- a/src/frame/gui/window_glsl_file.cpp
+++ b/src/frame/gui/window_glsl_file.cpp
@@ -96,11 +96,6 @@ bool WindowGlslFile::DrawCallback()
             error_message_ = e.what();
         }
     }
-    ImGui::SameLine();
-    if (ImGui::Button("Close"))
-    {
-        end_ = true;
-    }
     ImGui::Separator();
     if (!error_message_.empty())
     {

--- a/src/frame/gui/window_json_file.cpp
+++ b/src/frame/gui/window_json_file.cpp
@@ -85,11 +85,6 @@ bool WindowJsonFile::DrawCallback()
             error_message_ = e.what();
         }
     }
-    ImGui::SameLine();
-    if (ImGui::Button("Close"))
-    {
-        end_ = true;
-    }
     ImGui::Separator();
     if (!error_message_.empty())
     {


### PR DESCRIPTION
## Summary
- remove internal "Close" buttons from the GLSL and JSON editor windows

## Testing
- `cmake --preset linux-debug` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_6864dc5a0da48329a17c9dd7bcea55f7