### PR TITLE
Add Apply button to GLSL editor

### DIFF
--- a/editor/menubar.cpp
+++ b/editor/menubar.cpp
@@ -96,7 +96,8 @@ void Menubar::MenuEdit()
                     menubar_view_.GetDrawGui().AddWindow(
                         std::make_unique<WindowGlslFile>(
                             std::string("asset/shader/opengl/") + shader,
-                            device_));
+                            device_,
+                            menubar_file_.GetFileName()));
                 }
             }
             ImGui::EndMenu();

--- a/include/frame/gui/window_glsl_file.h
+++ b/include/frame/gui/window_glsl_file.h
@@ -22,6 +22,24 @@ class WindowGlslFile : public GuiWindowInterface
     std::string GetName() const override;
     void SetName(const std::string& name) override;
 
+    /**
+     * @brief Compile the current editor text without writing it to disk.
+     * @return True on successful compilation, false otherwise.
+     */
+    bool Compile();
+    /**
+     * @brief Apply the current editor text by compiling it and, on success,
+     * saving the file and reloading the device.
+     * @return True on success, false if compilation failed or writing the file
+     * failed.
+     */
+    bool Apply();
+
+    /** @brief Set the text in the internal editor. */
+    void SetEditorText(const std::string& text);
+    /** @brief Get the text from the internal editor. */
+    std::string GetEditorText() const;
+
   private:
     std::string name_;
     std::string file_name_;

--- a/include/frame/gui/window_glsl_file.h
+++ b/include/frame/gui/window_glsl_file.h
@@ -14,7 +14,10 @@ namespace frame::gui
 class WindowGlslFile : public GuiWindowInterface
 {
   public:
-    WindowGlslFile(const std::string& file_name, DeviceInterface& device);
+    WindowGlslFile(
+        const std::string& file_name,
+        DeviceInterface& device,
+        const std::string& level_file = "");
     ~WindowGlslFile() override = default;
 
     bool DrawCallback() override;
@@ -47,6 +50,7 @@ class WindowGlslFile : public GuiWindowInterface
     TextEditor editor_;
     bool end_ = false;
     std::string error_message_;
+    std::string level_file_;
 };
 
 } // End namespace frame::gui.

--- a/src/frame/gui/window_glsl_file.cpp
+++ b/src/frame/gui/window_glsl_file.cpp
@@ -13,9 +13,11 @@ namespace frame::gui
 {
 
 WindowGlslFile::WindowGlslFile(
-    const std::string& file_name, DeviceInterface& device)
+    const std::string& file_name,
+    DeviceInterface& device,
+    const std::string& level_file)
     : name_(std::format("GLSL File [{}]", file_name)), file_name_(file_name),
-      device_(device)
+      device_(device), level_file_(level_file)
 {
     editor_.SetLanguageDefinition(TextEditor::LanguageDefinitionId::Glsl);
     try
@@ -168,9 +170,19 @@ bool WindowGlslFile::Apply()
     }
     try
     {
-        auto proto_level = frame::json::SerializeLevel(device_.GetLevel());
-        auto level = frame::json::ParseLevel(device_.GetSize(), proto_level);
-        device_.Startup(std::move(level));
+        if (!level_file_.empty())
+        {
+            auto level = frame::json::ParseLevel(
+                device_.GetSize(), frame::file::FindFile(level_file_));
+            device_.Startup(std::move(level));
+        }
+        else
+        {
+            auto proto_level = frame::json::SerializeLevel(device_.GetLevel());
+            auto level =
+                frame::json::ParseLevel(device_.GetSize(), proto_level);
+            device_.Startup(std::move(level));
+        }
     }
     catch (const std::exception& e)
     {

--- a/src/frame/gui/window_glsl_file.cpp
+++ b/src/frame/gui/window_glsl_file.cpp
@@ -1,5 +1,7 @@
 #include "frame/gui/window_glsl_file.h"
 
+#include "frame/json/parse_level.h"
+#include "frame/json/serialize_level.h"
 #include "frame/logger.h"
 #include <cmath>
 #include <format>
@@ -164,7 +166,18 @@ bool WindowGlslFile::Apply()
         frame::Logger::GetInstance()->error(e.what());
         return false;
     }
-    device_.Resize(device_.GetSize());
+    try
+    {
+        auto proto_level = frame::json::SerializeLevel(device_.GetLevel());
+        auto level = frame::json::ParseLevel(device_.GetSize(), proto_level);
+        device_.Startup(std::move(level));
+    }
+    catch (const std::exception& e)
+    {
+        error_message_ = e.what();
+        frame::Logger::GetInstance()->error(e.what());
+        return false;
+    }
     return true;
 }
 

--- a/src/frame/gui/window_glsl_file.cpp
+++ b/src/frame/gui/window_glsl_file.cpp
@@ -40,8 +40,31 @@ bool WindowGlslFile::DrawCallback()
         try
         {
             std::string source = editor_.GetText();
-            std::ofstream out(frame::file::FindFile(file_name_));
-            out << source;
+
+            using frame::opengl::Shader;
+            using frame::opengl::ShaderEnum;
+            ShaderEnum shader_type = ShaderEnum::FRAGMENT_SHADER;
+            if (std::string_view(file_name_).ends_with(".vert"))
+                shader_type = ShaderEnum::VERTEX_SHADER;
+            Shader shader(shader_type);
+            if (!shader.LoadFromSource(source))
+            {
+                throw std::runtime_error(shader.GetErrorMessage());
+            }
+            error_message_.clear();
+        }
+        catch (const std::exception& e)
+        {
+            error_message_ = e.what();
+            frame::Logger::GetInstance()->error(e.what());
+        }
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Apply"))
+    {
+        try
+        {
+            std::string source = editor_.GetText();
 
             using frame::opengl::Shader;
             using frame::opengl::ShaderEnum;

--- a/tests/frame/opengl/CMakeLists.txt
+++ b/tests/frame/opengl/CMakeLists.txt
@@ -24,6 +24,8 @@ add_executable(FrameOpenGLTest
   renderer_test.h
   shader_test.cpp
   shader_test.h
+  window_glsl_file_test.cpp
+  window_glsl_file_test.h
   cubemap_test.cpp
   cubemap_test.h
   texture_test.cpp

--- a/tests/frame/opengl/CMakeLists.txt
+++ b/tests/frame/opengl/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(FrameOpenGLTest
     GTest::gmock
     GTest::gtest
     FrameFile
+    FrameGui
     FrameOpenGL
     FrameOpenGLFile
     FrameJson

--- a/tests/frame/opengl/window_glsl_file_test.cpp
+++ b/tests/frame/opengl/window_glsl_file_test.cpp
@@ -1,0 +1,21 @@
+#include "frame/opengl/window_glsl_file_test.h"
+#include <fstream>
+#include <string>
+
+namespace test
+{
+
+TEST_F(WindowGlslFileTest, FailedCompileDoesNotTouchFile)
+{
+    frame::gui::WindowGlslFile window(
+        temp_file_.string(), window_->GetDevice());
+    window.SetEditorText("false");
+    EXPECT_FALSE(window.Compile());
+
+    std::ifstream in(temp_file_);
+    std::string content(
+        (std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, std::string("void main() {}"));
+}
+
+} // namespace test

--- a/tests/frame/opengl/window_glsl_file_test.cpp
+++ b/tests/frame/opengl/window_glsl_file_test.cpp
@@ -18,4 +18,33 @@ TEST_F(WindowGlslFileTest, FailedCompileDoesNotTouchFile)
     EXPECT_EQ(content, std::string("void main() {}"));
 }
 
+TEST_F(WindowGlslFileTest, FailedApplyDoesNotTouchFile)
+{
+    frame::gui::WindowGlslFile window(
+        temp_file_.string(), window_->GetDevice());
+    window.SetEditorText("false");
+    EXPECT_FALSE(window.Apply());
+
+    std::ifstream in(temp_file_);
+    std::string content(
+        (std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, std::string("void main() {}"));
+}
+
+TEST_F(WindowGlslFileTest, ApplyWritesFileOnSuccess)
+{
+    frame::gui::WindowGlslFile window(
+        temp_file_.string(), window_->GetDevice());
+    const std::string shader =
+        "#version 330 core\nlayout(location=0) out vec4 frag_color;\nvoid "
+        "main(){frag_color=vec4(1.0);}";
+    window.SetEditorText(shader);
+    EXPECT_TRUE(window.Apply());
+
+    std::ifstream in(temp_file_);
+    std::string content(
+        (std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, shader);
+}
+
 } // namespace test

--- a/tests/frame/opengl/window_glsl_file_test.cpp
+++ b/tests/frame/opengl/window_glsl_file_test.cpp
@@ -8,7 +8,9 @@ namespace test
 TEST_F(WindowGlslFileTest, FailedCompileDoesNotTouchFile)
 {
     frame::gui::WindowGlslFile window(
-        temp_file_.string(), window_->GetDevice());
+        temp_file_.string(),
+        window_->GetDevice(),
+        "asset/json/device_test.json");
     window.SetEditorText("false");
     EXPECT_FALSE(window.Compile());
 
@@ -21,7 +23,9 @@ TEST_F(WindowGlslFileTest, FailedCompileDoesNotTouchFile)
 TEST_F(WindowGlslFileTest, FailedApplyDoesNotTouchFile)
 {
     frame::gui::WindowGlslFile window(
-        temp_file_.string(), window_->GetDevice());
+        temp_file_.string(),
+        window_->GetDevice(),
+        "asset/json/device_test.json");
     window.SetEditorText("false");
     EXPECT_FALSE(window.Apply());
 
@@ -34,7 +38,9 @@ TEST_F(WindowGlslFileTest, FailedApplyDoesNotTouchFile)
 TEST_F(WindowGlslFileTest, ApplyWritesFileOnSuccess)
 {
     frame::gui::WindowGlslFile window(
-        temp_file_.string(), window_->GetDevice());
+        temp_file_.string(),
+        window_->GetDevice(),
+        "asset/json/device_test.json");
     const std::string shader =
         "#version 330 core\nlayout(location=0) out vec4 frag_color;\nvoid "
         "main(){frag_color=vec4(1.0);}";

--- a/tests/frame/opengl/window_glsl_file_test.h
+++ b/tests/frame/opengl/window_glsl_file_test.h
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <imgui.h>
 
 #include "frame/gui/window_glsl_file.h"
 #include "frame/window_factory.h"
@@ -21,6 +22,7 @@ class WindowGlslFileTest : public testing::Test
   protected:
     void SetUp() override
     {
+        ImGui::CreateContext();
         temp_file_ =
             std::filesystem::temp_directory_path() / "glsl_window_test.frag";
         std::ofstream out(temp_file_);
@@ -31,6 +33,7 @@ class WindowGlslFileTest : public testing::Test
     {
         std::error_code ec;
         std::filesystem::remove(temp_file_, ec);
+        ImGui::DestroyContext();
     }
 
     std::filesystem::path temp_file_;

--- a/tests/frame/opengl/window_glsl_file_test.h
+++ b/tests/frame/opengl/window_glsl_file_test.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+
+#include "frame/gui/window_glsl_file.h"
+#include "frame/window_factory.h"
+
+namespace test
+{
+
+class WindowGlslFileTest : public testing::Test
+{
+  public:
+    WindowGlslFileTest()
+        : window_(frame::CreateNewWindow(frame::DrawingTargetEnum::NONE))
+    {
+    }
+
+  protected:
+    void SetUp() override
+    {
+        temp_file_ =
+            std::filesystem::temp_directory_path() / "glsl_window_test.frag";
+        std::ofstream out(temp_file_);
+        out << "void main() {}";
+    }
+
+    void TearDown() override
+    {
+        std::error_code ec;
+        std::filesystem::remove(temp_file_, ec);
+    }
+
+    std::filesystem::path temp_file_;
+    std::unique_ptr<frame::WindowInterface> window_;
+};
+
+} // namespace test

--- a/tests/frame/opengl/window_glsl_file_test.h
+++ b/tests/frame/opengl/window_glsl_file_test.h
@@ -4,6 +4,8 @@
 #include <fstream>
 #include <gtest/gtest.h>
 #include <imgui.h>
+#include "frame/file/file_system.h"
+#include "frame/json/parse_level.h"
 
 #include "frame/gui/window_glsl_file.h"
 #include "frame/window_factory.h"
@@ -27,6 +29,10 @@ class WindowGlslFileTest : public testing::Test
             std::filesystem::temp_directory_path() / "glsl_window_test.frag";
         std::ofstream out(temp_file_);
         out << "void main() {}";
+        auto level = frame::json::ParseLevel(
+            window_->GetDevice().GetSize(),
+            frame::file::FindFile("asset/json/device_test.json"));
+        window_->GetDevice().Startup(std::move(level));
     }
 
     void TearDown() override


### PR DESCRIPTION
## Summary
- separate compilation from applying in GLSL editor
- new **Apply** button recompiles the shader and reloads the scene

## Testing
- `cmake --preset linux-debug` *(fails: vcpkg install failed)*

------
https://chatgpt.com/codex/tasks/task_e_6864e42096e483298215512ed5f37571