### PR TITLE
Remove shader reload button

### DIFF
--- a/src/frame/gui/window_glsl_file.cpp
+++ b/src/frame/gui/window_glsl_file.cpp
@@ -49,26 +49,6 @@ bool WindowGlslFile::DrawCallback()
         Apply();
     }
     ImGui::SameLine();
-    if (ImGui::Button("Reload"))
-    {
-        try
-        {
-            std::ifstream file(frame::file::FindFile(file_name_));
-            if (file)
-            {
-                std::string content(
-                    (std::istreambuf_iterator<char>(file)),
-                    std::istreambuf_iterator<char>());
-                editor_.SetText(content);
-            }
-            error_message_.clear();
-        }
-        catch (const std::exception& e)
-        {
-            error_message_ = e.what();
-        }
-    }
-    ImGui::SameLine();
     if (ImGui::Button("Save"))
     {
         try


### PR DESCRIPTION
## Summary
- remove the shader reload action from the GLSL editor

## Testing
- `cmake --preset linux-debug` *(fails: Could not find vcpkg toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_6866477c8460832981e158d483302c61