### PR TITLE
Add Level Editor window

### DIFF
--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -1,37 +1,19 @@
-# Frame Editor.
+#Frame Editor.
 
-add_executable(FrameEditor
-  WIN32
-    main.cpp
-    menubar.cpp
-    menubar.h
-    menubar_view.cpp
-    menubar_view.h
-    menubar_file.cpp
-    menubar_file.h
-    window_start.cpp
-    window_start.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/../asset/json/new_project_template.json
-)
+add_executable(
+    FrameEditor WIN32 main.cpp menubar.cpp menubar.h menubar_view
+        .cpp menubar_view.h menubar_file.cpp menubar_file.h window_start
+        .cpp window_start.h window_level.cpp window_level.h ${
+            CMAKE_CURRENT_SOURCE_DIR} /
+        ../ asset / json / new_project_template.json)
 
-target_include_directories(FrameEditor
-  PUBLIC
-    editor/
-    ${CMAKE_CURRENT_SOURCE_DIR}/../..
-    ${CMAKE_CURRENT_BINARY_DIR}
-)
+    target_include_directories(
+        FrameEditor PUBLIC editor /
+        ${CMAKE_CURRENT_SOURCE_DIR} /../..${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(FrameEditor
-  PUBLIC
-    Frame
-    FrameCommon
-    FrameGui
-    FrameOpenGL
-    FrameOpenGLGui
-    FrameOpenGLFile
-    FrameProto
-    imgui::imgui
-    ImGuiColorTextEdit
-)
+        target_link_libraries(
+            FrameEditor PUBLIC Frame FrameCommon FrameGui FrameOpenGL
+                FrameOpenGLGui FrameOpenGLFile FrameProto
+                    imgui::imgui ImGuiColorTextEdit)
 
-set_property(TARGET FrameEditor PROPERTY FOLDER "FrameEditor")
+            set_property(TARGET FrameEditor PROPERTY FOLDER "FrameEditor")

--- a/editor/menubar.cpp
+++ b/editor/menubar.cpp
@@ -6,6 +6,7 @@
 #include "frame/gui/window_logger.h"
 #include "frame/gui/window_resolution.h"
 #include "frame/logger.h"
+#include "window_level.h"
 #include <imgui.h>
 #include <set>
 
@@ -76,6 +77,11 @@ void Menubar::MenuEdit()
             menubar_view_.GetDrawGui().AddWindow(
                 std::make_unique<WindowJsonFile>(
                     menubar_file_.GetFileName(), device_));
+        }
+        if (ImGui::MenuItem("Level Editor"))
+        {
+            menubar_view_.GetDrawGui().AddWindow(
+                std::make_unique<WindowLevel>(device_));
         }
         if (ImGui::BeginMenu("Shader"))
         {

--- a/editor/window_level.cpp
+++ b/editor/window_level.cpp
@@ -1,0 +1,93 @@
+#include "window_level.h"
+
+#include <imgui.h>
+
+namespace frame::gui
+{
+
+WindowLevel::WindowLevel(DeviceInterface& device) : device_(device)
+{
+}
+
+void WindowLevel::DisplayNode(LevelInterface& level, EntityId id)
+{
+    auto& node = level.GetSceneNodeFromId(id);
+    std::string name = level.GetNameFromId(id);
+    auto children = level.GetChildList(id);
+    ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow;
+    if (children.empty())
+        flags |= ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen;
+    bool open = ImGui::TreeNodeEx(
+        (void*)(static_cast<intptr_t>(id)), flags, "%s", name.c_str());
+    if (open && !children.empty())
+    {
+        for (auto child : children)
+        {
+            DisplayNode(level, child);
+        }
+        ImGui::TreePop();
+    }
+}
+
+bool WindowLevel::DrawCallback()
+{
+    auto& level = device_.GetLevel();
+    if (ImGui::BeginTabBar("##level_tabs"))
+    {
+        if (ImGui::BeginTabItem("Textures"))
+        {
+            for (auto id : level.GetTextures())
+            {
+                auto& tex = level.GetTextureFromId(id);
+                ImGui::BulletText("%s", tex.GetName().c_str());
+            }
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Programs"))
+        {
+            for (auto id : level.GetPrograms())
+            {
+                auto& prog = level.GetProgramFromId(id);
+                ImGui::BulletText("%s", prog.GetName().c_str());
+            }
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Materials"))
+        {
+            for (auto id : level.GetMaterials())
+            {
+                auto& mat = level.GetMaterialFromId(id);
+                ImGui::BulletText("%s", mat.GetName().c_str());
+            }
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Scene"))
+        {
+            auto root = level.GetDefaultRootSceneNodeId();
+            if (root)
+            {
+                DisplayNode(level, root);
+            }
+            ImGui::EndTabItem();
+        }
+        ImGui::EndTabBar();
+    }
+    return true;
+}
+
+bool WindowLevel::End() const
+{
+    return end_;
+}
+
+std::string WindowLevel::GetName() const
+{
+    return name_;
+}
+
+void WindowLevel::SetName(const std::string& name)
+{
+    name_ = name;
+}
+
+} // namespace frame::gui

--- a/editor/window_level.h
+++ b/editor/window_level.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "frame/device_interface.h"
+#include "frame/gui/gui_window_interface.h"
+
+namespace frame::gui
+{
+
+class WindowLevel : public GuiWindowInterface
+{
+  public:
+    explicit WindowLevel(DeviceInterface& device);
+    ~WindowLevel() override = default;
+
+    bool DrawCallback() override;
+    bool End() const override;
+    std::string GetName() const override;
+    void SetName(const std::string& name) override;
+
+  private:
+    void DisplayNode(LevelInterface& level, EntityId id);
+
+    DeviceInterface& device_;
+    std::string name_ = "Level Editor";
+    bool end_ = false;
+};
+
+} // namespace frame::gui


### PR DESCRIPTION
## Summary
- add WindowLevel class derived from GuiWindowInterface
- list textures, programs, materials and the scene tree
- expose Level Editor window via the Edit menu

## Testing
- `cmake --preset linux-debug` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_686a848ff0488329817a8668a5edc938