### PR TITLE
Refactor tab names to use NameInterface

### DIFF
--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -13,6 +13,15 @@ add_executable(FrameEditor
     window_start.h
     window_level.cpp
     window_level.h
+    tab_interface.h
+    tab_textures.cpp
+    tab_textures.h
+    tab_programs.cpp
+    tab_programs.h
+    tab_materials.cpp
+    tab_materials.h
+    tab_scene.cpp
+    tab_scene.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../asset/json/new_project_template.json
 )
 

--- a/editor/tab_interface.h
+++ b/editor/tab_interface.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "frame/level_interface.h"
+#include "frame/name_interface.h"
+
+namespace frame::gui {
+
+class TabInterface : public NameInterface {
+  public:
+    ~TabInterface() override = default;
+    virtual void Draw(LevelInterface& level) = 0;
+};
+
+} // namespace frame::gui

--- a/editor/tab_interface.h
+++ b/editor/tab_interface.h
@@ -7,8 +7,16 @@ namespace frame::gui {
 
 class TabInterface : public NameInterface {
   public:
+    explicit TabInterface(std::string name) : name_(std::move(name)) {}
     ~TabInterface() override = default;
+
+    std::string GetName() const override { return name_; }
+    void SetName(const std::string& name) override { name_ = name; }
+
     virtual void Draw(LevelInterface& level) = 0;
+
+  private:
+    std::string name_;
 };
 
 } // namespace frame::gui

--- a/editor/tab_materials.cpp
+++ b/editor/tab_materials.cpp
@@ -1,0 +1,14 @@
+#include "tab_materials.h"
+
+#include <imgui.h>
+
+namespace frame::gui {
+
+void TabMaterials::Draw(LevelInterface& level) {
+    for (auto id : level.GetMaterials()) {
+        auto& mat = level.GetMaterialFromId(id);
+        ImGui::BulletText("%s", mat.GetName().c_str());
+    }
+}
+
+} // namespace frame::gui

--- a/editor/tab_materials.h
+++ b/editor/tab_materials.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "tab_interface.h"
+
+namespace frame::gui {
+
+class TabMaterials : public TabInterface {
+  public:
+    std::string GetName() const override { return "Materials"; }
+    void Draw(LevelInterface& level) override;
+};
+
+} // namespace frame::gui

--- a/editor/tab_materials.h
+++ b/editor/tab_materials.h
@@ -6,7 +6,7 @@ namespace frame::gui {
 
 class TabMaterials : public TabInterface {
   public:
-    std::string GetName() const override { return "Materials"; }
+    TabMaterials() : TabInterface("Materials") {}
     void Draw(LevelInterface& level) override;
 };
 

--- a/editor/tab_programs.cpp
+++ b/editor/tab_programs.cpp
@@ -1,0 +1,14 @@
+#include "tab_programs.h"
+
+#include <imgui.h>
+
+namespace frame::gui {
+
+void TabPrograms::Draw(LevelInterface& level) {
+    for (auto id : level.GetPrograms()) {
+        auto& prog = level.GetProgramFromId(id);
+        ImGui::BulletText("%s", prog.GetName().c_str());
+    }
+}
+
+} // namespace frame::gui

--- a/editor/tab_programs.h
+++ b/editor/tab_programs.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "tab_interface.h"
+
+namespace frame::gui {
+
+class TabPrograms : public TabInterface {
+  public:
+    std::string GetName() const override { return "Programs"; }
+    void Draw(LevelInterface& level) override;
+};
+
+} // namespace frame::gui

--- a/editor/tab_programs.h
+++ b/editor/tab_programs.h
@@ -6,7 +6,7 @@ namespace frame::gui {
 
 class TabPrograms : public TabInterface {
   public:
-    std::string GetName() const override { return "Programs"; }
+    TabPrograms() : TabInterface("Programs") {}
     void Draw(LevelInterface& level) override;
 };
 

--- a/editor/tab_scene.cpp
+++ b/editor/tab_scene.cpp
@@ -1,0 +1,60 @@
+#include "tab_scene.h"
+
+#include <imgui.h>
+
+namespace ed = ax::NodeEditor;
+
+namespace frame::gui {
+
+TabScene::~TabScene() {
+    if (context_)
+        ed::DestroyEditor(context_);
+}
+
+void TabScene::DisplayNode(LevelInterface& level, EntityId id, EntityId parent) {
+    auto name = level.GetNameFromId(id);
+    ed::BeginNode(id);
+
+    auto input_id = id * 2 + 1;
+    auto output_id = id * 2 + 2;
+
+    ed::BeginPin(input_id, ed::PinKind::Input);
+    ImGui::Dummy(ImVec2(10, 10));
+    ed::EndPin();
+
+    ImGui::SameLine();
+    ImGui::Text("%s", name.c_str());
+    ImGui::SameLine();
+
+    ed::BeginPin(output_id, ed::PinKind::Output);
+    ImGui::Dummy(ImVec2(10, 10));
+    ed::EndPin();
+
+    ed::EndNode();
+
+    if (parent != frame::NullId) {
+        auto parent_output = parent * 2 + 2;
+        std::uint64_t link_id = (static_cast<std::uint64_t>(parent) << 32) |
+                                static_cast<std::uint64_t>(id);
+        ed::Link(static_cast<ed::LinkId>(link_id), parent_output, input_id);
+    }
+
+    for (auto child : level.GetChildList(id)) {
+        DisplayNode(level, child, id);
+    }
+}
+
+void TabScene::Draw(LevelInterface& level) {
+    if (!context_)
+        context_ = ed::CreateEditor();
+
+    ed::SetCurrentEditor(context_);
+    ed::Begin("SceneEditor");
+    auto root = level.GetDefaultRootSceneNodeId();
+    if (root)
+        DisplayNode(level, root, frame::NullId);
+    ed::End();
+    ed::SetCurrentEditor(nullptr);
+}
+
+} // namespace frame::gui

--- a/editor/tab_scene.h
+++ b/editor/tab_scene.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "tab_interface.h"
+#include "frame/entity_id.h"
+#include <imgui-node-editor/imgui_node_editor.h>
+
+namespace frame::gui {
+
+class TabScene : public TabInterface {
+  public:
+    TabScene() = default;
+    ~TabScene() override;
+
+    std::string GetName() const override { return "Scene"; }
+    void Draw(LevelInterface& level) override;
+
+  private:
+    void DisplayNode(LevelInterface& level, EntityId id, EntityId parent);
+
+    ax::NodeEditor::EditorContext* context_ = nullptr;
+};
+
+} // namespace frame::gui

--- a/editor/tab_scene.h
+++ b/editor/tab_scene.h
@@ -8,10 +8,9 @@ namespace frame::gui {
 
 class TabScene : public TabInterface {
   public:
-    TabScene() = default;
+    TabScene() : TabInterface("Scene") {}
     ~TabScene() override;
 
-    std::string GetName() const override { return "Scene"; }
     void Draw(LevelInterface& level) override;
 
   private:

--- a/editor/tab_textures.cpp
+++ b/editor/tab_textures.cpp
@@ -1,0 +1,14 @@
+#include "tab_textures.h"
+
+#include <imgui.h>
+
+namespace frame::gui {
+
+void TabTextures::Draw(LevelInterface& level) {
+    for (auto id : level.GetTextures()) {
+        auto& tex = level.GetTextureFromId(id);
+        ImGui::BulletText("%s", tex.GetName().c_str());
+    }
+}
+
+} // namespace frame::gui

--- a/editor/tab_textures.h
+++ b/editor/tab_textures.h
@@ -6,7 +6,7 @@ namespace frame::gui {
 
 class TabTextures : public TabInterface {
   public:
-    std::string GetName() const override { return "Textures"; }
+    TabTextures() : TabInterface("Textures") {}
     void Draw(LevelInterface& level) override;
 };
 

--- a/editor/tab_textures.h
+++ b/editor/tab_textures.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "tab_interface.h"
+
+namespace frame::gui {
+
+class TabTextures : public TabInterface {
+  public:
+    std::string GetName() const override { return "Textures"; }
+    void Draw(LevelInterface& level) override;
+};
+
+} // namespace frame::gui

--- a/editor/window_level.cpp
+++ b/editor/window_level.cpp
@@ -1,124 +1,28 @@
 #include "window_level.h"
 
-#include <algorithm>
-#include <cmath>
-#include <cstdint>
-#include <fstream>
-#include <imgui-node-editor/imgui_node_editor.h>
 #include <imgui.h>
+#include <fstream>
+#include <cstdint>
 
-#include "frame/entity_id.h"
 #include "frame/file/file_system.h"
 #include "frame/json/parse_level.h"
 
-namespace ed = ax::NodeEditor;
-
-namespace frame::gui
-{
+namespace frame::gui {
 
 WindowLevel::WindowLevel(DeviceInterface& device, const std::string& file_name)
-    : WindowJsonFile(file_name, device), device_(device)
-{
-}
+    : WindowJsonFile(file_name, device), device_(device) {}
 
-WindowLevel::~WindowLevel()
-{
-    if (context_)
-        ed::DestroyEditor(context_);
-}
-
-void WindowLevel::DisplayNode(
-    LevelInterface& level, EntityId id, EntityId parent)
-{
-    auto name = level.GetNameFromId(id);
-    ed::BeginNode(id);
-
-    auto input_id = id * 2 + 1;
-    auto output_id = id * 2 + 2;
-
-    ed::BeginPin(input_id, ed::PinKind::Input);
-    ImGui::Dummy(ImVec2(10, 10));
-    ed::EndPin();
-
-    ImGui::SameLine();
-    ImGui::Text("%s", name.c_str());
-    ImGui::SameLine();
-
-    ed::BeginPin(output_id, ed::PinKind::Output);
-    ImGui::Dummy(ImVec2(10, 10));
-    ed::EndPin();
-
-    ed::EndNode();
-
-    if (parent != frame::NullId)
-    {
-        auto parent_output = parent * 2 + 2;
-        std::uint64_t link_id = (static_cast<std::uint64_t>(parent) << 32) |
-                                static_cast<std::uint64_t>(id);
-        ed::Link(static_cast<ed::LinkId>(link_id), parent_output, input_id);
-    }
-
-    for (auto child : level.GetChildList(id))
-    {
-        DisplayNode(level, child, id);
-    }
-}
-
-void WindowLevel::DrawTexturesTab(LevelInterface& level)
-{
-    for (auto id : level.GetTextures())
-    {
-        auto& tex = level.GetTextureFromId(id);
-        ImGui::BulletText("%s", tex.GetName().c_str());
-    }
-}
-
-void WindowLevel::DrawProgramsTab(LevelInterface& level)
-{
-    for (auto id : level.GetPrograms())
-    {
-        auto& prog = level.GetProgramFromId(id);
-        ImGui::BulletText("%s", prog.GetName().c_str());
-    }
-}
-
-void WindowLevel::DrawMaterialsTab(LevelInterface& level)
-{
-    for (auto id : level.GetMaterials())
-    {
-        auto& mat = level.GetMaterialFromId(id);
-        ImGui::BulletText("%s", mat.GetName().c_str());
-    }
-}
-
-void WindowLevel::DrawSceneTab(LevelInterface& level)
-{
-    ed::SetCurrentEditor(context_);
-    ed::Begin("SceneEditor");
-    auto root = level.GetDefaultRootSceneNodeId();
-    if (root)
-    {
-        DisplayNode(level, root, frame::NullId);
-    }
-    ed::End();
-    ed::SetCurrentEditor(nullptr);
-}
-
-bool WindowLevel::DrawCallback()
-{
+bool WindowLevel::DrawCallback() {
     auto& level = device_.GetLevel();
     auto draw_toggle = [&]() {
-        if (show_json_)
-        {
+        if (show_json_) {
             ImGui::BeginDisabled();
             ImGui::Button("JSON Editor");
             ImGui::EndDisabled();
             ImGui::SameLine();
             if (ImGui::Button("Node Editor"))
                 show_json_ = false;
-        }
-        else
-        {
+        } else {
             if (ImGui::Button("JSON Editor"))
                 show_json_ = true;
             ImGui::SameLine();
@@ -128,44 +32,25 @@ bool WindowLevel::DrawCallback()
         }
     };
 
-    if (show_json_)
-    {
+    if (show_json_) {
         draw_toggle();
         ImGui::SameLine();
         WindowJsonFile::DrawCallback();
-    }
-    else
-    {
-        if (!context_)
-            context_ = ed::CreateEditor();
+    } else {
         draw_toggle();
         ImGui::SameLine();
-        if (ImGui::Button("Save"))
-        {
+        if (ImGui::Button("Save")) {
             // TODO: implement saving level
         }
         ImGui::Separator();
-        if (ImGui::BeginTabBar("##level_tabs"))
-        {
-            if (ImGui::BeginTabItem("Textures"))
-            {
-                DrawTexturesTab(level);
-                ImGui::EndTabItem();
-            }
-            if (ImGui::BeginTabItem("Programs"))
-            {
-                DrawProgramsTab(level);
-                ImGui::EndTabItem();
-            }
-            if (ImGui::BeginTabItem("Materials"))
-            {
-                DrawMaterialsTab(level);
-                ImGui::EndTabItem();
-            }
-            if (ImGui::BeginTabItem("Scene"))
-            {
-                DrawSceneTab(level);
-                ImGui::EndTabItem();
+        if (ImGui::BeginTabBar("##level_tabs")) {
+            TabInterface* tabs[] = {&tab_textures_, &tab_programs_,
+                                    &tab_materials_, &tab_scene_};
+            for (TabInterface* tab : tabs) {
+                if (ImGui::BeginTabItem(tab->GetName().c_str())) {
+                    tab->Draw(level);
+                    ImGui::EndTabItem();
+                }
             }
             ImGui::EndTabBar();
         }

--- a/editor/window_level.h
+++ b/editor/window_level.h
@@ -2,7 +2,11 @@
 
 #include "frame/device_interface.h"
 #include "frame/gui/window_json_file.h"
-#include <imgui-node-editor/imgui_node_editor.h>
+
+#include "tab_materials.h"
+#include "tab_programs.h"
+#include "tab_scene.h"
+#include "tab_textures.h"
 
 namespace frame::gui
 {
@@ -11,19 +15,16 @@ class WindowLevel : public WindowJsonFile
 {
   public:
     WindowLevel(DeviceInterface& device, const std::string& file_name);
-    ~WindowLevel() override;
+    ~WindowLevel() override = default;
 
     bool DrawCallback() override;
 
   private:
-    void DisplayNode(LevelInterface& level, EntityId id, EntityId parent);
-    void DrawTexturesTab(LevelInterface& level);
-    void DrawProgramsTab(LevelInterface& level);
-    void DrawMaterialsTab(LevelInterface& level);
-    void DrawSceneTab(LevelInterface& level);
-
     DeviceInterface& device_;
-    ax::NodeEditor::EditorContext* context_ = nullptr;
+    TabTextures tab_textures_;
+    TabPrograms tab_programs_;
+    TabMaterials tab_materials_;
+    TabScene tab_scene_;
     bool show_json_ = false;
 };
 


### PR DESCRIPTION
## Summary
- update `TabInterface` to inherit from `NameInterface`
- return `std::string` from tab `GetName()` implementations
- adjust `WindowLevel` to use the string-based names

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "absl")*
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_686caf03c85c8329864441135e5285bb