### PR TITLE
Fix workflow to use presets

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -41,10 +41,39 @@ jobs:
     - name: apt install
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-        sudo apt update 
-        sudo apt install -y libxmu-dev libxi-dev libgl-dev libglx-dev libgles-dev \
-         build-essential libx11-xcb-dev libegl1-mesa-dev libopengl-dev \
-        libxkbcommon-dev libwayland-dev libxrandr-dev mesa-vulkan-drivers libglu1-mesa-dev libdrm-dev libegl-dev libglm-dev 
+        sudo apt update
+        sudo apt install -y \
+          ninja-build \
+          build-essential \
+          libxi-dev \
+          libxmu-dev \
+          libx11-dev \
+          libxrandr-dev \
+          libxinerama-dev \
+          libx11-xcb-dev \
+          libxcb1-dev \
+          libxcb-randr0-dev \
+          libxcb-xfixes0-dev \
+          libxkbcommon-dev \
+          libwayland-dev \
+          wayland-protocols \
+          libgl1-mesa-dev \
+          libglu1-mesa-dev \
+          libglx-dev \
+          xorg-dev \
+          autoconf \
+          automake \
+          autoconf-archive \
+          libtool \
+          libtool-bin \
+          libltdl-dev \
+          gettext \
+          pkg-config \
+          gperf \
+          python3-jinja2
+    - name: Ensure Python Jinja2 available
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: pip install jinja2
       # the dependency list is too big but at least it works
       # https://packages.ubuntu.com/search
     - name: vcpkg build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,8 @@ jobs:
           autoconf-archive \
           libtool \
           libltdl-dev \
+          gettext \
+          pkg-config \
           python3-jinja2
 
     - name: Ensure Python Jinja2 available

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,9 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y ninja-build build-essential libxi-dev libxmu-dev libgl1-mesa-dev libglu1-mesa-dev autoconf automake autoconf-archive libtool python3-jinja2
+
+    - name: Ensure Python Jinja2 available
+      run: pip install jinja2
         
     #- name: Install Vulkan SDK
     #  run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
@@ -22,25 +22,26 @@ jobs:
     #    Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/1.3.261.1/windows/VulkanSDK-1.3.261.1-Installer.exe" -OutFile "VulkanSDKInstaller.exe"
     #    Start-Process ./VulkanSDKInstaller.exe -ArgumentList "/S" -NoNewWindow -Wait
       
-    - name: Bootstrap vcpkg
-      shell: cmd
+    - name: Install dependencies
       run: |
-        cd external\vcpkg
-        bootstrap-vcpkg.bat
-        vcpkg integrate install
+        sudo apt-get update
+        sudo apt-get install -y ninja-build libxmu-dev libxi-dev libgl-dev libglx-dev libgles-dev build-essential libx11-xcb-dev libegl1-mesa-dev libopengl-dev libxkbcommon-dev libwayland-dev libxrandr-dev mesa-vulkan-drivers libglu1-mesa-dev libdrm-dev libegl-dev libglm-dev
+
+    - name: Bootstrap vcpkg
+      run: |
+        cd external/vcpkg
+        ./bootstrap-vcpkg.sh
+        ./vcpkg integrate install
 
     # No need for a manual vcpkg install step, the manifest mode will handle it
 
     - name: Configure with CMake Preset
-      shell: cmd
-      run: cmake --preset windows
+      run: cmake --preset linux-release
 
     - name: Build with CMake Preset
-      shell: cmd
-      run: cmake --build --preset windows-release
+      run: cmake --build --preset linux-release
         
     - name: Run tests using CTest
-      shell: cmd
       run: |
-        cd build\windows
-        ctest -C Release --output-on-failure
+        cd build/linux-release
+        xvfb-run ctest --output-on-failure

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - name: Checkout code
@@ -22,26 +22,23 @@ jobs:
     #    Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/1.3.261.1/windows/VulkanSDK-1.3.261.1-Installer.exe" -OutFile "VulkanSDKInstaller.exe"
     #    Start-Process ./VulkanSDKInstaller.exe -ArgumentList "/S" -NoNewWindow -Wait
       
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y ninja-build libxmu-dev libxi-dev libgl-dev libglx-dev libgles-dev build-essential libx11-xcb-dev libegl1-mesa-dev libopengl-dev libxkbcommon-dev libwayland-dev libxrandr-dev mesa-vulkan-drivers libglu1-mesa-dev libdrm-dev libegl-dev libglm-dev
-
     - name: Bootstrap vcpkg
+      shell: cmd
       run: |
-        cd external/vcpkg
-        ./bootstrap-vcpkg.sh
-        ./vcpkg integrate install
+        cd external\vcpkg
+        bootstrap-vcpkg.bat
+        vcpkg integrate install
 
     # No need for a manual vcpkg install step, the manifest mode will handle it
 
     - name: Configure with CMake Preset
-      run: cmake --preset linux-release
+      run: cmake --preset windows
 
     - name: Build with CMake Preset
-      run: cmake --build --preset linux-release
+      run: cmake --build --preset windows-release
         
     - name: Run tests using CTest
+      shell: cmd
       run: |
-        cd build/linux-release
-        xvfb-run ctest --output-on-failure
+        cd build\windows
+        ctest -C Release --output-on-failure

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,8 @@ jobs:
         
     - name: Run tests using CTest
       shell: cmd
+      env:
+        SDL_VIDEODRIVER: dummy
       run: |
         cd build\windows
         ctest -C Release --output-on-failure

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,13 +4,14 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: windows-latest
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         lfs: true
+        submodules: true
 
     - name: Git-lfs pull
       run: |
@@ -21,34 +22,25 @@ jobs:
     #    Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/1.3.261.1/windows/VulkanSDK-1.3.261.1-Installer.exe" -OutFile "VulkanSDKInstaller.exe"
     #    Start-Process ./VulkanSDKInstaller.exe -ArgumentList "/S" -NoNewWindow -Wait
       
-    - name: Setup vcpkg
+    - name: Bootstrap vcpkg
+      shell: cmd
       run: |
-        git clone https://github.com/microsoft/vcpkg.git
-        cd vcpkg
-        git checkout tags/2024.02.14
-        ./bootstrap-vcpkg.bat
-        ./vcpkg integrate install
+        cd external\vcpkg
+        bootstrap-vcpkg.bat
+        vcpkg integrate install
 
     # No need for a manual vcpkg install step, the manifest mode will handle it
 
-    - name: Create Build Environment using CMake
+    - name: Configure with CMake Preset
       shell: cmd
-      run: |
-        mkdir build
-        cd build
-        cmake -DCMAKE_TOOLCHAIN_FILE=C:/actions-runner/_work/Frame/Frame/vcpkg/scripts/buildsystems/vcpkg.cmake -A x64 ..
+      run: cmake --preset windows
 
-    - name: Build with CMake
+    - name: Build with CMake Preset
       shell: cmd
-      run: |
-        cd build
-        cmake --build . --config Release
+      run: cmake --build --preset windows-release
         
-    - name: Run tests using gtest
+    - name: Run tests using CTest
       shell: cmd
       run: |
-        .\build\tests\Release\FrameFileTest.exe
-        .\build\tests\Release\FrameJsonTest.exe
-        .\build\tests\Release\FrameOpenGLTest.exe
-        .\build\tests\frame\opengl\file\tests\Release\FrameOpenGLFileTest.exe
-        .\build\tests\frame\tests\Release\FrameTest.exe
+        cd build\windows
+        ctest -C Release --output-on-failure

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
           automake \
           autoconf-archive \
           libtool \
+          libtool-bin \
           libltdl-dev \
           gettext \
           pkg-config \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,8 @@ jobs:
           wayland-protocols \
           libgl1-mesa-dev \
           libglu1-mesa-dev \
+          libglx-dev \
+          xorg-dev \
           autoconf \
           automake \
           autoconf-archive \
@@ -44,6 +46,7 @@ jobs:
           libltdl-dev \
           gettext \
           pkg-config \
+          gperf \
           python3-jinja2
 
     - name: Ensure Python Jinja2 available

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,19 @@ jobs:
     - name: Install build dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y ninja-build build-essential libxi-dev libxmu-dev libgl1-mesa-dev libglu1-mesa-dev autoconf automake autoconf-archive libtool python3-jinja2
+        sudo apt-get install -y \
+          ninja-build \
+          build-essential \
+          libxi-dev \
+          libxmu-dev \
+          libgl1-mesa-dev \
+          libglu1-mesa-dev \
+          autoconf \
+          automake \
+          autoconf-archive \
+          libtool \
+          libltdl-dev \
+          python3-jinja2
 
     - name: Ensure Python Jinja2 available
       run: pip install jinja2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
@@ -16,6 +16,11 @@ jobs:
     - name: Git-lfs pull
       run: |
         git lfs pull
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ninja-build build-essential libxi-dev libxmu-dev libgl1-mesa-dev libglu1-mesa-dev autoconf automake autoconf-archive libtool python3-jinja2
         
     #- name: Install Vulkan SDK
     #  run: |
@@ -23,22 +28,20 @@ jobs:
     #    Start-Process ./VulkanSDKInstaller.exe -ArgumentList "/S" -NoNewWindow -Wait
       
     - name: Bootstrap vcpkg
-      shell: cmd
       run: |
-        cd external\vcpkg
-        bootstrap-vcpkg.bat
-        vcpkg integrate install
+        cd external/vcpkg
+        ./bootstrap-vcpkg.sh
+        ./vcpkg integrate install
 
     # No need for a manual vcpkg install step, the manifest mode will handle it
 
     - name: Configure with CMake Preset
-      run: cmake --preset windows
+      run: cmake --preset linux-release
 
     - name: Build with CMake Preset
-      run: cmake --build --preset windows-release
+      run: cmake --build --preset linux-release
         
     - name: Run tests using CTest
-      shell: cmd
       run: |
-        cd build\windows
-        ctest -C Release --output-on-failure
+        cd build/linux-release
+        xvfb-run ctest --output-on-failure

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,16 @@ jobs:
           build-essential \
           libxi-dev \
           libxmu-dev \
+          libx11-dev \
+          libxrandr-dev \
+          libxinerama-dev \
+          libx11-xcb-dev \
+          libxcb1-dev \
+          libxcb-randr0-dev \
+          libxcb-xfixes0-dev \
+          libxkbcommon-dev \
+          libwayland-dev \
+          wayland-protocols \
           libgl1-mesa-dev \
           libglu1-mesa-dev \
           autoconf \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,6 @@ jobs:
         
     - name: Run tests using CTest
       shell: cmd
-      env:
-        SDL_VIDEODRIVER: dummy
       run: |
         cd build\windows
         ctest -C Release --output-on-failure

--- a/include/frame/json/serialize_json.h
+++ b/include/frame/json/serialize_json.h
@@ -4,7 +4,6 @@
 #include <format>
 #include <fstream>
 #include <google/protobuf/util/json_util.h>
-#include <print>
 #include <stdexcept>
 #include <string>
 

--- a/src/frame/CMakeLists.txt
+++ b/src/frame/CMakeLists.txt
@@ -57,6 +57,7 @@ target_include_directories(Frame
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include
     ${CMAKE_CURRENT_SOURCE_DIR}/../../src
     ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_BINARY_DIR}/src
     ${CMAKE_BINARY_DIR}/src/frame/proto
 )
 

--- a/src/frame/file/file_system.cpp
+++ b/src/frame/file/file_system.cpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <iostream>
 #include <string_view>
+#include <format>
 
 namespace
 {

--- a/src/frame/gui/CMakeLists.txt
+++ b/src/frame/gui/CMakeLists.txt
@@ -40,6 +40,7 @@ target_include_directories(FrameGui
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../src
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../external/ImGuiColorTextEdit
+  ${CMAKE_BINARY_DIR}/src
   ${CMAKE_BINARY_DIR}/src/frame/proto
 )
 

--- a/src/frame/gui/CMakeLists.txt
+++ b/src/frame/gui/CMakeLists.txt
@@ -40,6 +40,7 @@ target_include_directories(FrameGui
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../src
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../external/ImGuiColorTextEdit
+  ${CMAKE_BINARY_DIR}/src/frame/proto
 )
 
 target_link_libraries(FrameGui
@@ -50,6 +51,7 @@ target_link_libraries(FrameGui
     imgui::imgui
     spdlog::spdlog
     protobuf::libprotobuf
+    FrameProto
 )
 
 set_property(TARGET FrameGui PROPERTY FOLDER "Frame")

--- a/src/frame/json/CMakeLists.txt
+++ b/src/frame/json/CMakeLists.txt
@@ -39,6 +39,7 @@ target_include_directories(FrameJson
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../src
     ${Protobuf_INCLUDE_DIRS}
+    ${CMAKE_BINARY_DIR}/src
     ${CMAKE_BINARY_DIR}/src/frame/proto
 )
 

--- a/src/frame/opengl/CMakeLists.txt
+++ b/src/frame/opengl/CMakeLists.txt
@@ -48,7 +48,8 @@ target_include_directories(FrameOpenGL
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../src
     ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}/src/frame/proto
+    ${CMAKE_BINARY_DIR}/src
+    ${CMAKE_BINARY_DIR}/src/frame/proto
 )
 
 target_link_libraries(FrameOpenGL

--- a/src/frame/opengl/file/CMakeLists.txt
+++ b/src/frame/opengl/file/CMakeLists.txt
@@ -16,7 +16,8 @@ target_include_directories(FrameOpenGLFile
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../../include
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../../src
     ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}/src/frame/proto
+    ${CMAKE_BINARY_DIR}/src
+    ${CMAKE_BINARY_DIR}/src/frame/proto
   PRIVATE
     ${STB_INCLUDE_DIRS}
 )

--- a/src/frame/vulkan/CMakeLists.txt
+++ b/src/frame/vulkan/CMakeLists.txt
@@ -18,7 +18,8 @@ target_include_directories(FrameVulkan
 PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}/src/frame/proto
+    ${CMAKE_BINARY_DIR}/src
+    ${CMAKE_BINARY_DIR}/src/frame/proto
 )
 
 target_link_libraries(FrameVulkan

--- a/tests/frame/CMakeLists.txt
+++ b/tests/frame/CMakeLists.txt
@@ -17,7 +17,8 @@ target_include_directories(FrameTest
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include
     ${CMAKE_CURRENT_SOURCE_DIR}/../../tests
     ${CMAKE_CURRENT_BINARY_DIR}/../../
-    ${CMAKE_CURRENT_BINARY_DIR}/src/frame/proto
+    ${CMAKE_BINARY_DIR}/src
+    ${CMAKE_BINARY_DIR}/src/frame/proto
 )
 
 target_link_libraries(FrameTest


### PR DESCRIPTION
## Summary
- use submodules in checkout step
- bootstrap local `vcpkg` rather than cloning
- switch to `cmake` presets for configure and build
- run tests with CTest

## Testing
- `cmake --preset linux-release` *(fails: building glew:x64-linux failed)*
- `cmake -B build -S .` *(fails: Could not find a package configuration file provided by "absl")*

------
https://chatgpt.com/codex/tasks/task_e_686cb72e1f8c8329836c75dd2323f4dd