### PR TITLE
Enable adding textures via GUI

### DIFF
--- a/editor/menubar.cpp
+++ b/editor/menubar.cpp
@@ -75,7 +75,9 @@ void Menubar::MenuEdit()
         {
             menubar_view_.GetDrawGui().AddWindow(
                 std::make_unique<WindowLevel>(
-                    device_, menubar_file_.GetFileName()));
+                    device_,
+                    menubar_view_.GetDrawGui(),
+                    menubar_file_.GetFileName()));
         }
         if (ImGui::BeginMenu("Shader"))
         {

--- a/editor/tab_textures.cpp
+++ b/editor/tab_textures.cpp
@@ -11,8 +11,9 @@ namespace frame::gui
 void TabTextures::Draw(LevelInterface& level)
 {
     const float button_size = ImGui::GetFrameHeight();
-    bool open =
-        ImGui::CollapsingHeader("Textures", ImGuiTreeNodeFlags_DefaultOpen);
+    bool open = ImGui::CollapsingHeader(
+        "Textures",
+        ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_AllowItemOverlap);
     ImVec2 header_min = ImGui::GetItemRectMin();
     ImVec2 header_max = ImGui::GetItemRectMax();
     ImGui::SetItemAllowOverlap();
@@ -62,6 +63,8 @@ void TabTextures::AddTextureFromFile(
         texture->SetName(name);
         texture->SetSerializeEnable(true);
         level.AddTexture(std::move(texture));
+        if (update_json_callback_)
+            update_json_callback_();
     }
     catch (const std::exception&)
     {

--- a/editor/tab_textures.cpp
+++ b/editor/tab_textures.cpp
@@ -15,6 +15,7 @@ void TabTextures::Draw(LevelInterface& level)
         ImGui::CollapsingHeader("Textures", ImGuiTreeNodeFlags_DefaultOpen);
     ImVec2 header_min = ImGui::GetItemRectMin();
     ImVec2 header_max = ImGui::GetItemRectMax();
+    ImGui::SetItemAllowOverlap();
     ImGui::SetCursorScreenPos({header_max.x - button_size - 4.f, header_min.y});
     if (ImGui::Button("+", ImVec2(button_size, button_size)))
     {

--- a/editor/tab_textures.cpp
+++ b/editor/tab_textures.cpp
@@ -1,22 +1,70 @@
 #include "tab_textures.h"
 #include "frame/entity_id.h"
+#include "frame/file/file_system.h"
+#include "frame/opengl/texture.h"
 
 #include <imgui.h>
 
-namespace frame::gui {
+namespace frame::gui
+{
 
-void TabTextures::Draw(LevelInterface& level) {
-    if (ImGui::CollapsingHeader("Textures", ImGuiTreeNodeFlags_DefaultOpen)) {
-        for (auto id : level.GetTextures()) {
+void TabTextures::Draw(LevelInterface& level)
+{
+    const float button_size = ImGui::GetFrameHeight();
+    bool open =
+        ImGui::CollapsingHeader("Textures", ImGuiTreeNodeFlags_DefaultOpen);
+    ImVec2 header_min = ImGui::GetItemRectMin();
+    ImVec2 header_max = ImGui::GetItemRectMax();
+    ImGui::SetCursorScreenPos({header_max.x - button_size - 4.f, header_min.y});
+    if (ImGui::Button("+", ImVec2(button_size, button_size)))
+    {
+        draw_gui_.AddModalWindow(
+            std::make_unique<WindowFileDialog>(
+                "",
+                FileDialogEnum::OPEN,
+                [this, &level](const std::string& file) {
+                    AddTextureFromFile(level, file);
+                }));
+    }
+    if (open)
+    {
+        for (auto id : level.GetTextures())
+        {
             auto& tex = level.GetTextureFromId(id);
             ImGui::Selectable(tex.GetName().c_str());
-            if (ImGui::BeginDragDropSource()) {
+            if (ImGui::BeginDragDropSource())
+            {
                 EntityId payload = id;
-                ImGui::SetDragDropPayload("FRAME_ASSET_ID", &payload, sizeof(payload));
+                ImGui::SetDragDropPayload(
+                    "FRAME_ASSET_ID", &payload, sizeof(payload));
                 ImGui::Text("%s", tex.GetName().c_str());
                 ImGui::EndDragDropSource();
             }
         }
+    }
+}
+
+void TabTextures::AddTextureFromFile(
+    LevelInterface& level, const std::string& file)
+{
+    try
+    {
+        auto texture = std::make_unique<opengl::Texture>(file);
+        std::filesystem::path path = file;
+        std::string base_name = path.stem().string();
+        std::string name = base_name;
+        int counter = 1;
+        while (level.GetIdFromName(name) != frame::NullId)
+        {
+            name = base_name + "_" + std::to_string(counter++);
+        }
+        texture->SetName(name);
+        texture->SetSerializeEnable(true);
+        level.AddTexture(std::move(texture));
+    }
+    catch (const std::exception&)
+    {
+        // Ignore errors when loading texture
     }
 }
 

--- a/editor/tab_textures.h
+++ b/editor/tab_textures.h
@@ -2,6 +2,7 @@
 
 #include "frame/gui/draw_gui_interface.h"
 #include "frame/gui/window_file_dialog.h"
+#include <functional>
 #include "tab_interface.h"
 
 namespace frame::gui
@@ -10,8 +11,12 @@ namespace frame::gui
 class TabTextures : public TabInterface
 {
   public:
-    explicit TabTextures(DrawGuiInterface& draw_gui)
-        : TabInterface("Textures"), draw_gui_(draw_gui)
+    TabTextures(
+        DrawGuiInterface& draw_gui,
+        std::function<void()> update_json_callback)
+        : TabInterface("Textures"),
+          draw_gui_(draw_gui),
+          update_json_callback_(std::move(update_json_callback))
     {
     }
 
@@ -22,6 +27,7 @@ class TabTextures : public TabInterface
 
   private:
     DrawGuiInterface& draw_gui_;
+    std::function<void()> update_json_callback_;
 };
 
 } // namespace frame::gui

--- a/editor/tab_textures.h
+++ b/editor/tab_textures.h
@@ -1,13 +1,27 @@
 #pragma once
 
+#include "frame/gui/draw_gui_interface.h"
+#include "frame/gui/window_file_dialog.h"
 #include "tab_interface.h"
 
-namespace frame::gui {
+namespace frame::gui
+{
 
-class TabTextures : public TabInterface {
+class TabTextures : public TabInterface
+{
   public:
-    TabTextures() : TabInterface("Textures") {}
+    explicit TabTextures(DrawGuiInterface& draw_gui)
+        : TabInterface("Textures"), draw_gui_(draw_gui)
+    {
+    }
+
     void Draw(LevelInterface& level) override;
+
+  private:
+    void AddTextureFromFile(LevelInterface& level, const std::string& file);
+
+  private:
+    DrawGuiInterface& draw_gui_;
 };
 
 } // namespace frame::gui

--- a/editor/window_level.cpp
+++ b/editor/window_level.cpp
@@ -1,28 +1,39 @@
 #include "window_level.h"
 
-#include <imgui.h>
-#include <fstream>
 #include <cstdint>
+#include <fstream>
+#include <imgui.h>
 
 #include "frame/file/file_system.h"
 #include "frame/json/parse_level.h"
 
-namespace frame::gui {
+namespace frame::gui
+{
 
-WindowLevel::WindowLevel(DeviceInterface& device, const std::string& file_name)
-    : WindowJsonFile(file_name, device), device_(device) {}
+WindowLevel::WindowLevel(
+    DeviceInterface& device,
+    DrawGuiInterface& draw_gui,
+    const std::string& file_name)
+    : WindowJsonFile(file_name, device), device_(device), draw_gui_(draw_gui),
+      tab_textures_(draw_gui)
+{
+}
 
-bool WindowLevel::DrawCallback() {
+bool WindowLevel::DrawCallback()
+{
     auto& level = device_.GetLevel();
     auto draw_toggle = [&]() {
-        if (show_json_) {
+        if (show_json_)
+        {
             ImGui::BeginDisabled();
             ImGui::Button("JSON Editor");
             ImGui::EndDisabled();
             ImGui::SameLine();
             if (ImGui::Button("Node Editor"))
                 show_json_ = false;
-        } else {
+        }
+        else
+        {
             if (ImGui::Button("JSON Editor"))
                 show_json_ = true;
             ImGui::SameLine();
@@ -34,14 +45,18 @@ bool WindowLevel::DrawCallback() {
 
     draw_toggle();
     ImGui::SameLine();
-    if (ImGui::Button("Save")) {
+    if (ImGui::Button("Save"))
+    {
         // TODO: implement saving level
     }
     ImGui::Separator();
 
-    if (show_json_) {
+    if (show_json_)
+    {
         WindowJsonFile::DrawCallback();
-    } else {
+    }
+    else
+    {
         ImGui::Begin("Assets", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
         tab_textures_.Draw(level);
         tab_programs_.Draw(level);

--- a/editor/window_level.cpp
+++ b/editor/window_level.cpp
@@ -6,6 +6,8 @@
 
 #include "frame/file/file_system.h"
 #include "frame/json/parse_level.h"
+#include "frame/json/serialize_json.h"
+#include "frame/json/serialize_level.h"
 
 namespace frame::gui
 {
@@ -14,9 +16,18 @@ WindowLevel::WindowLevel(
     DeviceInterface& device,
     DrawGuiInterface& draw_gui,
     const std::string& file_name)
-    : WindowJsonFile(file_name, device), device_(device), draw_gui_(draw_gui),
-      tab_textures_(draw_gui)
+    : WindowJsonFile(file_name, device),
+      device_(device),
+      draw_gui_(draw_gui),
+      tab_textures_(draw_gui, [this]() { UpdateJsonEditor(); })
 {
+}
+
+void WindowLevel::UpdateJsonEditor()
+{
+    auto proto_level = frame::json::SerializeLevel(device_.GetLevel());
+    std::string json = frame::json::SaveProtoToJson(proto_level);
+    SetEditorText(json);
 }
 
 bool WindowLevel::DrawCallback()

--- a/editor/window_level.h
+++ b/editor/window_level.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "frame/device_interface.h"
+#include "frame/gui/draw_gui_interface.h"
 #include "frame/gui/window_json_file.h"
 
 #include "tab_materials.h"
@@ -14,13 +15,17 @@ namespace frame::gui
 class WindowLevel : public WindowJsonFile
 {
   public:
-    WindowLevel(DeviceInterface& device, const std::string& file_name);
+    WindowLevel(
+        DeviceInterface& device,
+        DrawGuiInterface& draw_gui,
+        const std::string& file_name);
     ~WindowLevel() override = default;
 
     bool DrawCallback() override;
 
   private:
     DeviceInterface& device_;
+    DrawGuiInterface& draw_gui_;
     TabTextures tab_textures_;
     TabPrograms tab_programs_;
     TabMaterials tab_materials_;

--- a/editor/window_level.h
+++ b/editor/window_level.h
@@ -21,6 +21,9 @@ class WindowLevel : public WindowJsonFile
         const std::string& file_name);
     ~WindowLevel() override = default;
 
+    /** @brief Update the JSON editor with the current level state. */
+    void UpdateJsonEditor();
+
     bool DrawCallback() override;
 
   private:

--- a/include/frame/gui/window_json_file.h
+++ b/include/frame/gui/window_json_file.h
@@ -25,6 +25,11 @@ class WindowJsonFile : public GuiWindowInterface
     std::string GetName() const override;
     void SetName(const std::string& name) override;
 
+    /** @brief Set the text in the internal editor. */
+    void SetEditorText(const std::string& text);
+    /** @brief Get the text from the internal editor. */
+    std::string GetEditorText() const;
+
   private:
     std::string name_;
     std::string file_name_;

--- a/src/frame/gui/window_json_file.cpp
+++ b/src/frame/gui/window_json_file.cpp
@@ -137,4 +137,14 @@ void WindowJsonFile::SetName(const std::string& name)
     name_ = name;
 }
 
+void WindowJsonFile::SetEditorText(const std::string& text)
+{
+    editor_.SetText(text);
+}
+
+std::string WindowJsonFile::GetEditorText() const
+{
+    return editor_.GetText();
+}
+
 } // End namespace frame::gui.


### PR DESCRIPTION
## Summary
- add a DrawGui reference to TabTextures so the editor can open a file dialog
- show a plus button in the texture tab and open a file dialog
- generate a unique name for the imported texture and add it to the level
- pass DrawGui to WindowLevel and update menubar to use the new constructor

## Testing
- `cmake --preset linux-release` *(fails: Could not find vcpkg toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68790edad7b8832989a6ccc57a872c5b