### PR TITLE
Fix JSON save button conflict and implement level saving

### DIFF
--- a/editor/window_level.cpp
+++ b/editor/window_level.cpp
@@ -56,9 +56,10 @@ bool WindowLevel::DrawCallback()
 
     draw_toggle();
     ImGui::SameLine();
-    if (ImGui::Button("Save"))
+    if (ImGui::Button("Save##level"))
     {
-        // TODO: implement saving level
+        auto proto_level = frame::json::SerializeLevel(level);
+        frame::json::SaveProtoToJsonFile(proto_level, GetFileName());
     }
     ImGui::Separator();
 

--- a/include/frame/gui/window_json_file.h
+++ b/include/frame/gui/window_json_file.h
@@ -30,6 +30,9 @@ class WindowJsonFile : public GuiWindowInterface
     /** @brief Get the text from the internal editor. */
     std::string GetEditorText() const;
 
+    /** @brief Get the file name associated with this window. */
+    const std::string& GetFileName() const;
+
   private:
     std::string name_;
     std::string file_name_;

--- a/src/frame/gui/window_json_file.cpp
+++ b/src/frame/gui/window_json_file.cpp
@@ -72,7 +72,7 @@ bool WindowJsonFile::DrawCallback()
         }
     }
     ImGui::SameLine();
-    if (ImGui::Button("Save"))
+    if (ImGui::Button("Save##json"))
     {
         try
         {
@@ -145,6 +145,11 @@ void WindowJsonFile::SetEditorText(const std::string& text)
 std::string WindowJsonFile::GetEditorText() const
 {
     return editor_.GetText();
+}
+
+const std::string& WindowJsonFile::GetFileName() const
+{
+    return file_name_;
 }
 
 } // End namespace frame::gui.


### PR DESCRIPTION
## Summary
- avoid ImGui ID collisions in JSON editor and level editor
- expose JSON editor's file name
- implement saving the level from level editor

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "absl")*

------
https://chatgpt.com/codex/tasks/task_e_687b999f8f40832982031ad107df0122