### PR TITLE
Fix node flow not resizing with editor window

### DIFF
--- a/editor/tab_scene.cpp
+++ b/editor/tab_scene.cpp
@@ -8,9 +8,11 @@ namespace frame::gui
 
 void TabScene::Draw(LevelInterface& level)
 {
+    ImVec2 avail = ImGui::GetContentRegionAvail();
+    node_flow_.setSize(avail);
+
     if (!initialized_)
     {
-        node_flow_.setSize(ImVec2(600.0f, 600.0f));
         auto root = level.GetDefaultRootSceneNodeId();
         std::function<void(EntityId, int)> add = [&](EntityId id, int depth) {
             auto name = level.GetNameFromId(id);


### PR DESCRIPTION
## Summary
- auto-size node flow canvas to match available space

## Testing
- `ctest --test-dir build/linux-debug --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6885d34ea2f083298fd261b4348c3776