### PR TITLE
Restore scene graph links and add node creation

### DIFF
--- a/editor/tab_scene.cpp
+++ b/editor/tab_scene.cpp
@@ -18,10 +18,11 @@ void TabScene::BuildScene(LevelInterface& level)
     std::function<void(EntityId, int)> add = [&](EntityId id, int depth) {
         auto name = level.GetNameFromId(id);
         auto node = node_flow_.addLambdaNode(
-            [name](ImFlow::BaseNode*) { ImGui::Text("%s", name.c_str()); },
+            [](ImFlow::BaseNode*) {},
             ImVec2(depth * 100.0f, depth * 60.0f));
+        node->setTitle(name);
         node->addIN<int>("in", 0, ImFlow::ConnectionFilter::None());
-        node->addOUT<int>("out");
+        static_cast<void>(node->addOUT<int>("out"));
         nodes_[id] = node;
         for (auto child : level.GetChildList(id))
             add(child, depth + 1);

--- a/editor/tab_scene.cpp
+++ b/editor/tab_scene.cpp
@@ -18,8 +18,7 @@ void TabScene::BuildScene(LevelInterface& level)
     std::function<void(EntityId, int)> add = [&](EntityId id, int depth) {
         auto name = level.GetNameFromId(id);
         auto node = node_flow_.addLambdaNode(
-            [](ImFlow::BaseNode*) {},
-            ImVec2(depth * 100.0f, depth * 60.0f));
+            [](ImFlow::BaseNode*) {}, ImVec2(depth * 100.0f, depth * 60.0f));
         node->setTitle(name);
         node->addIN<int>("in", 0, ImFlow::ConnectionFilter::None());
         static_cast<void>(node->addOUT<int>("out"));
@@ -45,7 +44,7 @@ void TabScene::Draw(LevelInterface& level)
     ImVec2 avail = ImGui::GetContentRegionAvail();
     node_flow_.setSize(avail);
 
-    if (ImGui::Button("Add Node"))
+    if (ImGui::Button("New Node"))
     {
         auto functor = [&level](const std::string& n) -> frame::NodeInterface* {
             auto maybe = level.GetIdFromName(n);
@@ -65,14 +64,9 @@ void TabScene::Draw(LevelInterface& level)
         if (root_id != frame::NullId)
             node->SetParentName(level.GetNameFromId(root_id));
         level.AddSceneNode(std::move(node));
-        initialized_ = false;
     }
 
-    if (!initialized_)
-    {
-        BuildScene(level);
-        initialized_ = true;
-    }
+    BuildScene(level);
 
     node_flow_.update();
 }

--- a/editor/tab_scene.cpp
+++ b/editor/tab_scene.cpp
@@ -1,31 +1,78 @@
 #include "tab_scene.h"
 
 #define IMGUI_DEFINE_MATH_OPERATORS
+#include <glm/glm.hpp>
 #include <imgui.h>
+
+#include "frame/node_matrix.h"
 
 namespace frame::gui
 {
+
+void TabScene::BuildScene(LevelInterface& level)
+{
+    nodes_.clear();
+    node_flow_ = ImFlow::ImNodeFlow();
+
+    auto root = level.GetDefaultRootSceneNodeId();
+    std::function<void(EntityId, int)> add = [&](EntityId id, int depth) {
+        auto name = level.GetNameFromId(id);
+        auto node = node_flow_.addLambdaNode(
+            [name](ImFlow::BaseNode*) { ImGui::Text("%s", name.c_str()); },
+            ImVec2(depth * 100.0f, depth * 60.0f));
+        node->addIN<int>("in", 0, ImFlow::ConnectionFilter::None());
+        node->addOUT<int>("out");
+        nodes_[id] = node;
+        for (auto child : level.GetChildList(id))
+            add(child, depth + 1);
+    };
+    if (root)
+        add(root, 0);
+
+    for (const auto& [id, node] : nodes_)
+    {
+        auto parent_id = level.GetParentId(id);
+        if (parent_id != frame::NullId && nodes_.count(parent_id))
+        {
+            nodes_[parent_id]->outPin("out")->createLink(node->inPin("in"));
+        }
+    }
+}
 
 void TabScene::Draw(LevelInterface& level)
 {
     ImVec2 avail = ImGui::GetContentRegionAvail();
     node_flow_.setSize(avail);
 
+    if (ImGui::Button("Add Node"))
+    {
+        auto functor = [&level](const std::string& n) -> frame::NodeInterface* {
+            auto maybe = level.GetIdFromName(n);
+            if (!maybe)
+                return nullptr;
+            return &level.GetSceneNodeFromId(maybe);
+        };
+        auto root_id = level.GetDefaultRootSceneNodeId();
+        std::string base = "Node";
+        std::string name = base;
+        int counter = 1;
+        while (level.GetIdFromName(name) != frame::NullId)
+            name = base + std::to_string(counter++);
+        auto node =
+            std::make_unique<frame::NodeMatrix>(functor, glm::mat4(1.0f));
+        node->SetName(name);
+        if (root_id != frame::NullId)
+            node->SetParentName(level.GetNameFromId(root_id));
+        level.AddSceneNode(std::move(node));
+        initialized_ = false;
+    }
+
     if (!initialized_)
     {
-        auto root = level.GetDefaultRootSceneNodeId();
-        std::function<void(EntityId, int)> add = [&](EntityId id, int depth) {
-            auto name = level.GetNameFromId(id);
-            node_flow_.addLambdaNode(
-                [name](ImFlow::BaseNode*) { ImGui::Text("%s", name.c_str()); },
-                ImVec2(depth * 50.0f, depth * 20.0f));
-            for (auto child : level.GetChildList(id))
-                add(child, depth + 1);
-        };
-        if (root)
-            add(root, 0);
+        BuildScene(level);
         initialized_ = true;
     }
+
     node_flow_.update();
 }
 

--- a/editor/tab_scene.h
+++ b/editor/tab_scene.h
@@ -6,6 +6,8 @@
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include <ImNodeFlow.h>
 #include <imgui.h>
+#include <memory>
+#include <unordered_map>
 
 namespace frame::gui
 {
@@ -21,8 +23,13 @@ class TabScene : public TabInterface
     void Draw(LevelInterface& level) override;
 
   private:
+    void BuildScene(LevelInterface& level);
+
+  private:
     bool initialized_ = false;
     ImFlow::ImNodeFlow node_flow_;
+    std::unordered_map<frame::EntityId, std::shared_ptr<ImFlow::BaseNode>>
+        nodes_;
 };
 
 } // namespace frame::gui

--- a/editor/tab_scene.h
+++ b/editor/tab_scene.h
@@ -26,7 +26,6 @@ class TabScene : public TabInterface
     void BuildScene(LevelInterface& level);
 
   private:
-    bool initialized_ = false;
     ImFlow::ImNodeFlow node_flow_;
     std::unordered_map<frame::EntityId, std::shared_ptr<ImFlow::BaseNode>>
         nodes_;


### PR DESCRIPTION
## Summary
- reconnect scene graph elements in the node editor using ImNodeFlow
- allow creation of new matrix nodes via a button

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6885e099f24483299ea8946852971dda