### PR TITLE
cleanup: Remove unused shadow mapping code

### DIFF
--- a/include/frame/light_interface.h
+++ b/include/frame/light_interface.h
@@ -61,16 +61,6 @@ struct LightInterface : public NameInterface
      * @return Return the color of the light.
      */
     virtual glm::vec3 GetColorIntensity() const = 0;
-    /**
-     * @brief Set the shadow map texture name.
-     * @param name: Name of the shadow map texture.
-     */
-    virtual void SetShadowMapTextureName(const std::string& name) = 0;
-    /**
-     * @brief Get the shadow map texture name.
-     * @return Name of the shadow map texture.
-     */
-    virtual std::string GetShadowMapTextureName() const = 0;
 };
 
 } // End namespace frame.

--- a/src/frame/json/parse_scene_tree.cpp
+++ b/src/frame/json/parse_scene_tree.cpp
@@ -317,56 +317,24 @@ std::function<NodeInterface*(const std::string& name)> GetFunctor(
     {
     case proto::NodeLight::POINT_LIGHT: {
         EntityId node_id = NullId;
-        if (proto_scene_light.shadow_type() == proto::NodeLight::NO_SHADOW)
-        {
-            auto node_light = std::make_unique<frame::NodeLight>(
-                GetFunctor(level),
-                LightTypeEnum::POINT_LIGHT,
-                ParseUniform(proto_scene_light.position()),
-                ParseUniform(proto_scene_light.color()));
-            node_light->GetData().set_name(proto_scene_light.name());
-            node_id = level.AddSceneNode(std::move(node_light));
-        }
-        else
-        {
-            auto node_light = std::make_unique<frame::NodeLight>(
-                GetFunctor(level),
-                LightTypeEnum::POINT_LIGHT,
-                static_cast<ShadowTypeEnum>(
-                    proto_scene_light.shadow_type()),
-                proto_scene_light.shadow_texture(),
-                ParseUniform(proto_scene_light.position()),
-                ParseUniform(proto_scene_light.color()));
-            node_light->GetData().set_name(proto_scene_light.name());
-            node_id = level.AddSceneNode(std::move(node_light));
-        }
+        auto node_light = std::make_unique<frame::NodeLight>(
+            GetFunctor(level),
+            LightTypeEnum::POINT_LIGHT,
+            ParseUniform(proto_scene_light.position()),
+            ParseUniform(proto_scene_light.color()));
+        node_light->GetData().set_name(proto_scene_light.name());
+        node_id = level.AddSceneNode(std::move(node_light));
         return static_cast<bool>(node_id);
     }
     case proto::NodeLight::DIRECTIONAL_LIGHT: {
         EntityId node_id = NullId;
-        if (proto_scene_light.shadow_type() == proto::NodeLight::NO_SHADOW)
-        {
-            auto node_light = std::make_unique<frame::NodeLight>(
-                GetFunctor(level),
-                LightTypeEnum::DIRECTIONAL_LIGHT,
-                ParseUniform(proto_scene_light.position()),
-                ParseUniform(proto_scene_light.color()));
-            node_light->GetData().set_name(proto_scene_light.name());
-            node_id = level.AddSceneNode(std::move(node_light));
-        }
-        else
-        {
-            auto node_light = std::make_unique<frame::NodeLight>(
-                GetFunctor(level),
-                LightTypeEnum::DIRECTIONAL_LIGHT,
-                static_cast<ShadowTypeEnum>(
-                    proto_scene_light.shadow_type()),
-                proto_scene_light.shadow_texture(),
-                ParseUniform(proto_scene_light.position()),
-                ParseUniform(proto_scene_light.color()));
-            node_light->GetData().set_name(proto_scene_light.name());
-            node_id = level.AddSceneNode(std::move(node_light));
-        }
+        auto node_light = std::make_unique<frame::NodeLight>(
+            GetFunctor(level),
+            LightTypeEnum::DIRECTIONAL_LIGHT,
+            ParseUniform(proto_scene_light.position()),
+            ParseUniform(proto_scene_light.color()));
+        node_light->GetData().set_name(proto_scene_light.name());
+        node_id = level.AddSceneNode(std::move(node_light));
         return static_cast<bool>(node_id);
     }
     case proto::NodeLight::AMBIENT_LIGHT:

--- a/src/frame/node_light.cpp
+++ b/src/frame/node_light.cpp
@@ -50,40 +50,6 @@ NodeLight::NodeLight(
     }
 }
 
-NodeLight::NodeLight(
-    std::function<NodeInterface*(const std::string&)> func,
-    const frame::LightTypeEnum light_type,
-    const frame::ShadowTypeEnum shadow_type,
-    const std::string& shadow_texture,
-    const glm::vec3 position_or_direction,
-    const glm::vec3 color)
-    : NodeInterface(func)
-{
-    data_.set_light_type(
-        static_cast<proto::NodeLight::LightTypeEnum>(light_type));
-    data_.mutable_color()->CopyFrom(json::SerializeUniformVector3(color));
-    switch (data_.light_type())
-    {
-    case proto::NodeLight::POINT_LIGHT:
-        data_.mutable_position()->CopyFrom(
-            json::SerializeUniformVector3(position_or_direction));
-        break;
-    case proto::NodeLight::DIRECTIONAL_LIGHT:
-        data_.mutable_direction()->CopyFrom(
-            json::SerializeUniformVector3(position_or_direction));
-        break;
-    default: {
-        std::string value = std::to_string(static_cast<int>(light_type));
-        throw std::runtime_error("illegal light(" + value + ")");
-    }
-    }
-    if (shadow_type != ShadowTypeEnum::NO_SHADOW)
-    {
-        data_.set_shadow_type(
-            static_cast<proto::NodeLight::ShadowTypeEnum>(shadow_type));
-        data_.set_shadow_texture(shadow_texture);
-    }
-}
 
 NodeLight::NodeLight(
     std::function<NodeInterface*(const std::string&)> func,
@@ -105,33 +71,6 @@ NodeLight::NodeLight(
     data_.set_dot_outer_limit(dot_outer_limit);
 }
 
-NodeLight::NodeLight(
-    std::function<NodeInterface*(const std::string&)> func,
-    ShadowTypeEnum shadow_type,
-    const std::string& shadow_texture,
-    const glm::vec3 position,
-    const glm::vec3 direction,
-    const glm::vec3 color,
-    const float dot_inner_limit,
-    const float dot_outer_limit)
-    : NodeInterface(func)
-{
-    data_.set_light_type(
-        static_cast<proto::NodeLight::LightTypeEnum>(
-            LightTypeEnum::SPOT_LIGHT));
-    data_.mutable_position()->CopyFrom(json::SerializeUniformVector3(position));
-    data_.mutable_direction()->CopyFrom(
-        json::SerializeUniformVector3(direction));
-    data_.mutable_color()->CopyFrom(json::SerializeUniformVector3(color));
-    data_.set_dot_inner_limit(dot_inner_limit);
-    data_.set_dot_outer_limit(dot_outer_limit);
-    if (shadow_type != ShadowTypeEnum::NO_SHADOW)
-    {
-        data_.set_shadow_type(
-            static_cast<proto::NodeLight::ShadowTypeEnum>(shadow_type));
-        data_.set_shadow_texture(shadow_texture);
-    }
-}
 
 glm::mat4 NodeLight::GetLocalModel(const double dt) const
 {

--- a/src/frame/node_light.h
+++ b/src/frame/node_light.h
@@ -41,24 +41,6 @@ class NodeLight : public NodeInterface, public Serialize<proto::NodeLight>
         const glm::vec3 position_or_direction,
         const glm::vec3 color);
     /**
-     * @brief Create a point or directional light with shadow.
-     * @param func: This function return the ID from a string (it will need
-     *        a level passed in the capture list).
-     * @param light_type: Light type of the light.
-     * @param shadow_type: Type of shadow used.
-     * @param shadow_texture: Name of the texture to render for the shadows.
-     * @param position_or_direction: Position (if point light) or direction
-     *        (if directional light).
-     * @param color: Color of the light in vec3 format.
-     */
-    NodeLight(
-        std::function<NodeInterface*(const std::string&)> func,
-        const frame::LightTypeEnum light_type,
-        const frame::ShadowTypeEnum shadow_type,
-        const std::string& shadow_texture,
-        const glm::vec3 position_or_direction,
-        const glm::vec3 color);
-    /**
      * @brief Create a spot light.
      * @param func: This function return the ID from a string (it will need
      *        a level passed in the capture list).
@@ -70,27 +52,6 @@ class NodeLight : public NodeInterface, public Serialize<proto::NodeLight>
      */
     NodeLight(
         std::function<NodeInterface*(const std::string&)> func,
-        const glm::vec3 position,
-        const glm::vec3 direction,
-        const glm::vec3 color,
-        const float dot_inner_limit,
-        const float dot_outer_limit);
-    /**
-     * @brief Create a spot light.
-     * @param func: This function return the ID from a string (it will need
-     * a level passed in the capture list).
-     * @param shadow_type: Type of shadow used.
-     * @param shadow_texture: Name of the texture to render for the shadows.
-     * @param position: Position of the spot light.
-     * @param direction: Direction of the spot light.
-     * @param color: Color in a vec3 format.
-     * @param dot_inner_limit: Inner limit of the total light in dot format.
-     * @param dot_outer_limit: Outer limit of the total light in dot format.
-     */
-    NodeLight(
-        std::function<NodeInterface*(const std::string&)> func,
-        ShadowTypeEnum shadow_type,
-        const std::string& shadow_texture,
         const glm::vec3 position,
         const glm::vec3 direction,
         const glm::vec3 color,

--- a/src/frame/opengl/light.h
+++ b/src/frame/opengl/light.h
@@ -84,29 +84,12 @@ class LightPoint : public LightInterface
     {
         return color_intensity_;
     }
-    /**
-     * @brief Set the shadow map texture name.
-     * @param name: Name of the shadow map texture.
-     */
-    void SetShadowMapTextureName(const std::string& name)
-    {
-        shadow_map_texture_name_ = name;
-	}
-    /**
-     * @brief Get the shadow map texture name.
-     * @return Name of the shadow map texture.
-     */
-    std::string GetShadowMapTextureName() const
-    {
-        return shadow_map_texture_name_;
-    }
 
   protected:
     glm::vec3 position_;
     glm::vec3 color_intensity_;
     ShadowTypeEnum shadow_type_enum_ = ShadowTypeEnum::NO_SHADOW;
     std::string name_;
-    std::string shadow_map_texture_name_;
 };
 
 /**
@@ -183,29 +166,12 @@ class LightDirectional : public LightInterface
     {
         return color_intensity_;
     }
-    /**
-     * @brief Set the shadow map texture name.
-     * @param name: Name of the shadow map texture.
-     */
-    void SetShadowMapTextureName(const std::string& name)
-    {
-        shadow_map_texture_name_ = name;
-    }
-    /**
-     * @brief Get the shadow map texture name.
-     * @return Name of the shadow map texture.
-     */
-    std::string GetShadowMapTextureName() const
-    {
-        return shadow_map_texture_name_;
-    }
 
   protected:
     glm::vec3 direction_;
     glm::vec3 color_intensity_;
     ShadowTypeEnum shadow_type_enum_ = ShadowTypeEnum::NO_SHADOW;
 	std::string name_;
-    std::string shadow_map_texture_name_;
 };
 
 /**

--- a/src/frame/proto/scene.proto
+++ b/src/frame/proto/scene.proto
@@ -167,8 +167,6 @@ message NodeLight {
 
 	// Shadow type for the light.
 	ShadowTypeEnum shadow_type = 9;
-	// Name of an existing texture to render the shadow depth into.
-	string shadow_texture = 10;
 }
 
 // Scene definition.


### PR DESCRIPTION
Remove legacy shadow mapping infrastructure that's no longer needed after implementing ray-traced shadows. This includes:

- Shadow map texture methods from light interface and OpenGL light classes
- Shadow mapping constructors from NodeLight
- Shadow texture fields from protobuf definition
- Branching logic in scene parsing for shadow vs non-shadow lights

The ray-traced shadow implementation remains fully functional.

🤖 Generated with [Claude Code](https://claude.ai/code)