### PR TITLE
Use light direction for shadow sun

### DIFF
--- a/asset/json/shadow.json
+++ b/asset/json/shadow.json
@@ -228,7 +228,7 @@
                 "parent": "root",
                 "light_type": "DIRECTIONAL_LIGHT",
                 "shadow_type": "SOFT_SHADOW",
-                "position": {
+                "direction": {
                     "x": -1.0,
                     "y": 1.0,
                     "z": 1.0


### PR DESCRIPTION
## Summary
- use a direction vector instead of a position for the sun light in the shadow example

## Testing
- `cmake --preset linux-release` *(fails: dependency build did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_689f71a61e6c83298e8df00f284465a3