### PR TITLE
Apply world transform to directional lights

### DIFF
--- a/src/frame/level.cpp
+++ b/src/frame/level.cpp
@@ -148,8 +148,11 @@ EntityId Level::AddSceneNode(std::unique_ptr<NodeInterface>&& scene_node)
         }
         case proto::NodeLight::DIRECTIONAL_LIGHT: {
             glm::vec3 dir = json::ParseUniform(data.direction());
+            glm::mat4 model = node_light->GetLocalModel(0.0);
+            glm::vec3 world_dir = glm::mat3(model) * dir;
+            world_dir = glm::normalize(world_dir);
             light = std::make_unique<opengl::LightDirectional>(
-                dir,
+                world_dir,
                 json::ParseUniform(data.color()),
                 static_cast<ShadowTypeEnum>(data.shadow_type()));
             break;
@@ -408,6 +411,7 @@ void Level::UpdateLights(double dt)
         case proto::NodeLight::DIRECTIONAL_LIGHT: {
             glm::vec3 dir = json::ParseUniform(data.direction());
             glm::vec3 world_dir = glm::mat3(model) * dir;
+            world_dir = glm::normalize(world_dir);
             light.SetVector(world_dir);
             break;
         }

--- a/tests/frame/opengl/light_test.cpp
+++ b/tests/frame/opengl/light_test.cpp
@@ -1,4 +1,9 @@
 #include "frame/opengl/light_test.h"
+#include "frame/level.h"
+#include "frame/node_matrix.h"
+#include "frame/node_light.h"
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/constants.hpp>
 
 namespace test
 {
@@ -44,6 +49,47 @@ TEST_F(LightTest, AddLightToLightManagerLightTest)
     EXPECT_EQ(2, light_manager_->GetLightCount());
     light_manager_->RemoveAllLights();
     EXPECT_EQ(0, light_manager_->GetLightCount());
+}
+
+TEST_F(LightTest, DirectionalLightUsesParentRotation)
+{
+    frame::Level level;
+    auto func = [&level](const std::string& name) -> frame::NodeInterface* {
+        auto id = level.GetIdFromName(name);
+        if (id == frame::NullId)
+        {
+            return nullptr;
+        }
+        return &level.GetSceneNodeFromId(id);
+    };
+
+    glm::mat4 transform = glm::scale(glm::mat4(1.0f), glm::vec3(2.0f));
+    transform = glm::rotate(transform, glm::half_pi<float>(), glm::vec3(0, 1, 0));
+    auto node_matrix = std::make_unique<frame::NodeMatrix>(func, transform, false);
+    node_matrix->SetName("parent");
+
+    auto node_light = std::make_unique<frame::NodeLight>(
+        func,
+        frame::LightTypeEnum::DIRECTIONAL_LIGHT,
+        glm::vec3(0.0f, 0.0f, -1.0f),
+        glm::vec3(1.0f, 1.0f, 1.0f));
+    node_light->SetName("light");
+    node_light->SetParentName("parent");
+
+    level.AddSceneNode(std::move(node_matrix));
+    level.AddSceneNode(std::move(node_light));
+
+    auto lights = level.GetLights();
+    ASSERT_EQ(1u, lights.size());
+    auto& light_interface = level.GetLightFromId(lights[0]);
+    auto* directional =
+        dynamic_cast<frame::opengl::LightDirectional*>(&light_interface);
+    ASSERT_NE(nullptr, directional);
+    auto dir = directional->GetVector();
+    EXPECT_NEAR(-1.0f, dir.x, 1e-5f);
+    EXPECT_NEAR(0.0f, dir.y, 1e-5f);
+    EXPECT_NEAR(0.0f, dir.z, 1e-5f);
+    EXPECT_NEAR(1.0f, glm::length(dir), 1e-5f);
 }
 
 } // End namespace test.


### PR DESCRIPTION
## Summary
- Rotate directional light vectors using the node's world transform and normalize the result
- Normalize directional light vectors during light updates
- Add unit test verifying directional lights respect parent node rotation

## Testing
- `cmake -S . -B build` *(fails: Could not find GLEWConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e124b7988329b7e75ab7c2daca35