### PR TITLE
Align ray tracing example with shadow scene structure

### DIFF
--- a/asset/json/raytracing.json
+++ b/asset/json/raytracing.json
@@ -53,6 +53,16 @@
     ],
     "materials": [
         {
+            "name": "CubeMapMaterial",
+            "program_name": "CubeMapProgram",
+            "texture_names": [
+                "skybox"
+            ],
+            "inner_names": [
+                "Skybox"
+            ]
+        },
+        {
             "name": "RayTraceMaterial",
             "program_name": "RayTraceProgram",
             "texture_names": [
@@ -79,6 +89,34 @@
     ],
     "programs": [
         {
+            "name": "CubeMapProgram",
+            "input_texture_names": [
+                "skybox"
+            ],
+            "output_texture_names": [
+                "albedo"
+            ],
+            "input_scene_type": {
+                "value": "CUBE"
+            },
+            "shader_vertex": "cubemap.vert",
+            "shader_fragment": "cubemap.frag",
+            "uniforms": [
+                {
+                    "name": "projection",
+                    "uniform_enum": "PROJECTION_MAT4"
+                },
+                {
+                    "name": "view",
+                    "uniform_enum": "VIEW_MAT4"
+                },
+                {
+                    "name": "model",
+                    "uniform_enum": "MODEL_MAT4"
+                }
+            ]
+        },
+        {
             "name": "RayTraceProgram",
             "output_texture_names": [
                 "albedo"
@@ -90,7 +128,7 @@
             "input_scene_type": {
                 "value": "QUAD"
             },
-            "input_scene_root_name": "apple_root",
+            "input_scene_root_name": "mesh_holder",
             "shader_vertex": "raytracing.vert",
             "shader_fragment": "raytracing.frag",
             "uniforms": [
@@ -125,10 +163,6 @@
                 {
                     "name": "light_color",
                     "uniform_enum": "LIGHT_COLOR_VEC3"
-                },
-                {
-                    "name": "time",
-                    "uniform_enum": "FLOAT_TIME_S"
                 }
             ]
         },
@@ -174,10 +208,6 @@
                 {
                     "name": "light_color",
                     "uniform_enum": "LIGHT_COLOR_VEC3"
-                },
-                {
-                    "name": "time",
-                    "uniform_enum": "FLOAT_TIME_S"
                 }
             ]
         }
@@ -196,24 +226,23 @@
                 }
             },
             {
-                "name": "apple_root",
+                "name": "mesh_holder",
                 "parent": "root",
-                "matrix_type_enum": "ROTATION_MATRIX",
                 "quaternion": {
                     "x": 0.0,
-                    "y": 0.09973979,
-                    "z": 0.07480484,
-                    "w": 0.9921977
+                    "y": 0.2930181,
+                    "z": 0.2197635,
+                    "w": 0.9305076
                 }
             },
             {
-                "name": "mesh_holder",
-                "parent": "apple_root",
+                "name": "env_holder",
+                "parent": "root",
                 "quaternion": {
                     "x": 0.0,
-                    "y": 0.1979232,
-                    "z": 0.1484424,
-                    "w": 0.9689124
+                    "y": 0.0499792,
+                    "z": 0.0,
+                    "w": 0.9987503
                 }
             }
         ],
@@ -243,6 +272,12 @@
         ],
         "node_static_meshes": [
             {
+                "name": "CubeMapMesh",
+                "parent": "env_holder",
+                "material_name": "CubeMapMaterial",
+                "mesh_enum": "CUBE"
+            },
+            {
                 "name": "RayTracingRendering",
                 "parent": "root",
                 "mesh_enum": "QUAD",
@@ -259,13 +294,13 @@
         "node_lights": [
             {
                 "name": "sun",
-                "parent": "root",
+                "parent": "env_holder",
                 "light_type": "DIRECTIONAL_LIGHT",
                 "shadow_type": "NO_SHADOW",
                 "direction": {
                     "x": 1.0,
                     "y": -1.0,
-                    "z": 1.0
+                    "z": -1.0
                 },
                 "color": {
                     "x": 1.0,
@@ -276,3 +311,4 @@
         ]
     }
 }
+

--- a/asset/shader/opengl/raytracing.frag
+++ b/asset/shader/opengl/raytracing.frag
@@ -10,7 +10,6 @@ uniform mat4 projection_inv;
 uniform mat4 view_inv;
 uniform mat4 model;
 uniform vec3 camera_position;
-uniform float time;
 // Direction from the light toward the scene.
 uniform vec3 light_dir;
 uniform vec3 light_color;
@@ -143,20 +142,13 @@ void main()
             diff = max(dot(hit_normal, normalize(-dir)), 0.0);
 
         vec3 tex_color = texture(apple_texture, hit_uv).rgb;
-        frag_color = vec4(diff * col * tex_color, 1.0);
+        vec3 env_reflect_dir = reflect(ray_dir_world, hit_normal);
+        env_reflect_dir = vec3(env_reflect_dir.x, -env_reflect_dir.y, env_reflect_dir.z);
+        vec3 env_color = texture(skybox, env_reflect_dir).rgb;
+        frag_color = vec4(diff * col * tex_color + 0.2 * env_color, 1.0);
     }
     else
     {
-        // Flip Y to match the shadow scene's cubemap orientation and rotate
-        // the sample direction using time so the environment spins slowly.
-        vec3 env_dir = vec3(ray_dir_world.x, -ray_dir_world.y, ray_dir_world.z);
-        float angle = time * 0.25;
-        mat3 rot = mat3(
-            cos(angle), 0.0, sin(angle),
-            0.0,        1.0, 0.0,
-            -sin(angle),0.0, cos(angle));
-        env_dir = rot * env_dir;
-        vec3 env_color = texture(skybox, env_dir).rgb;
-        frag_color = vec4(env_color, 1.0);
+        discard;
     }
 }


### PR DESCRIPTION
## Summary
- Add CubeMap material and program to ray tracing example
- Restructure ray tracing scene tree with env holder and cubemap mesh
- Use cubemap for reflections and drop backdrop hack in ray tracing shader

## Testing
- `cmake -S . -B build` *(fails: Could not find GLEWConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68aad967ec048329aefce387e7b9de2d