### PR TITLE
Add PBR shading to apple ray tracing example

### DIFF
--- a/asset/json/raytracing.json
+++ b/asset/json/raytracing.json
@@ -60,6 +60,50 @@
                 "value": "RGB"
             },
             "file_name": "asset/apple/color.jpg"
+        },
+        {
+            "name": "apple_normal_texture",
+            "cubemap": false,
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            },
+            "file_name": "asset/apple/normal.jpg"
+        },
+        {
+            "name": "apple_roughness_texture",
+            "cubemap": false,
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "R"
+            },
+            "file_name": "asset/apple/roughness.jpg"
+        },
+        {
+            "name": "apple_metalness_texture",
+            "cubemap": false,
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "R"
+            },
+            "file_name": "asset/apple/metalness.jpg"
+        },
+        {
+            "name": "apple_ao_texture",
+            "cubemap": false,
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "R"
+            },
+            "file_name": "asset/apple/ambient_occlusion.jpg"
         }
     ],
     "materials": [
@@ -78,10 +122,18 @@
             "program_name": "RayTraceProgram",
             "texture_names": [
                 "apple_texture",
+                "apple_normal_texture",
+                "apple_roughness_texture",
+                "apple_metalness_texture",
+                "apple_ao_texture",
                 "skybox_env"
             ],
             "inner_names": [
                 "apple_texture",
+                "apple_normal_texture",
+                "apple_roughness_texture",
+                "apple_metalness_texture",
+                "apple_ao_texture",
                 "skybox_env"
             ],
             "buffer_names": [
@@ -94,8 +146,22 @@
         {
             "name": "RayTracePreprocessMaterial",
             "program_name": "RayTracePreprocessProgram",
-            "texture_names": [],
-            "inner_names": []
+            "texture_names": [
+                "apple_texture",
+                "apple_normal_texture",
+                "apple_roughness_texture",
+                "apple_metalness_texture",
+                "apple_ao_texture",
+                "skybox_env"
+            ],
+            "inner_names": [
+                "apple_texture",
+                "apple_normal_texture",
+                "apple_roughness_texture",
+                "apple_metalness_texture",
+                "apple_ao_texture",
+                "skybox_env"
+            ]
         }
     ],
     "programs": [
@@ -134,6 +200,10 @@
             ],
             "input_texture_names": [
                 "apple_texture",
+                "apple_normal_texture",
+                "apple_roughness_texture",
+                "apple_metalness_texture",
+                "apple_ao_texture",
                 "skybox_env"
             ],
             "input_scene_type": {


### PR DESCRIPTION
## Summary
- Load ambient occlusion, normal, roughness and metalness textures for the apple asset
- Bind new textures for ray traced apple preprocessing and rendering programs
- Implement GGX-based PBR lighting in `raytracing.frag`

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "absl" with any of the following names: abslConfig.cmake, absl-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68abfda1add083299ac464e53b44db53