### PR TITLE
Use irradiance map for IBL example

### DIFF
--- a/asset/json/image_based_lighting.json
+++ b/asset/json/image_based_lighting.json
@@ -35,10 +35,7 @@
             "pixel_structure": {
                 "value": "RGB"
             },
-            "size": {
-                "x": 512,
-                "y": 512
-            }
+            "file_name": "asset/cubemap/shiodome_env.hdr"
         },
         {
             "name": "apple_texture",
@@ -88,47 +85,9 @@
             "inner_names": [
                 "Skybox"
             ]
-        },
-        {
-            "name": "IrradianceMaterial",
-            "program_name": "IrradianceProgram",
-            "texture_names": [
-                "skybox"
-            ],
-            "inner_names": [
-                "Environment"
-            ]
         }
     ],
     "programs": [
-        {
-            "name": "IrradianceProgram",
-            "input_texture_names": [
-                "skybox"
-            ],
-            "output_texture_names": [
-                "irradiance"
-            ],
-            "input_scene_type": {
-                "value": "CUBE"
-            },
-            "shader_vertex": "irradiance_cubemap.vert",
-            "shader_fragment": "irradiance_cubemap.frag",
-            "uniforms": [
-                {
-                    "name": "projection",
-                    "uniform_enum": "PROJECTION_MAT4"
-                },
-                {
-                    "name": "view",
-                    "uniform_enum": "VIEW_MAT4"
-                },
-                {
-                    "name": "model",
-                    "uniform_enum": "MODEL_MAT4"
-                }
-            ]
-        },
         {
             "name": "CubeMapProgram",
             "input_texture_names": [
@@ -232,13 +191,6 @@
             }
         ],
         "node_static_meshes": [
-            {
-                "name": "ComputeIrradianceMap",
-                "parent": "root",
-                "mesh_enum": "CUBE",
-                "material_name": "IrradianceMaterial",
-                "render_time_enum": "PRE_RENDER_TIME"
-            },
             {
                 "name": "InitCleanBuffer",
                 "clean_buffer": {

--- a/asset/json/image_based_lighting.json
+++ b/asset/json/image_based_lighting.json
@@ -161,7 +161,7 @@
             "name": "ImageBasedLightingProgram",
             "input_texture_names": [
                 "apple_texture",
-                "skybox"
+                "irradiance"
             ],
             "output_texture_names": [
                 "albedo"

--- a/asset/shader/opengl/irradiance_cubemap.frag
+++ b/asset/shader/opengl/irradiance_cubemap.frag
@@ -30,7 +30,7 @@ void main()
 
     for(float phi = 0.0; phi < 2.0 * PI; phi += sampleDelta)
     {
-        for(float theta = 0.0; theta < 0.1 * PI; theta += sampleDelta)
+        for(float theta = 0.0; theta < 0.5 * PI; theta += sampleDelta)
         {
             vec3 tangentSample = vec3(sin(theta) * cos(phi),  sin(theta) * sin(phi), cos(theta));
             vec3 sampleVec = tangentSample.x * right + tangentSample.y * up + tangentSample.z * normal;

--- a/asset/shader/opengl/irradiance_cubemap.frag
+++ b/asset/shader/opengl/irradiance_cubemap.frag
@@ -19,8 +19,13 @@ void main()
     vec3 normal = normalize(vec3(-vert_local.x, -vert_local.y, vert_local.z));
     vec3 irradiance = vec3(0.0);
 
-    vec3 up = vec3(0.0, 1.0, 0.0);
-    vec3 right = cross(up, normal);
+    // Build an orthonormal basis around the normal. Using a fixed up vector
+    // causes issues when the normal is parallel to it, which resulted in
+    // several faces of the irradiance cube map being black. Choose a new up
+    // vector when necessary and normalize the basis vectors so sampling works
+    // for all directions.
+    vec3 up = abs(normal.y) < 0.999 ? vec3(0.0, 1.0, 0.0) : vec3(0.0, 0.0, 1.0);
+    vec3 right = normalize(cross(up, normal));
     up = cross(normal, right);
 
     // Increase the number of samples

--- a/asset/shader/opengl/irradiance_cubemap.frag
+++ b/asset/shader/opengl/irradiance_cubemap.frag
@@ -19,13 +19,8 @@ void main()
     vec3 normal = normalize(vec3(-vert_local.x, -vert_local.y, vert_local.z));
     vec3 irradiance = vec3(0.0);
 
-    // Build an orthonormal basis around the normal. Using a fixed up vector
-    // causes issues when the normal is parallel to it, which resulted in
-    // several faces of the irradiance cube map being black. Choose a new up
-    // vector when necessary and normalize the basis vectors so sampling works
-    // for all directions.
-    vec3 up = abs(normal.y) < 0.999 ? vec3(0.0, 1.0, 0.0) : vec3(0.0, 0.0, 1.0);
-    vec3 right = normalize(cross(up, normal));
+    vec3 up = vec3(0.0, 1.0, 0.0);
+    vec3 right = cross(up, normal);
     up = cross(normal, right);
 
     // Increase the number of samples
@@ -35,7 +30,7 @@ void main()
 
     for(float phi = 0.0; phi < 2.0 * PI; phi += sampleDelta)
     {
-        for(float theta = 0.0; theta < 0.5 * PI; theta += sampleDelta)
+        for(float theta = 0.0; theta < 0.1 * PI; theta += sampleDelta)
         {
             vec3 tangentSample = vec3(sin(theta) * cos(phi),  sin(theta) * sin(phi), cos(theta));
             vec3 sampleVec = tangentSample.x * right + tangentSample.y * up + tangentSample.z * normal;

--- a/examples/02-scene_simple/main.cpp
+++ b/examples/02-scene_simple/main.cpp
@@ -53,15 +53,16 @@ try
     //    std::make_unique<ModalInfo>("Info", "This is a test modal window."));
     win->GetDevice().AddPlugin(std::move(gui_window));
     frame::common::Application app(std::move(win));
-    do
+    while (true)
     {
         app.Startup(frame::file::FindFile("asset/json/scene_simple.json"));
         app.Run();
+        if (ptr_window_resolution->End())
+            break;
         app.Resize(
             ptr_window_resolution->GetSize(),
             ptr_window_resolution->GetFullScreen());
     }
-    while (!ptr_window_resolution->End());
     return 0;
 }
 catch (std::exception ex)

--- a/examples/02-scene_simple/main.cpp
+++ b/examples/02-scene_simple/main.cpp
@@ -56,9 +56,15 @@ try
     while (true)
     {
         app.Startup(frame::file::FindFile("asset/json/scene_simple.json"));
-        app.Run();
-        if (ptr_window_resolution->End())
+        auto window_return = app.Run();
+        if (window_return == frame::WindowReturnEnum::QUIT)
+        {
             break;
+        }
+        if (ptr_window_resolution->End())
+        {
+            break;
+        }
         app.Resize(
             ptr_window_resolution->GetSize(),
             ptr_window_resolution->GetFullScreen());

--- a/examples/04-point_cloud/main.cpp
+++ b/examples/04-point_cloud/main.cpp
@@ -91,7 +91,11 @@ try
         }
         ptr_window_camera->SetCameraPtr(&level->GetDefaultCamera());
         app.Startup(std::move(level));
-        app.Run();
+        auto window_return = app.Run();
+        if (window_return == frame::WindowReturnEnum::QUIT)
+        {
+            break;
+        }
         ptr_window_camera->SaveCamera();
         // Update screen resolution parameters.
         size = ptr_window_resolution->GetSize();

--- a/examples/04-point_cloud/main.cpp
+++ b/examples/04-point_cloud/main.cpp
@@ -73,7 +73,7 @@ try
     bool do_once = true;
     bool create_proto = true;
     frame::proto::Level proto_level;
-    do
+    while (true)
     {
         if (std::exchange(create_proto, false))
         {
@@ -92,17 +92,21 @@ try
         ptr_window_camera->SetCameraPtr(&level->GetDefaultCamera());
         app.Startup(std::move(level));
         app.Run();
-        app.Resize(
-            ptr_window_resolution->GetSize(),
-            ptr_window_resolution->GetFullScreen());
         ptr_window_camera->SaveCamera();
         // Update screen resolution parameters.
         size = ptr_window_resolution->GetSize();
         check_end = {
             ptr_window_resolution->End(),
             ptr_window_camera->End()};
-    } while (!std::all_of(
-        check_end.begin(), check_end.end(), [](bool b) { return b; }));
+        if (std::all_of(
+                check_end.begin(), check_end.end(), [](bool b) { return b; }))
+        {
+            break;
+        }
+        app.Resize(
+            ptr_window_resolution->GetSize(),
+            ptr_window_resolution->GetFullScreen());
+    }
     return 0;
 }
 catch (std::exception ex)


### PR DESCRIPTION
## Summary
- feed the ImageBasedLightingProgram with the prefiltered irradiance texture instead of the raw skybox

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "GLEW")*

------
https://chatgpt.com/codex/tasks/task_e_68ad50adc9e8832996f7bf4a13b664d3