### PR TITLE
Clean up raytracing example PBR textures

### DIFF
--- a/asset/json/raytracing.json
+++ b/asset/json/raytracing.json
@@ -51,7 +51,7 @@
             "file_name": "asset/cubemap/shiodome_env.hdr"
         },
         {
-            "name": "apple_texture",
+            "name": "albedo_texture",
             "cubemap": false,
             "pixel_element_size": {
                 "value": "BYTE"
@@ -62,7 +62,7 @@
             "file_name": "asset/apple/color.jpg"
         },
         {
-            "name": "apple_normal_texture",
+            "name": "normal_texture",
             "cubemap": false,
             "pixel_element_size": {
                 "value": "BYTE"
@@ -73,7 +73,7 @@
             "file_name": "asset/apple/normal.jpg"
         },
         {
-            "name": "apple_roughness_texture",
+            "name": "roughness_texture",
             "cubemap": false,
             "pixel_element_size": {
                 "value": "BYTE"
@@ -84,7 +84,7 @@
             "file_name": "asset/apple/roughness.jpg"
         },
         {
-            "name": "apple_metalness_texture",
+            "name": "metallic_texture",
             "cubemap": false,
             "pixel_element_size": {
                 "value": "BYTE"
@@ -95,7 +95,7 @@
             "file_name": "asset/apple/metalness.jpg"
         },
         {
-            "name": "apple_ao_texture",
+            "name": "ao_texture",
             "cubemap": false,
             "pixel_element_size": {
                 "value": "BYTE"
@@ -121,19 +121,19 @@
             "name": "RayTraceMaterial",
             "program_name": "RayTraceProgram",
             "texture_names": [
-                "apple_texture",
-                "apple_normal_texture",
-                "apple_roughness_texture",
-                "apple_metalness_texture",
-                "apple_ao_texture",
+                "albedo_texture",
+                "normal_texture",
+                "roughness_texture",
+                "metallic_texture",
+                "ao_texture",
                 "skybox_env"
             ],
             "inner_names": [
-                "apple_texture",
-                "apple_normal_texture",
-                "apple_roughness_texture",
-                "apple_metalness_texture",
-                "apple_ao_texture",
+                "albedo_texture",
+                "normal_texture",
+                "roughness_texture",
+                "metallic_texture",
+                "ao_texture",
                 "skybox_env"
             ],
             "buffer_names": [
@@ -155,19 +155,19 @@
             "name": "RayTracePreprocessMaterial",
             "program_name": "RayTracePreprocessProgram",
             "texture_names": [
-                "apple_texture",
-                "apple_normal_texture",
-                "apple_roughness_texture",
-                "apple_metalness_texture",
-                "apple_ao_texture",
+                "albedo_texture",
+                "normal_texture",
+                "roughness_texture",
+                "metallic_texture",
+                "ao_texture",
                 "skybox_env"
             ],
             "inner_names": [
-                "apple_texture",
-                "apple_normal_texture",
-                "apple_roughness_texture",
-                "apple_metalness_texture",
-                "apple_ao_texture",
+                "albedo_texture",
+                "normal_texture",
+                "roughness_texture",
+                "metallic_texture",
+                "ao_texture",
                 "skybox_env"
             ],
             "buffer_names": [
@@ -215,11 +215,11 @@
                 "albedo"
             ],
             "input_texture_names": [
-                "apple_texture",
-                "apple_normal_texture",
-                "apple_roughness_texture",
-                "apple_metalness_texture",
-                "apple_ao_texture",
+                "albedo_texture",
+                "normal_texture",
+                "roughness_texture",
+                "metallic_texture",
+                "ao_texture",
                 "skybox_env"
             ],
             "input_scene_type": {

--- a/asset/shader/opengl/raytracing.frag
+++ b/asset/shader/opengl/raytracing.frag
@@ -13,11 +13,12 @@ uniform vec3 camera_position;
 // Direction from the light toward the scene.
 uniform vec3 light_dir;
 uniform vec3 light_color;
-uniform sampler2D apple_texture;
-uniform sampler2D apple_normal_texture;
-uniform sampler2D apple_roughness_texture;
-uniform sampler2D apple_metalness_texture;
-uniform sampler2D apple_ao_texture;
+// Generic PBR textures for the traced mesh.
+uniform sampler2D albedo_texture;
+uniform sampler2D normal_texture;
+uniform sampler2D roughness_texture;
+uniform sampler2D metallic_texture;
+uniform sampler2D ao_texture;
 uniform samplerCube skybox_env;
 
 struct Vertex
@@ -281,7 +282,7 @@ void main()
         vec3 N = normalize(inv_model3 * hit_normal_model);
         vec3 T = normalize(inv_model3 * hit_tangent_model);
         vec3 B = normalize(inv_model3 * hit_bitangent_model);
-        vec3 normal_map = texture(apple_normal_texture, hit_uv).xyz * 2.0 - 1.0;
+        vec3 normal_map = texture(normal_texture, hit_uv).xyz * 2.0 - 1.0;
         vec3 hit_normal = normalize(mat3(T, B, N) * normal_map);
         // Position of the hit point in model space for casting shadow rays.
         vec3 hit_pos_model = ray_origin + closest_t * ray_dir;
@@ -296,10 +297,10 @@ void main()
         bool in_shadow = anyHitBVH(shadow_origin, shadow_dir);
 
         float shadow_factor = in_shadow ? 0.3 : 1.0;
-        vec3 albedo = texture(apple_texture, hit_uv).rgb;
-        float roughness = texture(apple_roughness_texture, hit_uv).r;
-        float metallic = texture(apple_metalness_texture, hit_uv).r;
-        float ao = texture(apple_ao_texture, hit_uv).r;
+        vec3 albedo = texture(albedo_texture, hit_uv).rgb;
+        float roughness = texture(roughness_texture, hit_uv).r;
+        float metallic = texture(metallic_texture, hit_uv).r;
+        float ao = texture(ao_texture, hit_uv).r;
         vec3 V = normalize(camera_position - (model * vec4(hit_pos_model, 1.0)).xyz);
         vec3 L = normalize(-dir);
         vec3 H = normalize(V + L);

--- a/examples/07-raytracing/main.cpp
+++ b/examples/07-raytracing/main.cpp
@@ -1,5 +1,4 @@
-// Ray tracing example.
-// Preprocess apple mesh off-screen so only ray-traced image is displayed.
+// Ray tracing example using PBR textures.
 // From: https://sourceforge.net/p/predef/wiki/OperatingSystems/
 #if defined(_WIN32) || defined(_WIN64)
 #define WINDOWS_LEAN_AND_MEAN


### PR DESCRIPTION
## Summary
- Make raytracing fragment shader use generic PBR texture names
- Update raytracing example JSON to reference generic textures
- Simplify example comment

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "glad")*

------
https://chatgpt.com/codex/tasks/task_e_68b0658650e8832986e6e364c14b99bb