### PR TITLE
Add preprocess program support to materials

### DIFF
--- a/asset/json/raytracing.json
+++ b/asset/json/raytracing.json
@@ -120,6 +120,7 @@
         {
             "name": "RayTraceMaterial",
             "program_name": "RayTraceProgram",
+            "preprocess_program_name": "RayTracePreprocessProgram",
             "texture_names": [
                 "albedo_texture",
                 "normal_texture",
@@ -149,34 +150,6 @@
             ],
             "inner_node_names": [
                 "model"
-            ]
-        },
-        {
-            "name": "RayTracePreprocessMaterial",
-            "program_name": "RayTracePreprocessProgram",
-            "texture_names": [
-                "albedo_texture",
-                "normal_texture",
-                "roughness_texture",
-                "metallic_texture",
-                "ao_texture",
-                "skybox_env"
-            ],
-            "inner_names": [
-                "albedo_texture",
-                "normal_texture",
-                "roughness_texture",
-                "metallic_texture",
-                "ao_texture",
-                "skybox_env"
-            ],
-            "buffer_names": [
-                "AppleMesh.0.triangle",
-                "AppleMesh.0.bvh"
-            ],
-            "inner_buffer_names": [
-                "TriangleBuffer",
-                "BvhBuffer"
             ]
         }
     ],
@@ -385,7 +358,7 @@
                 "name": "AppleMesh",
                 "parent": "mesh_holder",
                 "file_name": "dragon.obj",
-                "material_name": "RayTracePreprocessMaterial",
+                "material_name": "RayTraceMaterial",
                 "render_time_enum": "PRE_RENDER_TIME"
             }
         ],

--- a/include/frame/material_interface.h
+++ b/include/frame/material_interface.h
@@ -36,6 +36,13 @@ class MaterialInterface : public Serialize<proto::Material>
     virtual EntityId GetProgramId(
         const LevelInterface* level = nullptr) const = 0;
     /**
+     * @brief Get the preprocess program id from a level or from the local stored one.
+     * @param level: Pointer to the local level.
+     * @return Id of the preprocess program (can be the linked program).
+     */
+    virtual EntityId GetPreprocessProgramId(
+        const LevelInterface* level = nullptr) const = 0;
+    /**
      * @brief Get the inner name that correspond to a texture id.
      * @param id: The id to check for corresponding string.
      * @return The string.
@@ -46,6 +53,11 @@ class MaterialInterface : public Serialize<proto::Material>
      * @param id: the stored program id.
      */
     virtual void SetProgramId(EntityId id) = 0;
+    /**
+     * @brief Store local preprocess program id.
+     * @param id: the stored preprocess program id.
+     */
+    virtual void SetPreprocessProgramId(EntityId id) = 0;
     /**
      * @brief Store a texture reference associated to a given name.
      * @param id: Texture reference id.

--- a/src/frame/json/parse_material.cpp
+++ b/src/frame/json/parse_material.cpp
@@ -37,6 +37,19 @@ std::unique_ptr<frame::MaterialInterface> ParseMaterialOpenGL(
         EntityId program_id = maybe_program_id;
         material->SetProgramId(program_id);
     }
+    if (!proto_material.preprocess_program_name().empty())
+    {
+        material->GetData().set_preprocess_program_name(
+            proto_material.preprocess_program_name());
+        material->SetPreprocessProgramName(
+            proto_material.preprocess_program_name());
+        auto maybe_preprocess_id =
+            level.GetIdFromName(proto_material.preprocess_program_name());
+        if (maybe_preprocess_id)
+        {
+            material->SetPreprocessProgramId(maybe_preprocess_id);
+        }
+    }
     for (int i = 0; i < inner_size; ++i)
     {
         auto maybe_texture_id =

--- a/src/frame/json/serialize_material.cpp
+++ b/src/frame/json/serialize_material.cpp
@@ -11,6 +11,12 @@ proto::Material SerializeMaterial(
     proto_material.set_name(material_interface.GetName());
     proto_material.set_program_name(
         level_interface.GetNameFromId(material_interface.GetProgramId()));
+    if (material_interface.GetPreprocessProgramId())
+    {
+        proto_material.set_preprocess_program_name(
+            level_interface.GetNameFromId(
+                material_interface.GetPreprocessProgramId()));
+    }
     for (const auto texture_id : material_interface.GetTextureIds())
     {
         std::string inner_name = material_interface.GetInnerName(texture_id);

--- a/src/frame/opengl/material.cpp
+++ b/src/frame/opengl/material.cpp
@@ -114,6 +114,25 @@ frame::EntityId Material::GetProgramId(
     throw std::runtime_error("No valid program!");
 }
 
+frame::EntityId Material::GetPreprocessProgramId(
+    const LevelInterface* level /*= nullptr*/) const
+{
+    if (preprocess_program_id_)
+    {
+        return preprocess_program_id_;
+    }
+    if (!preprocess_program_name_.empty() && level)
+    {
+        auto maybe_id = level->GetIdFromName(preprocess_program_name_);
+        if (maybe_id)
+        {
+            preprocess_program_id_ = maybe_id;
+            return preprocess_program_id_;
+        }
+    }
+    return NullId;
+}
+
 void Material::SetProgramId(EntityId id)
 {
     if (!id)
@@ -122,6 +141,15 @@ void Material::SetProgramId(EntityId id)
     }
     // TODO(anirul): Check that the program has a valid uniform!
     program_id_ = id;
+}
+
+void Material::SetPreprocessProgramId(EntityId id)
+{
+    if (!id)
+    {
+        throw std::runtime_error("Not a valid program id.");
+    }
+    preprocess_program_id_ = id;
 }
 
 std::string Material::GetInnerBufferName(const std::string& name) const

--- a/src/frame/opengl/material.h
+++ b/src/frame/opengl/material.h
@@ -29,6 +29,14 @@ class Material : public MaterialInterface
      */
     EntityId GetProgramId(const LevelInterface* level = nullptr) const override;
     /**
+     * @brief This is getting the preprocess program id from a level or from the
+     * local stored one.
+     * @param level: Pointer to the local level.
+     * @return Id of the preprocess program (can be the linked program).
+     */
+    EntityId GetPreprocessProgramId(
+        const LevelInterface* level = nullptr) const override;
+    /**
      * @brief Get the inner name that correspond to a texture id.
      * @param id: The id to check for corresponding string.
      * @return The string.
@@ -39,6 +47,11 @@ class Material : public MaterialInterface
      * @param id: the stored program id.
      */
     void SetProgramId(EntityId id) override;
+    /**
+     * @brief Store local preprocess program id.
+     * @param id: the stored preprocess program id.
+     */
+    void SetPreprocessProgramId(EntityId id) override;
     /**
      * @brief Store a texture reference associated to a given name.
      * @param id: Texture reference id.
@@ -88,6 +101,11 @@ class Material : public MaterialInterface
         const std::string& name, const std::string& inner_name) override;
     std::vector<std::string> GetNodeNames() const override;
 
+    void SetPreprocessProgramName(const std::string& name)
+    {
+        preprocess_program_name_ = name;
+    }
+
   private:
     std::map<EntityId, std::string> id_name_map_ = {};
     // Preserve insertion order for buffer bindings to match shader layout
@@ -95,8 +113,10 @@ class Material : public MaterialInterface
     std::map<std::string, std::string> name_node_name_map_ = {};
     mutable std::array<EntityId, 32> id_array_ = {};
     mutable EntityId program_id_ = 0;
+    mutable EntityId preprocess_program_id_ = 0;
     std::string name_;
     std::string program_name_;
+    std::string preprocess_program_name_;
 };
 
 } // End namespace frame::opengl.

--- a/src/frame/opengl/renderer.cpp
+++ b/src/frame/opengl/renderer.cpp
@@ -408,6 +408,32 @@ void Renderer::PreRender()
             auto temp_viewport = viewport_;
             // Query textures from the material.
             auto& material = level_.GetMaterialFromId(material_id);
+            if (!material.GetData().preprocess_program_name().empty())
+            {
+                auto saved_program = material.GetProgramId();
+                auto preprocess_id = material.GetPreprocessProgramId();
+                if (preprocess_id)
+                {
+                    auto& preprocess_program =
+                        level_.GetProgramFromId(preprocess_id);
+                    auto out_ids = preprocess_program.GetOutputTextureIds();
+                    if (!out_ids.empty())
+                    {
+                        auto& tex = level_.GetTextureFromId(*out_ids.begin());
+                        auto size = json::ParseSize(tex.GetData().size());
+                        viewport_ = glm::ivec4(0, 0, size.x, size.y);
+                    }
+                    material.SetProgramId(preprocess_id);
+                    RenderNode(
+                        p.first,
+                        material_id,
+                        kProjectionCubemap,
+                        kViewsCubemap[0]);
+                    material.SetProgramId(saved_program);
+                    viewport_ = temp_viewport;
+                }
+                continue;
+            }
             auto ids = material.GetTextureIds();
             if (ids.empty())
             {

--- a/src/frame/proto/material.proto
+++ b/src/frame/proto/material.proto
@@ -5,12 +5,14 @@ package frame.proto;
 // Material
 // Next 10
 message Material {
-	// Name of the material.
-	string name = 1;
-	// Program reference.
-	string program_name = 5;
-	// Reference name of the texture names in the texture file.
-	repeated string texture_names = 3;
+        // Name of the material.
+        string name = 1;
+        // Program reference.
+        string program_name = 5;
+        // Optional preprocess program reference.
+        optional string preprocess_program_name = 10;
+        // Reference name of the texture names in the texture file.
+        repeated string texture_names = 3;
 	// Reference to the name inside the material in the shader file.
 	repeated string inner_names = 4;
         // Reference name of the buffer names in the buffer file.


### PR DESCRIPTION
## Summary
- Support optional preprocess program in material proto and serialization
- Parse and store preprocess program name/id, enabling materials to run a preprocessing shader
- Execute preprocess program during renderer pre-render and simplify raytracing scene JSON to single material

## Testing
- `cmake -S . -B build` *(fails: Could not find glad)*


------
https://chatgpt.com/codex/tasks/task_e_68bfc476de54832986cb881a50d2cf84