### PR TITLE
Use planks textures for raytraced dragon

### DIFF
--- a/asset/json/raytracing.json
+++ b/asset/json/raytracing.json
@@ -59,7 +59,7 @@
             "pixel_structure": {
                 "value": "RGB"
             },
-            "file_name": "asset/apple/color.jpg"
+            "file_name": "asset/planks/color.jpg"
         },
         {
             "name": "normal_texture",
@@ -70,7 +70,7 @@
             "pixel_structure": {
                 "value": "RGB"
             },
-            "file_name": "asset/apple/normal.jpg"
+            "file_name": "asset/planks/normal.jpg"
         },
         {
             "name": "roughness_texture",
@@ -81,7 +81,7 @@
             "pixel_structure": {
                 "value": "GREY"
             },
-            "file_name": "asset/apple/roughness.jpg"
+            "file_name": "asset/planks/roughness.jpg"
         },
         {
             "name": "metallic_texture",
@@ -92,7 +92,7 @@
             "pixel_structure": {
                 "value": "GREY"
             },
-            "file_name": "asset/apple/metalness.jpg"
+            "file_name": "asset/planks/metalness.jpg"
         },
         {
             "name": "ao_texture",
@@ -103,7 +103,7 @@
             "pixel_structure": {
                 "value": "GREY"
             },
-            "file_name": "asset/apple/ambient_occlusion.jpg"
+            "file_name": "asset/planks/ambient_occlusion.jpg"
         }
     ],
     "materials": [


### PR DESCRIPTION
## Summary
- use wooden plank textures for the raytraced dragon model

## Testing
- `cmake --preset linux-debug` (fails: Could not find toolchain file `/workspace/Frame/external/vcpkg/scripts/buildsystems/vcpkg.cmake`)


------
https://chatgpt.com/codex/tasks/task_e_68bfcd9d58008329822d9615859658d0