### PR TITLE
Fix Vulkan swapchain sync and SDL window lifecycle

### DIFF
--- a/frame/opengl/renderer.cpp
+++ b/frame/opengl/renderer.cpp
@@ -455,8 +455,6 @@ std::size_t BuildRaytracingSourceStateHash(
 constexpr std::size_t kRaytraceFloatsPerVertex = 12;
 constexpr std::size_t kRaytraceTriangleVertexStrideBytes =
     sizeof(float) * kRaytraceFloatsPerVertex;
-constexpr std::uint32_t kRaytraceMaterialTransmissive = 0;
-constexpr std::uint32_t kRaytraceMaterialOpaque = 1;
 
 struct RaytraceVertex
 {
@@ -473,49 +471,6 @@ struct RaytraceVertex
     float pad2;
     float pad3;
 };
-
-constexpr std::size_t kRaytraceTriangleStrideBytes = sizeof(RaytraceVertex) * 3;
-
-struct RaytraceSceneEntry
-{
-    frame::EntityId source_node_id = frame::NullId;
-    frame::EntityId source_material_id = frame::NullId;
-    frame::EntityId source_buffer_id = frame::NullId;
-    std::uint64_t source_generation = 0;
-    glm::mat4 model = glm::mat4(1.0f);
-    std::uint32_t triangle_offset = 0;
-    std::uint32_t triangle_count = 0;
-    std::uint32_t bvh_root_index = 0;
-    std::uint32_t material_id = kRaytraceMaterialOpaque;
-    bool transmissive = false;
-};
-
-struct PreparedRaytraceSceneEntry
-{
-    RaytraceSceneEntry entry = {};
-    std::vector<std::uint8_t> triangle_bytes = {};
-};
-
-struct RaytraceInstanceData
-{
-    glm::mat4 object_to_world = glm::mat4(1.0f);
-    glm::mat4 world_to_object = glm::mat4(1.0f);
-    glm::uvec4 metadata = glm::uvec4(0u);
-};
-
-std::uint32_t GetRaytraceTriangleCount(const std::vector<std::uint8_t>& bytes)
-{
-    if (bytes.empty())
-    {
-        return 0;
-    }
-    if (bytes.size() % kRaytraceTriangleStrideBytes != 0)
-    {
-        throw std::runtime_error(
-            "OpenGL raytrace triangle buffer size is not aligned to the expected triangle stride.");
-    }
-    return static_cast<std::uint32_t>(bytes.size() / kRaytraceTriangleStrideBytes);
-}
 
 std::vector<std::uint8_t> ApplyTriangleColorMultiplier(
     const std::vector<std::uint8_t>& raw,
@@ -590,18 +545,22 @@ std::vector<std::uint8_t> TransformTriangleBytes(
     return transformed;
 }
 
-std::vector<RaytraceSceneEntry> CollectRaytraceSceneEntries(
+std::vector<std::uint8_t> BuildAggregateTriangleBytes(
     frame::LevelInterface& level,
+    bool transmissive,
     double time_seconds)
 {
-    std::vector<RaytraceSceneEntry> entries = {};
-    std::uint32_t transmissive_triangle_offset = 0;
-    std::uint32_t opaque_triangle_offset = 0;
-    std::uint32_t transmissive_bvh_offset = 0;
-    std::uint32_t opaque_bvh_offset = 0;
+    std::vector<std::uint8_t> aggregate_triangle_bytes = {};
+    const auto reference_color =
+        ResolveRaytracingReferenceColor(level, transmissive);
     for (const auto& [source_node_id, source_material_id] :
          GetRaytracingSourceMeshMaterials(level))
     {
+        if (IsTransmissiveMaterial(level, source_material_id) != transmissive)
+        {
+            continue;
+        }
+
         auto* node =
             dynamic_cast<NodeMesh*>(&level.GetSceneNodeFromId(source_node_id));
         if (!node)
@@ -628,100 +587,25 @@ std::vector<RaytraceSceneEntry> CollectRaytraceSceneEntries(
             continue;
         }
 
-        const auto triangle_count =
-            GetRaytraceTriangleCount(triangle_buffer->GetRawData());
-        if (triangle_count == 0)
-        {
-            continue;
-        }
-
-        RaytraceSceneEntry entry = {};
-        entry.source_node_id = source_node_id;
-        entry.source_material_id = source_material_id;
-        entry.source_buffer_id = triangle_buffer_id;
-        entry.source_generation = triangle_buffer->GetGeneration();
-        entry.model = node->GetLocalModel(time_seconds);
-        entry.triangle_count = triangle_count;
-        entry.transmissive =
-            IsTransmissiveMaterial(level, source_material_id);
-        entry.material_id = entry.transmissive ? kRaytraceMaterialTransmissive
-                                               : kRaytraceMaterialOpaque;
-        if (entry.transmissive)
-        {
-            entry.triangle_offset = transmissive_triangle_offset;
-            entry.bvh_root_index = transmissive_bvh_offset;
-            transmissive_triangle_offset += triangle_count;
-            transmissive_bvh_offset += triangle_count * 2u - 1u;
-        }
-        else
-        {
-            entry.triangle_offset = opaque_triangle_offset;
-            entry.bvh_root_index = opaque_bvh_offset;
-            opaque_triangle_offset += triangle_count;
-            opaque_bvh_offset += triangle_count * 2u - 1u;
-        }
-        entries.push_back(std::move(entry));
-    }
-    return entries;
-}
-
-std::vector<PreparedRaytraceSceneEntry> PrepareRaytraceSceneEntries(
-    frame::LevelInterface& level,
-    const std::vector<RaytraceSceneEntry>& entries,
-    bool apply_node_transform)
-{
-    std::vector<PreparedRaytraceSceneEntry> prepared_entries = {};
-    prepared_entries.reserve(entries.size());
-    const auto transmissive_reference_color =
-        ResolveRaytracingReferenceColor(level, true);
-    const auto opaque_reference_color =
-        ResolveRaytracingReferenceColor(level, false);
-    for (const auto& entry : entries)
-    {
-        auto* triangle_buffer = dynamic_cast<opengl::Buffer*>(
-            &level.GetBufferFromId(entry.source_buffer_id));
-        if (!triangle_buffer)
-        {
-            continue;
-        }
-
         const auto source_color =
-            ResolveRaytracingSourceMaterialColor(level, entry.source_material_id);
+            ResolveRaytracingSourceMaterialColor(level, source_material_id);
         const auto color_multiplier = ResolveRaytracingColorMultiplier(
             source_color,
-            entry.transmissive ? transmissive_reference_color
-                               : opaque_reference_color);
-        auto triangle_bytes = apply_node_transform
-            ? TransformTriangleBytes(triangle_buffer->GetRawData(), entry.model)
-            : triangle_buffer->GetRawData();
-        triangle_bytes =
-            ApplyTriangleColorMultiplier(triangle_bytes, color_multiplier);
-        prepared_entries.push_back(
-            PreparedRaytraceSceneEntry{entry, std::move(triangle_bytes)});
-    }
-    return prepared_entries;
-}
-
-std::vector<std::uint8_t> BuildAggregateTriangleBytes(
-    const std::vector<PreparedRaytraceSceneEntry>& prepared_entries,
-    bool transmissive)
-{
-    std::vector<std::uint8_t> aggregate_triangle_bytes = {};
-    for (const auto& prepared_entry : prepared_entries)
-    {
-        if (prepared_entry.entry.transmissive != transmissive)
-        {
-            continue;
-        }
+            reference_color);
+        const auto transformed = TransformTriangleBytes(
+            triangle_buffer->GetRawData(),
+            node->GetLocalModel(time_seconds));
+        const auto tinted =
+            ApplyTriangleColorMultiplier(transformed, color_multiplier);
         aggregate_triangle_bytes.insert(
             aggregate_triangle_bytes.end(),
-            prepared_entry.triangle_bytes.begin(),
-            prepared_entry.triangle_bytes.end());
+            tinted.begin(),
+            tinted.end());
     }
     return aggregate_triangle_bytes;
 }
 
-std::vector<frame::BVHNode> BuildAggregateBvhNodes(
+std::vector<std::uint8_t> BuildAggregateBvhBytes(
     const std::vector<std::uint8_t>& triangle_bytes)
 {
     if (triangle_bytes.empty())
@@ -750,12 +634,8 @@ std::vector<frame::BVHNode> BuildAggregateBvhNodes(
 
     std::vector<std::uint32_t> indices(vertex_count);
     std::iota(indices.begin(), indices.end(), 0u);
-    return frame::BuildBVH(points, indices);
-}
+    const auto bvh_nodes = frame::BuildBVH(points, indices);
 
-std::vector<std::uint8_t> EncodeBvhNodes(
-    const std::vector<frame::BVHNode>& bvh_nodes)
-{
     std::vector<std::uint8_t> bytes(
         bvh_nodes.size() * sizeof(frame::BVHNode));
     if (!bytes.empty())
@@ -763,149 +643,6 @@ std::vector<std::uint8_t> EncodeBvhNodes(
         std::memcpy(bytes.data(), bvh_nodes.data(), bytes.size());
     }
     return bytes;
-}
-
-std::vector<std::uint8_t> BuildAggregateBvhBytes(
-    const std::vector<std::uint8_t>& triangle_bytes)
-{
-    return EncodeBvhNodes(BuildAggregateBvhNodes(triangle_bytes));
-}
-
-std::vector<std::uint8_t> BuildPerMeshAggregateBvhBytes(
-    const std::vector<PreparedRaytraceSceneEntry>& prepared_entries,
-    bool transmissive)
-{
-    std::vector<frame::BVHNode> aggregate_nodes = {};
-    for (const auto& prepared_entry : prepared_entries)
-    {
-        if (prepared_entry.entry.transmissive != transmissive)
-        {
-            continue;
-        }
-        auto local_nodes = BuildAggregateBvhNodes(prepared_entry.triangle_bytes);
-        if (local_nodes.empty())
-        {
-            continue;
-        }
-        const int node_offset = static_cast<int>(aggregate_nodes.size());
-        for (auto& node : local_nodes)
-        {
-            if (node.left >= 0)
-            {
-                node.left += node_offset;
-            }
-            if (node.right >= 0)
-            {
-                node.right += node_offset;
-            }
-            if (node.triangle_count > 0 && node.first_triangle >= 0)
-            {
-                node.first_triangle +=
-                    static_cast<int>(prepared_entry.entry.triangle_offset);
-            }
-        }
-        aggregate_nodes.insert(
-            aggregate_nodes.end(),
-            local_nodes.begin(),
-            local_nodes.end());
-    }
-    return EncodeBvhNodes(aggregate_nodes);
-}
-
-std::vector<std::uint8_t> EncodeRaytraceInstanceData(
-    const std::vector<RaytraceInstanceData>& instances)
-{
-    if (instances.empty())
-    {
-        return {0u};
-    }
-    std::vector<std::uint8_t> bytes(
-        instances.size() * sizeof(RaytraceInstanceData));
-    std::memcpy(bytes.data(), instances.data(), bytes.size());
-    return bytes;
-}
-
-std::vector<std::uint8_t> BuildPerMeshRaytraceInstanceBytes(
-    const std::vector<RaytraceSceneEntry>& entries)
-{
-    std::vector<RaytraceInstanceData> instances = {};
-    instances.reserve(entries.size());
-    for (const auto& entry : entries)
-    {
-        RaytraceInstanceData instance = {};
-        instance.object_to_world = entry.model;
-        const float determinant = glm::determinant(glm::mat3(entry.model));
-        instance.world_to_object =
-            std::abs(determinant) > 1.0e-8f ? glm::inverse(entry.model)
-                                            : glm::mat4(1.0f);
-        instance.metadata = glm::uvec4(
-            entry.triangle_offset,
-            entry.material_id,
-            entry.bvh_root_index,
-            entry.triangle_count);
-        instances.push_back(std::move(instance));
-    }
-    return EncodeRaytraceInstanceData(instances);
-}
-
-std::vector<std::uint8_t> BuildWorldSpaceRaytraceInstanceBytes(
-    const std::vector<std::uint8_t>& transmissive_triangles,
-    const std::vector<std::uint8_t>& opaque_triangles)
-{
-    std::vector<RaytraceInstanceData> instances = {};
-    const auto transmissive_triangle_count =
-        GetRaytraceTriangleCount(transmissive_triangles);
-    if (transmissive_triangle_count > 0)
-    {
-        RaytraceInstanceData instance = {};
-        instance.metadata = glm::uvec4(
-            0u,
-            kRaytraceMaterialTransmissive,
-            0u,
-            transmissive_triangle_count);
-        instances.push_back(std::move(instance));
-    }
-    const auto opaque_triangle_count = GetRaytraceTriangleCount(opaque_triangles);
-    if (opaque_triangle_count > 0)
-    {
-        RaytraceInstanceData instance = {};
-        instance.metadata = glm::uvec4(
-            0u,
-            kRaytraceMaterialOpaque,
-            0u,
-            opaque_triangle_count);
-        instances.push_back(std::move(instance));
-    }
-    return EncodeRaytraceInstanceData(instances);
-}
-
-std::vector<std::uint8_t> BuildSharedTransformRaytraceInstanceBytes(
-    const glm::mat4& shared_model,
-    std::uint32_t transmissive_triangle_count,
-    std::uint32_t opaque_triangle_count)
-{
-    std::vector<RaytraceInstanceData> instances = {};
-    const float determinant = glm::determinant(glm::mat3(shared_model));
-    const glm::mat4 world_to_object =
-        std::abs(determinant) > 1.0e-8f ? glm::inverse(shared_model)
-                                        : glm::mat4(1.0f);
-    const auto append_instance =
-        [&](std::uint32_t material_id,
-            std::uint32_t triangle_count) {
-            if (triangle_count == 0)
-            {
-                return;
-            }
-            RaytraceInstanceData instance = {};
-            instance.object_to_world = shared_model;
-            instance.world_to_object = world_to_object;
-            instance.metadata =
-                glm::uvec4(0u, material_id, 0u, triangle_count);
-            instances.push_back(std::move(instance));
-        };
-    append_instance(kRaytraceMaterialTransmissive, transmissive_triangle_count);
-    append_instance(kRaytraceMaterialOpaque, opaque_triangle_count);
-    return EncodeRaytraceInstanceData(instances);
 }
 
 } // namespace
@@ -1006,13 +743,16 @@ void Renderer::UpdateAggregateRaytraceSceneBuffers()
         return;
     }
 
-    const std::size_t scene_state_hash = BuildRaytracingSourceStateHash(
+    const auto transmissive_triangles = BuildAggregateTriangleBytes(
         level_,
-        delta_time_,
-        use_world_space_buffers);
-    const bool geometry_changed =
-        !has_raytrace_scene_state_hash_ ||
-        last_raytrace_scene_state_hash_ != scene_state_hash;
+        true,
+        delta_time_);
+    const auto opaque_triangles = BuildAggregateTriangleBytes(
+        level_,
+        false,
+        delta_time_);
+    const auto transmissive_bvh = BuildAggregateBvhBytes(transmissive_triangles);
+    const auto opaque_bvh = BuildAggregateBvhBytes(opaque_triangles);
 
     auto update_named_buffer = [&](MaterialInterface& material,
                                    const char* inner_name,
@@ -1038,49 +778,6 @@ void Renderer::UpdateAggregateRaytraceSceneBuffers()
         }
     };
 
-    std::vector<std::uint8_t> transmissive_triangles = {};
-    std::vector<std::uint8_t> opaque_triangles = {};
-    std::vector<std::uint8_t> transmissive_bvh = {};
-    std::vector<std::uint8_t> opaque_bvh = {};
-    std::vector<std::uint8_t> raytrace_instances =
-        EncodeRaytraceInstanceData(std::vector<RaytraceInstanceData>{});
-    const bool update_instance_buffer =
-        geometry_changed || (!use_world_space_buffers && !use_shared_scene_transform);
-    if (geometry_changed)
-    {
-        const auto prepared_entries = PrepareRaytraceSceneEntries(
-            level_,
-            scene_entries,
-            use_world_space_buffers);
-        transmissive_triangles =
-            BuildAggregateTriangleBytes(prepared_entries, true);
-        opaque_triangles = BuildAggregateTriangleBytes(prepared_entries, false);
-        if (use_world_space_buffers)
-        {
-            transmissive_bvh = BuildAggregateBvhBytes(transmissive_triangles);
-            opaque_bvh = BuildAggregateBvhBytes(opaque_triangles);
-            raytrace_instances = BuildWorldSpaceRaytraceInstanceBytes(
-                transmissive_triangles,
-                opaque_triangles);
-        }
-        else if (use_shared_scene_transform)
-        {
-            transmissive_bvh = BuildAggregateBvhBytes(transmissive_triangles);
-            opaque_bvh = BuildAggregateBvhBytes(opaque_triangles);
-        }
-        else
-        {
-            transmissive_bvh =
-                BuildPerMeshAggregateBvhBytes(prepared_entries, true);
-            opaque_bvh =
-                BuildPerMeshAggregateBvhBytes(prepared_entries, false);
-        }
-    }
-    if (!use_world_space_buffers && !use_shared_scene_transform)
-    {
-        raytrace_instances = BuildPerMeshRaytraceInstanceBytes(scene_entries);
-    }
-
     for (const auto& [node_id, material_id] :
          level_.GetMeshMaterialIds(proto::NodeMesh::SCENE_RENDER_TIME))
     {
@@ -1092,21 +789,12 @@ void Renderer::UpdateAggregateRaytraceSceneBuffers()
         }
         auto& material = level_.GetMaterialFromId(material_id);
 
-        if (geometry_changed)
-        {
-            update_named_buffer(
-                material, "TriangleBufferTransmissive", transmissive_triangles);
-            update_named_buffer(
-                material, "BvhBufferTransmissive", transmissive_bvh);
-            update_named_buffer(
-                material, "TriangleBufferOpaque", opaque_triangles);
-            update_named_buffer(material, "BvhBufferOpaque", opaque_bvh);
-        }
-        if (update_instance_buffer)
-        {
-            update_named_buffer(
-                material, "RaytraceInstanceBuffer", raytrace_instances);
-        }
+        update_named_buffer(
+            material, "TriangleBufferTransmissive", transmissive_triangles);
+        update_named_buffer(
+            material, "BvhBufferTransmissive", transmissive_bvh);
+        update_named_buffer(material, "TriangleBufferOpaque", opaque_triangles);
+        update_named_buffer(material, "BvhBufferOpaque", opaque_bvh);
     }
 
     last_raytrace_scene_state_hash_ = scene_state_hash;
@@ -1203,21 +891,9 @@ void Renderer::RenderMesh(
     if (IsRaytracingProgram(program) &&
         render_time_ == proto::NodeMesh::SCENE_RENDER_TIME)
     {
-        if (HasRaytracingSourceMeshes(level_))
+        if (RaytraceSceneRequiresWorldSpaceBuffers(level_))
         {
-            if (RequiresRuntimeRaytraceSceneBuffers(level_, delta_time_))
-            {
-                model_matrix = glm::mat4(1.0f);
-            }
-            else if (!program.GetTemporarySceneRoot().empty())
-            {
-                auto temp_id = level_.GetIdFromName(program.GetTemporarySceneRoot());
-                if (temp_id != NullId)
-                {
-                    auto& temp_node = level_.GetSceneNodeFromId(temp_id);
-                    model_matrix = temp_node.GetLocalModel(delta_time_);
-                }
-            }
+            model_matrix = glm::mat4(1.0f);
         }
         else if (!program.GetTemporarySceneRoot().empty())
         {
@@ -1654,7 +1330,7 @@ void Renderer::PreRender()
         }
         preprocess_entry(p, true);
     }
-    if (RequiresRuntimeRaytraceSceneBuffers(level_, delta_time_))
+    if (RaytraceSceneRequiresWorldSpaceBuffers(level_))
     {
         UpdateAggregateRaytraceSceneBuffers();
     }

--- a/frame/opengl/renderer.cpp
+++ b/frame/opengl/renderer.cpp
@@ -3,7 +3,9 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cstdint>
 #include <cstring>
+#include <functional>
 #include <format>
 #include <glad/glad.h>
 #include <glm/gtc/type_ptr.hpp>
@@ -127,11 +129,6 @@ bool RaytraceSceneRequiresWorldSpaceBuffers(frame::LevelInterface& level)
         }
     }
     return false;
-}
-
-bool HasRaytracingSourceMeshes(frame::LevelInterface& level)
-{
-    return !GetRaytracingSourceMeshMaterials(level).empty();
 }
 
 std::vector<std::pair<EntityId, std::string>> GetActiveTextureBindings(
@@ -340,6 +337,112 @@ std::array<float, 4> ResolveRaytracingColorMultiplier(
         multiplier[channel] = std::clamp(value, 0.0f, 4.0f);
     }
     return multiplier;
+}
+
+template <typename T>
+void HashCombine(std::size_t& seed, const T& value)
+{
+    seed ^= std::hash<T>{}(value) + 0x9e3779b9u + (seed << 6u) + (seed >> 2u);
+}
+
+void HashFloat(std::size_t& seed, float value)
+{
+    std::uint32_t bits = 0;
+    std::memcpy(&bits, &value, sizeof(bits));
+    HashCombine(seed, bits);
+}
+
+void HashColor(std::size_t& seed, const std::array<float, 4>& color)
+{
+    for (const float channel : color)
+    {
+        HashFloat(seed, channel);
+    }
+}
+
+void HashMatrix(std::size_t& seed, const glm::mat4& matrix)
+{
+    const float* values = glm::value_ptr(matrix);
+    for (int i = 0; i < 16; ++i)
+    {
+        HashFloat(seed, values[i]);
+    }
+}
+
+void HashByteSamples(
+    std::size_t& seed, const std::vector<std::uint8_t>& bytes)
+{
+    HashCombine(seed, bytes.size());
+    if (bytes.empty())
+    {
+        return;
+    }
+
+    constexpr std::array<float, 8> kRatios = {
+        0.0f, 0.11f, 0.23f, 0.37f, 0.53f, 0.67f, 0.83f, 1.0f};
+    const std::size_t max_index = bytes.size() - 1;
+    for (const float ratio : kRatios)
+    {
+        const auto index = static_cast<std::size_t>(
+            ratio * static_cast<float>(max_index));
+        HashCombine(seed, bytes[index]);
+    }
+}
+
+std::size_t BuildRaytracingSourceStateHash(
+    frame::LevelInterface& level,
+    double time_seconds)
+{
+    std::size_t state_hash = 0;
+    const auto source_mesh_materials = GetRaytracingSourceMeshMaterials(level);
+    HashCombine(state_hash, source_mesh_materials.size());
+    for (const auto& [source_node_id, source_material_id] : source_mesh_materials)
+    {
+        HashCombine(state_hash, static_cast<std::uint64_t>(source_node_id));
+        HashCombine(state_hash, static_cast<std::uint64_t>(source_material_id));
+
+        auto* node =
+            dynamic_cast<NodeMesh*>(&level.GetSceneNodeFromId(source_node_id));
+        if (!node)
+        {
+            continue;
+        }
+
+        HashMatrix(state_hash, node->GetLocalModel(time_seconds));
+        HashCombine(
+            state_hash,
+            IsTransmissiveMaterial(level, source_material_id));
+        HashColor(
+            state_hash,
+            ResolveRaytracingSourceMaterialColor(level, source_material_id));
+
+        const auto mesh_id = node->GetLocalMesh();
+        HashCombine(state_hash, static_cast<std::uint64_t>(mesh_id));
+        if (!mesh_id)
+        {
+            continue;
+        }
+
+        const auto triangle_buffer_id =
+            level.GetMeshFromId(mesh_id).GetTriangleBufferId();
+        HashCombine(
+            state_hash,
+            static_cast<std::uint64_t>(triangle_buffer_id));
+        if (!triangle_buffer_id)
+        {
+            continue;
+        }
+
+        auto* triangle_buffer = dynamic_cast<Buffer*>(
+            &level.GetBufferFromId(triangle_buffer_id));
+        if (!triangle_buffer)
+        {
+            continue;
+        }
+
+        HashByteSamples(state_hash, triangle_buffer->GetRawData());
+    }
+    return state_hash;
 }
 
 constexpr std::size_t kRaytraceFloatsPerVertex = 12;
@@ -621,16 +724,14 @@ void Renderer::UpdateRaytraceBuffersIfNeeded(SkinnedMesh& skinned_mesh)
             }
         }
     }
-
-    if (HasRaytracingSourceMeshes(level_))
-    {
-        UpdateAggregateRaytraceSceneBuffers();
-    }
 }
 
 void Renderer::UpdateAggregateRaytraceSceneBuffers()
 {
-    if (last_raytrace_scene_buffer_update_time_ == delta_time_)
+    const std::size_t scene_state_hash =
+        BuildRaytracingSourceStateHash(level_, delta_time_);
+    if (has_raytrace_scene_state_hash_ &&
+        last_raytrace_scene_state_hash_ == scene_state_hash)
     {
         return;
     }
@@ -689,7 +790,8 @@ void Renderer::UpdateAggregateRaytraceSceneBuffers()
         update_named_buffer(material, "BvhBufferOpaque", opaque_bvh);
     }
 
-    last_raytrace_scene_buffer_update_time_ = delta_time_;
+    last_raytrace_scene_state_hash_ = scene_state_hash;
+    has_raytrace_scene_state_hash_ = true;
 }
 
 std::optional<glm::mat4> Renderer::RenderNode(
@@ -1275,6 +1377,3 @@ void Renderer::PostProcess()
 }
 
 } // End namespace frame::opengl.
-
-
-

--- a/frame/opengl/renderer.cpp
+++ b/frame/opengl/renderer.cpp
@@ -378,13 +378,20 @@ void HashByteSamples(
         return;
     }
 
-    constexpr std::array<float, 8> kRatios = {
-        0.0f, 0.11f, 0.23f, 0.37f, 0.53f, 0.67f, 0.83f, 1.0f};
+    constexpr std::array<std::pair<std::size_t, std::size_t>, 8> kRatios = {{
+        {0u, 1u},
+        {11u, 100u},
+        {23u, 100u},
+        {37u, 100u},
+        {53u, 100u},
+        {67u, 100u},
+        {83u, 100u},
+        {1u, 1u},
+    }};
     const std::size_t max_index = bytes.size() - 1;
-    for (const float ratio : kRatios)
+    for (const auto& [numerator, denominator] : kRatios)
     {
-        const auto index = static_cast<std::size_t>(
-            ratio * static_cast<float>(max_index));
+        const auto index = (max_index * numerator) / denominator;
         HashCombine(seed, bytes[index]);
     }
 }

--- a/frame/opengl/renderer.h
+++ b/frame/opengl/renderer.h
@@ -145,7 +145,8 @@ class Renderer : public RendererInterface
     // Texture frame (used in render mesh).
     frame::proto::TextureFrame texture_frame_;
     bool first_render_ = true;
-    double last_raytrace_scene_buffer_update_time_ = -1.0;
+    std::size_t last_raytrace_scene_state_hash_ = 0;
+    bool has_raytrace_scene_state_hash_ = false;
     // The render callback it will be called once per mesh.
     RenderCallback callback_ = [](UniformCollectionInterface&,
                                   MeshInterface&,
@@ -153,6 +154,5 @@ class Renderer : public RendererInterface
 };
 
 } // End namespace frame::opengl.
-
 
 

--- a/frame/opengl/sdl_opengl_window.cpp
+++ b/frame/opengl/sdl_opengl_window.cpp
@@ -58,7 +58,7 @@ SDLOpenGLWindow::SDLOpenGLWindow(glm::uvec2 size) : size_(size)
         "SDL OpenGL",
         size_.x,
         size_.y,
-        SDL_WINDOW_RESIZABLE | SDL_WINDOW_OPENGL);
+        SDL_WINDOW_RESIZABLE | SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN);
     if (!sdl_window_)
     {
         throw std::runtime_error("Couldn't start a window in SDL3.");
@@ -129,6 +129,10 @@ WindowReturnEnum SDLOpenGLWindow::Run(std::function<bool()> lambda)
             plugin_interface->Startup(size_);
         }
     }
+
+    SDL_ShowWindow(sdl_window_);
+    SDL_RaiseWindow(sdl_window_);
+
     WindowReturnEnum window_return_enum = WindowReturnEnum::CONTINUE;
     auto previous_frame = std::chrono::steady_clock::now();
     while (window_return_enum == WindowReturnEnum::CONTINUE)
@@ -201,7 +205,8 @@ WindowReturnEnum SDLOpenGLWindow::Run(std::function<bool()> lambda)
 
 bool SDLOpenGLWindow::RunEvent(const SDL_Event& event, const double dt)
 {
-    if (event.type == SDL_EVENT_QUIT)
+    if (event.type == SDL_EVENT_QUIT ||
+        event.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED)
     {
         return false;
     }

--- a/frame/vulkan/device.cpp
+++ b/frame/vulkan/device.cpp
@@ -50,6 +50,11 @@ namespace
 
 constexpr std::uint32_t kHardwareRaytracingAsBinding = 32;
 
+const char* BoolToString(bool value)
+{
+    return value ? "on" : "off";
+}
+
 template <typename T>
 T AlignUp(T value, T alignment)
 {
@@ -1553,6 +1558,7 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
             ScopedTimer timer(logger_, "CreateComputePipeline");
             CreateComputePipeline();
         }
+        LogRuntimeConfiguration();
     }
     catch (const std::exception& ex)
     {
@@ -2390,6 +2396,67 @@ void Device::Display(double dt)
     }
 
     current_frame_ = (current_frame_ + 1) % kMaxFramesInFlight;
+}
+
+void Device::LogRuntimeConfiguration() const
+{
+    const bool validation_enabled = absl::GetFlag(FLAGS_vk_validation);
+    const bool has_active_program = active_program_info_.has_value();
+    const bool has_compute_shader =
+        has_active_program && !active_program_info_->compute_shader.empty();
+    const bool has_raytracing_stage_mapping =
+        has_active_program &&
+        !active_program_info_->raygen_shader.empty() &&
+        !active_program_info_->miss_shader.empty() &&
+        !active_program_info_->closesthit_shader.empty();
+    const bool raytracing_pipeline_ready =
+        static_cast<bool>(raytracing_pipeline_);
+    const bool compute_pipeline_ready =
+        static_cast<bool>(compute_pipeline_);
+    const bool hardware_scene_ready =
+        static_cast<bool>(hardware_raytracing_tlas_);
+
+    std::string active_path = "graphics";
+    if (raytracing_pipeline_ready && hardware_scene_ready)
+    {
+        active_path = "hardware_rt";
+    }
+    else if (compute_pipeline_ready)
+    {
+        active_path = "compute_fallback";
+    }
+    else if (raytracing_pipeline_ready)
+    {
+        active_path = "raytracing_pipeline_without_scene";
+    }
+    else if (use_raytracing_pipeline_)
+    {
+        active_path = "hardware_rt_requested_pipeline_missing";
+    }
+    else if (use_compute_raytracing_)
+    {
+        active_path = "compute_requested_pipeline_missing";
+    }
+
+    std::string material_name = "<none>";
+    if (level_ && has_active_program && active_program_info_->material_id != NullId)
+    {
+        material_name = level_->GetNameFromId(active_program_info_->material_id);
+    }
+
+    logger_->info(
+        "Vulkan runtime summary: validation={}, program='{}', material='{}', path={}, hw_rt_supported={}, hw_rt_requested={}, hw_rt_scene_ready={}, rt_pipeline_ready={}, compute_pipeline_ready={}, compute_shader_mapped={}, rt_stage_mapping={}.",
+        BoolToString(validation_enabled),
+        has_active_program ? active_program_info_->program_name.c_str() : "<none>",
+        material_name,
+        active_path,
+        BoolToString(hardware_raytracing_supported_),
+        BoolToString(use_hardware_raytracing_),
+        BoolToString(hardware_scene_ready),
+        BoolToString(raytracing_pipeline_ready),
+        BoolToString(compute_pipeline_ready),
+        BoolToString(has_compute_shader),
+        BoolToString(has_raytracing_stage_mapping));
 }
 
 

--- a/frame/vulkan/device.cpp
+++ b/frame/vulkan/device.cpp
@@ -1572,7 +1572,17 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
     if (!sync_resources_)
     {
         sync_resources_ = std::make_unique<SyncResources>(
-            *vk_unique_device_, kMaxFramesInFlight);
+            *vk_unique_device_,
+            kMaxFramesInFlight,
+            swapchain_resources_ ? swapchain_resources_->GetImages().size() : 0);
+    }
+    else if (swapchain_resources_ &&
+             sync_resources_->GetSwapchainImageCount() !=
+                 swapchain_resources_->GetImages().size())
+    {
+        sync_resources_->Destroy();
+        sync_resources_->SetSwapchainImageCount(
+            swapchain_resources_->GetImages().size());
     }
     if (sync_resources_ && !sync_resources_->IsCreated())
     {
@@ -2325,7 +2335,7 @@ void Device::Display(double dt)
     const vk::PipelineStageFlags wait_stages[] = {
         vk::PipelineStageFlagBits::eColorAttachmentOutput};
     const vk::Semaphore signal_semaphores[] = {
-        sync_resources_->GetRenderFinished(current_frame_)};
+        sync_resources_->GetRenderFinished(image_index)};
 
     vk::SubmitInfo submit_info(
         1,
@@ -2439,6 +2449,13 @@ void Device::RecreateSwapchain()
     swapchain_resources_->Create(size_);
     command_resources_->AllocateBuffers(
         static_cast<std::uint32_t>(kMaxFramesInFlight));
+    if (sync_resources_)
+    {
+        sync_resources_->Destroy();
+        sync_resources_->SetSwapchainImageCount(
+            swapchain_resources_->GetImages().size());
+        sync_resources_->Create();
+    }
     CreateSwapchainPreviewImage();
 
     if (use_hardware_raytracing_)

--- a/frame/vulkan/device.cpp
+++ b/frame/vulkan/device.cpp
@@ -402,9 +402,11 @@ void HashByteSamples(
 
 std::size_t BuildRaytracingSourceStateHash(
     frame::LevelInterface& level,
-    double time_seconds)
+    double time_seconds,
+    bool include_node_matrices)
 {
     std::size_t state_hash = 0;
+    HashCombine(state_hash, include_node_matrices);
     const auto source_mesh_materials = GetRaytracingSourceMeshMaterials(level);
     HashCombine(state_hash, source_mesh_materials.size());
     for (const auto& [source_node_id, source_material_id] : source_mesh_materials)
@@ -419,7 +421,10 @@ std::size_t BuildRaytracingSourceStateHash(
             continue;
         }
 
-        HashMatrix(state_hash, node->GetLocalModel(time_seconds));
+        if (include_node_matrices)
+        {
+            HashMatrix(state_hash, node->GetLocalModel(time_seconds));
+        }
         HashCombine(
             state_hash,
             IsTransmissiveMaterial(level, source_material_id));
@@ -491,6 +496,48 @@ bool RaytraceSceneRequiresWorldSpaceBuffers(frame::LevelInterface& level)
 bool HasRaytracingSourceMeshes(frame::LevelInterface& level)
 {
     return !GetRaytracingSourceMeshMaterials(level).empty();
+}
+
+std::optional<glm::mat4> GetSharedRaytraceSceneTransform(
+    frame::LevelInterface& level,
+    double time_seconds)
+{
+    const auto source_mesh_materials = GetRaytracingSourceMeshMaterials(level);
+    if (source_mesh_materials.empty())
+    {
+        return std::nullopt;
+    }
+
+    std::optional<glm::mat4> shared_model = std::nullopt;
+    for (const auto& [source_node_id, source_material_id] : source_mesh_materials)
+    {
+        (void)source_material_id;
+        auto* node =
+            dynamic_cast<NodeMesh*>(&level.GetSceneNodeFromId(source_node_id));
+        if (!node)
+        {
+            return std::nullopt;
+        }
+        const glm::mat4 model = node->GetLocalModel(time_seconds);
+        if (!shared_model)
+        {
+            shared_model = model;
+            continue;
+        }
+        if (*shared_model != model)
+        {
+            return std::nullopt;
+        }
+    }
+    return shared_model;
+}
+
+bool CanUseSharedTransformHardwareRaytraceScene(
+    frame::LevelInterface& level,
+    double time_seconds)
+{
+    return !RaytraceSceneRequiresWorldSpaceBuffers(level) &&
+           GetSharedRaytraceSceneTransform(level, time_seconds).has_value();
 }
 
 constexpr std::size_t kRaytraceFloatsPerVertex = 12;
@@ -782,7 +829,8 @@ void UploadDeviceLocalBuffer(
 std::vector<std::uint8_t> BuildAggregateTriangleBytes(
     frame::LevelInterface& level,
     bool transmissive,
-    double time_seconds)
+    double time_seconds,
+    bool apply_node_transform = true)
 {
     std::vector<std::uint8_t> aggregate_triangle_bytes = {};
     const auto reference_color =
@@ -827,9 +875,12 @@ std::vector<std::uint8_t> BuildAggregateTriangleBytes(
         const auto color_multiplier = ResolveRaytracingColorMultiplier(
             source_color,
             reference_color);
-        const auto transformed = TransformTriangleBytes(
-            triangle_buffer->GetRawData(),
-            node->GetLocalModel(time_seconds));
+        const auto transformed =
+            apply_node_transform
+                ? TransformTriangleBytes(
+                      triangle_buffer->GetRawData(),
+                      node->GetLocalModel(time_seconds))
+                : triangle_buffer->GetRawData();
         const auto tinted =
             ApplyTriangleColorMultiplier(transformed, color_multiplier);
         aggregate_triangle_bytes.insert(
@@ -2001,10 +2052,18 @@ bool Device::UpdateAggregateRaytracingSceneBuffers(bool build_software_bvh)
     {
         return false;
     }
+    const bool use_shared_transform_hardware_scene =
+        !build_software_bvh &&
+        CanUseSharedTransformHardwareRaytraceScene(
+            *level_,
+            static_cast<double>(elapsed_time_seconds_));
+    const bool use_world_space_triangles =
+        build_software_bvh || !use_shared_transform_hardware_scene;
     const std::size_t scene_state_hash =
         BuildRaytracingSourceStateHash(
             *level_,
-            static_cast<double>(elapsed_time_seconds_));
+            static_cast<double>(elapsed_time_seconds_),
+            use_world_space_triangles);
     if (has_raytrace_scene_state_hash_ &&
         last_raytrace_scene_state_hash_ == scene_state_hash)
     {
@@ -2050,12 +2109,14 @@ bool Device::UpdateAggregateRaytracingSceneBuffers(bool build_software_bvh)
         BuildAggregateTriangleBytes(
             *level_,
             true,
-            static_cast<double>(elapsed_time_seconds_));
+            static_cast<double>(elapsed_time_seconds_),
+            use_world_space_triangles);
     const auto opaque_triangles =
         BuildAggregateTriangleBytes(
             *level_,
             false,
-            static_cast<double>(elapsed_time_seconds_));
+            static_cast<double>(elapsed_time_seconds_),
+            use_world_space_triangles);
 
     bool updated = false;
     updated |= update_buffer(
@@ -2679,10 +2740,18 @@ void Device::RecordCommandBuffer(
     const auto& gui_render_pass = swapchain_resources_->GetGuiRenderPass();
     const auto& gui_framebuffers = swapchain_resources_->GetGuiFramebuffers();
 
+    const bool has_raytrace_source_meshes =
+        level_ && HasRaytracingSourceMeshes(*level_);
+    const bool use_shared_transform_hardware_scene =
+        has_raytrace_source_meshes &&
+        use_hardware_raytracing_ &&
+        CanUseSharedTransformHardwareRaytraceScene(
+            *level_,
+            static_cast<double>(elapsed_time_seconds_));
     const bool use_world_space_raytrace_scene =
-        level_ &&
+        has_raytrace_source_meshes &&
         (use_compute_raytracing_ || use_raytracing_pipeline_) &&
-        HasRaytracingSourceMeshes(*level_);
+        !use_shared_transform_hardware_scene;
     std::string preferred_scene_root;
     if (!use_world_space_raytrace_scene &&
         level_ &&

--- a/frame/vulkan/device.cpp
+++ b/frame/vulkan/device.cpp
@@ -3,7 +3,9 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
+#include <functional>
 #include <limits>
 #include <numeric>
 #include <optional>
@@ -41,6 +43,7 @@
 #include "frame/proto/uniform.pb.h"
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/matrix_inverse.hpp>
+#include <glm/gtc/type_ptr.hpp>
 
 namespace frame::vulkan
 {
@@ -340,6 +343,112 @@ std::array<float, 4> ResolveRaytracingColorMultiplier(
     return multiplier;
 }
 
+template <typename T>
+void HashCombine(std::size_t& seed, const T& value)
+{
+    seed ^= std::hash<T>{}(value) + 0x9e3779b9u + (seed << 6u) + (seed >> 2u);
+}
+
+void HashFloat(std::size_t& seed, float value)
+{
+    std::uint32_t bits = 0;
+    std::memcpy(&bits, &value, sizeof(bits));
+    HashCombine(seed, bits);
+}
+
+void HashColor(std::size_t& seed, const std::array<float, 4>& color)
+{
+    for (const float channel : color)
+    {
+        HashFloat(seed, channel);
+    }
+}
+
+void HashMatrix(std::size_t& seed, const glm::mat4& matrix)
+{
+    const float* values = glm::value_ptr(matrix);
+    for (int i = 0; i < 16; ++i)
+    {
+        HashFloat(seed, values[i]);
+    }
+}
+
+void HashByteSamples(
+    std::size_t& seed, const std::vector<std::uint8_t>& bytes)
+{
+    HashCombine(seed, bytes.size());
+    if (bytes.empty())
+    {
+        return;
+    }
+
+    constexpr std::array<float, 8> kRatios = {
+        0.0f, 0.11f, 0.23f, 0.37f, 0.53f, 0.67f, 0.83f, 1.0f};
+    const std::size_t max_index = bytes.size() - 1;
+    for (const float ratio : kRatios)
+    {
+        const auto index = static_cast<std::size_t>(
+            ratio * static_cast<float>(max_index));
+        HashCombine(seed, bytes[index]);
+    }
+}
+
+std::size_t BuildRaytracingSourceStateHash(
+    frame::LevelInterface& level,
+    double time_seconds)
+{
+    std::size_t state_hash = 0;
+    const auto source_mesh_materials = GetRaytracingSourceMeshMaterials(level);
+    HashCombine(state_hash, source_mesh_materials.size());
+    for (const auto& [source_node_id, source_material_id] : source_mesh_materials)
+    {
+        HashCombine(state_hash, static_cast<std::uint64_t>(source_node_id));
+        HashCombine(state_hash, static_cast<std::uint64_t>(source_material_id));
+
+        auto* node =
+            dynamic_cast<NodeMesh*>(&level.GetSceneNodeFromId(source_node_id));
+        if (!node)
+        {
+            continue;
+        }
+
+        HashMatrix(state_hash, node->GetLocalModel(time_seconds));
+        HashCombine(
+            state_hash,
+            IsTransmissiveMaterial(level, source_material_id));
+        HashColor(
+            state_hash,
+            ResolveRaytracingSourceMaterialColor(level, source_material_id));
+
+        const auto mesh_id = node->GetLocalMesh();
+        HashCombine(state_hash, static_cast<std::uint64_t>(mesh_id));
+        if (!mesh_id)
+        {
+            continue;
+        }
+
+        const auto triangle_buffer_id =
+            level.GetMeshFromId(mesh_id).GetTriangleBufferId();
+        HashCombine(
+            state_hash,
+            static_cast<std::uint64_t>(triangle_buffer_id));
+        if (!triangle_buffer_id)
+        {
+            continue;
+        }
+
+        auto* triangle_buffer = dynamic_cast<Buffer*>(
+            &level.GetBufferFromId(triangle_buffer_id));
+        if (!triangle_buffer)
+        {
+            continue;
+        }
+
+        HashByteSamples(state_hash, triangle_buffer->GetRawData());
+    }
+    return state_hash;
+}
+
 bool RaytraceSceneRequiresWorldSpaceBuffers(frame::LevelInterface& level)
 {
     for (const auto& [node_id, material_id] :
@@ -370,11 +479,6 @@ bool RaytraceSceneRequiresWorldSpaceBuffers(frame::LevelInterface& level)
         }
     }
     return false;
-}
-
-bool HasRaytracingSourceMeshes(frame::LevelInterface& level)
-{
-    return !GetRaytracingSourceMeshMaterials(level).empty();
 }
 
 constexpr std::size_t kRaytraceFloatsPerVertex = 12;
@@ -1020,7 +1124,8 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
     use_raytracing_pipeline_ = false;
     compute_output_in_shader_read_ = false;
     elapsed_time_seconds_ = 0.0f;
-    last_raytrace_scene_buffer_update_time_ = -1.0f;
+    last_raytrace_scene_state_hash_ = 0;
+    has_raytrace_scene_state_hash_ = false;
 
     // Prefer programs configured for render passes; otherwise fall back to the
     // first available program.
@@ -1701,7 +1806,8 @@ void Device::Cleanup()
     current_level_data_.reset();
     level_.reset();
     elapsed_time_seconds_ = 0.0f;
-    last_raytrace_scene_buffer_update_time_ = -1.0f;
+    last_raytrace_scene_state_hash_ = 0;
+    has_raytrace_scene_state_hash_ = false;
     active_program_info_.reset();
     use_procedural_quad_pipeline_ = false;
     use_raytracing_pipeline_ = false;
@@ -1815,8 +1921,8 @@ void Device::UpdateRaytraceBuffers()
                     level_->GetBufferFromId(triangle_buffer_id));
                 triangle_buffer.Copy(triangles);
                 if (buffer_resources_->UpdateStorageBuffer(
-                    level_->GetNameFromId(triangle_buffer_id),
-                    triangle_buffer.GetRawData()))
+                        level_->GetNameFromId(triangle_buffer_id),
+                        triangle_buffer.GetRawData()))
                 {
                     ++updated_buffer_count;
                 }
@@ -1835,8 +1941,8 @@ void Device::UpdateRaytraceBuffers()
                     bvh_nodes.size() * sizeof(frame::BVHNode),
                     bvh_nodes.data());
                 if (buffer_resources_->UpdateStorageBuffer(
-                    level_->GetNameFromId(bvh_buffer_id),
-                    bvh_buffer.GetRawData()))
+                        level_->GetNameFromId(bvh_buffer_id),
+                        bvh_buffer.GetRawData()))
                 {
                     ++updated_buffer_count;
                 }
@@ -1844,7 +1950,7 @@ void Device::UpdateRaytraceBuffers()
         }
     }
     bool updated_aggregate_scene = false;
-    if (HasRaytracingSourceMeshes(*level_))
+    if (RaytraceSceneRequiresWorldSpaceBuffers(*level_))
     {
         updated_aggregate_scene = UpdateAggregateRaytracingSceneBuffers(
             !use_hardware_raytracing_);
@@ -1883,7 +1989,12 @@ bool Device::UpdateAggregateRaytracingSceneBuffers(bool build_software_bvh)
     {
         return false;
     }
-    if (last_raytrace_scene_buffer_update_time_ == elapsed_time_seconds_)
+    const std::size_t scene_state_hash =
+        BuildRaytracingSourceStateHash(
+            *level_,
+            static_cast<double>(elapsed_time_seconds_));
+    if (has_raytrace_scene_state_hash_ &&
+        last_raytrace_scene_state_hash_ == scene_state_hash)
     {
         return false;
     }
@@ -1949,7 +2060,8 @@ bool Device::UpdateAggregateRaytracingSceneBuffers(bool build_software_bvh)
             BuildAggregateBvhBytes(opaque_triangles));
     }
 
-    last_raytrace_scene_buffer_update_time_ = elapsed_time_seconds_;
+    last_raytrace_scene_state_hash_ = scene_state_hash;
+    has_raytrace_scene_state_hash_ = true;
     return updated;
 }
 
@@ -2558,7 +2670,7 @@ void Device::RecordCommandBuffer(
     const bool use_world_space_raytrace_scene =
         level_ &&
         (use_compute_raytracing_ || use_raytracing_pipeline_) &&
-        HasRaytracingSourceMeshes(*level_);
+        RaytraceSceneRequiresWorldSpaceBuffers(*level_);
     std::string preferred_scene_root;
     if (!use_world_space_raytrace_scene &&
         level_ &&

--- a/frame/vulkan/device.cpp
+++ b/frame/vulkan/device.cpp
@@ -642,24 +642,6 @@ vk::TransformMatrixKHR MakeIdentityTransform()
     return transform;
 }
 
-vk::TransformMatrixKHR MakeTransformMatrix(const glm::mat4& matrix)
-{
-    vk::TransformMatrixKHR transform = {};
-    transform.matrix[0][0] = matrix[0][0];
-    transform.matrix[0][1] = matrix[1][0];
-    transform.matrix[0][2] = matrix[2][0];
-    transform.matrix[0][3] = matrix[3][0];
-    transform.matrix[1][0] = matrix[0][1];
-    transform.matrix[1][1] = matrix[1][1];
-    transform.matrix[1][2] = matrix[2][1];
-    transform.matrix[1][3] = matrix[3][1];
-    transform.matrix[2][0] = matrix[0][2];
-    transform.matrix[2][1] = matrix[1][2];
-    transform.matrix[2][2] = matrix[2][2];
-    transform.matrix[2][3] = matrix[3][2];
-    return transform;
-}
-
 bool AreTexturesCompatibleForReuse(
     const frame::vulkan::Texture& old_texture,
     const frame::vulkan::Texture& new_texture)
@@ -947,191 +929,6 @@ std::vector<std::uint8_t> BuildAggregateBvhBytes(
         std::memcpy(bytes.data(), bvh_nodes.data(), bytes.size());
     }
     return bytes;
-}
-
-struct HardwareRaytraceSourceEntry
-{
-    EntityId source_node_id = NullId;
-    EntityId source_material_id = NullId;
-    EntityId source_buffer_id = NullId;
-    std::uint64_t source_generation = 0;
-    glm::mat4 model = glm::mat4(1.0f);
-    std::uint32_t triangle_count = 0;
-    std::uint32_t triangle_offset = 0;
-    std::uint32_t material_id = 0;
-};
-
-std::vector<HardwareRaytraceSourceEntry> CollectHardwareRaytraceSourceEntries(
-    frame::LevelInterface& level,
-    double time_seconds)
-{
-    std::vector<HardwareRaytraceSourceEntry> entries = {};
-    std::uint32_t transmissive_offset = 0;
-    std::uint32_t opaque_offset = 0;
-    for (const auto& [source_node_id, source_material_id] :
-         GetRaytracingSourceMeshMaterials(level))
-    {
-        auto* node = dynamic_cast<frame::NodeMesh*>(
-            &level.GetSceneNodeFromId(source_node_id));
-        if (!node)
-        {
-            continue;
-        }
-        const auto mesh_id = node->GetLocalMesh();
-        if (!mesh_id)
-        {
-            continue;
-        }
-        const auto triangle_buffer_id =
-            level.GetMeshFromId(mesh_id).GetTriangleBufferId();
-        if (!triangle_buffer_id)
-        {
-            continue;
-        }
-        auto* triangle_buffer = dynamic_cast<frame::vulkan::Buffer*>(
-            &level.GetBufferFromId(triangle_buffer_id));
-        if (!triangle_buffer)
-        {
-            continue;
-        }
-        const auto& triangle_bytes = triangle_buffer->GetRawData();
-        if (triangle_bytes.empty() ||
-            triangle_bytes.size() % kRaytraceTriangleVertexStrideBytes != 0)
-        {
-            continue;
-        }
-        const auto vertex_count = triangle_bytes.size() /
-            kRaytraceTriangleVertexStrideBytes;
-        if (vertex_count < 3 || (vertex_count % 3) != 0)
-        {
-            continue;
-        }
-        HardwareRaytraceSourceEntry entry = {};
-        entry.source_node_id = source_node_id;
-        entry.source_material_id = source_material_id;
-        entry.source_buffer_id = triangle_buffer_id;
-        entry.source_generation = triangle_buffer->GetGeneration();
-        entry.model = node->GetLocalModel(time_seconds);
-        entry.triangle_count = static_cast<std::uint32_t>(vertex_count / 3);
-        const bool transmissive =
-            IsTransmissiveMaterial(level, source_material_id);
-        entry.material_id = transmissive ? 0u : 1u;
-        entry.triangle_offset = transmissive ? transmissive_offset : opaque_offset;
-        if (transmissive)
-        {
-            transmissive_offset += entry.triangle_count;
-        }
-        else
-        {
-            opaque_offset += entry.triangle_count;
-        }
-        entries.push_back(std::move(entry));
-    }
-    return entries;
-}
-
-std::vector<frame::vulkan::Device::HardwareRaytracingInstanceData>
-BuildHardwareRaytracingInstanceData(
-    const std::vector<HardwareRaytraceSourceEntry>& entries,
-    const std::optional<glm::mat4>& shared_scene_model = std::nullopt)
-{
-    std::vector<frame::vulkan::Device::HardwareRaytracingInstanceData> data = {};
-    data.reserve(entries.size());
-    const bool use_shared_scene_transform = shared_scene_model.has_value();
-    for (const auto& entry : entries)
-    {
-        frame::vulkan::Device::HardwareRaytracingInstanceData instance = {};
-        if (use_shared_scene_transform)
-        {
-            // Shared-transform scenes keep geometry/TLAS in scene-local space.
-            // The current scene matrix is supplied through the uniform block
-            // each frame, so baking it into the instance buffer would make
-            // shading lag behind the animated scene transform.
-            instance.object_to_world = glm::mat4(1.0f);
-            instance.world_to_object = glm::mat4(1.0f);
-        }
-        else
-        {
-            instance.object_to_world = entry.model;
-            const float entry_det = glm::determinant(glm::mat3(entry.model));
-            instance.world_to_object =
-                std::abs(entry_det) > 1.0e-8f
-                    ? glm::inverse(entry.model)
-                    : glm::mat4(1.0f);
-        }
-        instance.metadata = glm::uvec4(
-            entry.triangle_offset,
-            entry.material_id,
-            use_shared_scene_transform ? 1u : 0u,
-            0u);
-        data.push_back(std::move(instance));
-    }
-    return data;
-}
-
-std::vector<std::uint8_t> EncodeHardwareRaytracingInstanceData(
-    const std::vector<frame::vulkan::Device::HardwareRaytracingInstanceData>&
-        instances)
-{
-    std::vector<std::uint8_t> bytes(
-        instances.size() *
-        sizeof(frame::vulkan::Device::HardwareRaytracingInstanceData));
-    if (!bytes.empty())
-    {
-        std::memcpy(bytes.data(), instances.data(), bytes.size());
-    }
-    return bytes;
-}
-
-bool HardwareRaytracingLayoutMatches(
-    const std::vector<HardwareRaytraceSourceEntry>& entries,
-    const std::vector<frame::vulkan::Device::HardwareRaytracingGeometry>&
-        geometries)
-{
-    if (entries.size() != geometries.size())
-    {
-        return false;
-    }
-    for (std::size_t i = 0; i < entries.size(); ++i)
-    {
-        const auto& entry = entries[i];
-        const auto& geometry = geometries[i];
-        if (entry.source_node_id != geometry.source_node_id ||
-            entry.source_material_id != geometry.source_material_id ||
-            entry.source_buffer_id != geometry.source_buffer_id ||
-            entry.triangle_count != geometry.triangle_count ||
-            entry.triangle_offset != geometry.triangle_offset ||
-            entry.material_id != geometry.material_id)
-        {
-            return false;
-        }
-    }
-    return true;
-}
-
-std::vector<vk::AccelerationStructureInstanceKHR>
-BuildHardwareRaytracingAsInstances(
-    const std::vector<HardwareRaytraceSourceEntry>& entries,
-    const std::optional<glm::mat4>& shared_scene_model = std::nullopt)
-{
-    std::vector<vk::AccelerationStructureInstanceKHR> instances = {};
-    instances.reserve(entries.size());
-    const bool use_shared_scene_transform = shared_scene_model.has_value();
-    for (std::size_t i = 0; i < entries.size(); ++i)
-    {
-        const auto& entry = entries[i];
-        vk::AccelerationStructureInstanceKHR instance{};
-        instance.transform = use_shared_scene_transform
-            ? MakeIdentityTransform()
-            : MakeTransformMatrix(entry.model);
-        instance.instanceCustomIndex = static_cast<std::uint32_t>(i);
-        instance.mask = 0xFF;
-        instance.instanceShaderBindingTableRecordOffset = 0;
-        instance.flags = static_cast<VkGeometryInstanceFlagsKHR>(
-            vk::GeometryInstanceFlagBitsKHR::eTriangleFacingCullDisable);
-        instances.push_back(instance);
-    }
-    return instances;
 }
 
 } // namespace
@@ -1839,7 +1636,7 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
         command_queue_ = std::make_unique<CommandQueue>(
             *vk_unique_device_,
             graphics_queue_,
-            graphics_queue_family_index_);
+            *command_resources_->GetPool());
         buffer_resources_ = std::make_unique<BufferResourceManager>(
             *vk_unique_device_,
             *gpu_memory_manager_,
@@ -2218,16 +2015,12 @@ void Device::UpdateRaytraceBuffers()
     bool updated_aggregate_scene = false;
     if (HasRaytracingSourceMeshes(*level_))
     {
-        if (HasRaytracingSourceMeshes(*level_))
+        updated_aggregate_scene = UpdateAggregateRaytracingSceneBuffers(
+            !use_hardware_raytracing_);
+        if (use_hardware_raytracing_ && updated_aggregate_scene)
         {
-            updated_aggregate_scene =
-                UpdateAggregateRaytracingSceneBuffers(false);
             UpdateHardwareRaytracingScene();
         }
-    }
-    else if (RaytraceSceneRequiresWorldSpaceBuffers(*level_))
-    {
-        updated_aggregate_scene = UpdateAggregateRaytracingSceneBuffers(true);
     }
     if (updated_buffer_count > 0 || updated_aggregate_scene)
     {
@@ -2571,106 +2364,25 @@ void Device::UpdateHardwareRaytracingDescriptor()
         return;
     }
 
-void Device::UpdateHardwareRaytracingDescriptor(
-    std::optional<std::size_t> frame_index)
-{
-    if (!vk_unique_device_ || !use_hardware_raytracing_ ||
-        !active_hardware_raytracing_scene_index_ || !active_program_info_)
-    {
-        return;
-    }
-
-    const auto scene_index = *active_hardware_raytracing_scene_index_;
-    if (scene_index >= hardware_raytracing_scene_slots_.size())
-    {
-        return;
-    }
-    const auto& scene = hardware_raytracing_scene_slots_[scene_index];
-    if (!scene.tlas || !scene.shader_instance_buffer)
-    {
-        return;
-    }
-
-    const bool has_instance_binding = std::any_of(
-        active_program_info_->bindings.begin(),
-        active_program_info_->bindings.end(),
-        [](const ProgramPipelineInfo::BindingInfo& binding) {
-            return binding.binding_type ==
-                       frame::proto::ProgramBinding::STORAGE_BUFFER &&
-                   binding.binding == kHardwareRaytracingInstanceBinding;
-        });
-    const bool has_as_binding = std::any_of(
-        active_program_info_->bindings.begin(),
-        active_program_info_->bindings.end(),
-        [](const ProgramPipelineInfo::BindingInfo& binding) {
-            return binding.binding == kHardwareRaytracingAsBinding;
-        });
-
-    auto update_descriptor_for_frame = [&](std::size_t frame) {
-        const vk::DescriptorSet descriptor_set = GetDescriptorSet(frame);
-        if (!descriptor_set)
-        {
-            return;
-        }
-
-        std::vector<vk::WriteDescriptorSet> descriptor_writes = {};
-        std::vector<vk::DescriptorBufferInfo> buffer_infos = {};
-        std::vector<vk::WriteDescriptorSetAccelerationStructureKHR>
-            acceleration_writes = {};
-        std::vector<vk::AccelerationStructureKHR> acceleration_handles = {};
-
-        if (has_instance_binding)
-        {
-            buffer_infos.emplace_back(
-                *scene.shader_instance_buffer,
-                0,
-                scene.shader_instance_buffer_size);
-            descriptor_writes.emplace_back(
-                descriptor_set,
-                kHardwareRaytracingInstanceBinding,
-                0,
-                1,
-                vk::DescriptorType::eStorageBuffer,
-                nullptr,
-                &buffer_infos.back());
-        }
-
-        if (has_as_binding)
-        {
-            acceleration_handles.push_back(scene.tlas.get());
-            acceleration_writes.emplace_back(
-                static_cast<std::uint32_t>(acceleration_handles.size()),
-                acceleration_handles.data());
-            descriptor_writes.emplace_back(
-                descriptor_set,
-                kHardwareRaytracingAsBinding,
-                0,
-                1,
-                vk::DescriptorType::eAccelerationStructureKHR);
-            descriptor_writes.back().setPNext(&acceleration_writes.back());
-        }
-
-        if (!descriptor_writes.empty())
-        {
-            vk_unique_device_->updateDescriptorSets(
-                static_cast<std::uint32_t>(descriptor_writes.size()),
-                descriptor_writes.data(),
-                0,
-                nullptr);
-        }
-        descriptor_scene_indices_[frame] = scene_index;
-    };
-
-    if (frame_index)
-    {
-        update_descriptor_for_frame(*frame_index);
-        return;
-    }
-
-    for (std::size_t frame = 0; frame < descriptor_sets_.size(); ++frame)
-    {
-        update_descriptor_for_frame(frame);
-    }
+    std::array<vk::AccelerationStructureKHR, 1> acceleration_handles = {
+        hardware_raytracing_tlas_.get()};
+    vk::WriteDescriptorSetAccelerationStructureKHR acceleration_write(
+        static_cast<std::uint32_t>(acceleration_handles.size()),
+        acceleration_handles.data());
+    vk::WriteDescriptorSet descriptor_write(
+        descriptor_set_,
+        kHardwareRaytracingAsBinding,
+        0,
+        static_cast<std::uint32_t>(acceleration_handles.size()),
+        vk::DescriptorType::eAccelerationStructureKHR);
+    descriptor_write.setPNext(&acceleration_write);
+    const std::array<vk::WriteDescriptorSet, 1> descriptor_writes = {
+        descriptor_write};
+    vk_unique_device_->updateDescriptorSets(
+        static_cast<std::uint32_t>(descriptor_writes.size()),
+        descriptor_writes.data(),
+        0,
+        nullptr);
 }
 
 std::optional<vk::DescriptorImageInfo> Device::GetComputeOutputDescriptorInfo() const
@@ -2762,16 +2474,6 @@ void Device::Display(double dt)
         return;
     }
 
-    frame_in_flight_[current_frame_] = false;
-    frame_scene_indices_[current_frame_] = std::nullopt;
-    PollHardwareRaytracingSceneBuilds();
-    if (use_hardware_raytracing_ &&
-        descriptor_scene_indices_[current_frame_] !=
-            active_hardware_raytracing_scene_index_)
-    {
-        UpdateHardwareRaytracingDescriptor(current_frame_);
-    }
-
     const auto& swapchain = swapchain_resources_->GetSwapchain();
     auto acquire = vk_unique_device_->acquireNextImageKHR(
         *swapchain,
@@ -2852,10 +2554,6 @@ void Device::Display(double dt)
         }
         return;
     }
-
-    frame_in_flight_[current_frame_] = true;
-    frame_scene_indices_[current_frame_] =
-        descriptor_scene_indices_[current_frame_];
 
     vk::PresentInfoKHR present_info(
         1,
@@ -3085,38 +2783,13 @@ void Device::RecordCommandBuffer(
         {
             return;
         }
-        if (!buffer_resources_->GetUniformBuffer(current_frame_))
+        if (!buffer_resources_->GetUniformBuffer())
         {
             return;
         }
-        UniformBlock block = MakeUniformBlock(
+        auto block = MakeUniformBlock(
             state, elapsed_time_seconds_);
-        if (use_hardware_raytracing_ &&
-            descriptor_scene_indices_[current_frame_] &&
-            *descriptor_scene_indices_[current_frame_] <
-                hardware_raytracing_scene_slots_.size())
-        {
-            const auto& scene = hardware_raytracing_scene_slots_
-                [*descriptor_scene_indices_[current_frame_]];
-            if (scene.uses_shared_scene_transform && level_)
-            {
-                if (const auto shared_scene_model =
-                        GetSharedRaytraceSceneTransform(
-                            *level_,
-                            static_cast<double>(elapsed_time_seconds_));
-                    shared_scene_model)
-                {
-                    block.model = *shared_scene_model;
-                    block.model_inv = glm::inverse(*shared_scene_model);
-                }
-            }
-            else if (scene.has_uniform_block)
-            {
-                block = scene.uniform_block;
-            }
-        }
         buffer_resources_->UpdateUniform(
-            current_frame_,
             &block, sizeof(UniformBlock));
     };
     update_uniform_buffer(scene_state);
@@ -3149,10 +2822,8 @@ void Device::RecordCommandBuffer(
             barrier);
     };
 
-    const vk::DescriptorSet descriptor_set = GetDescriptorSet(current_frame_);
-
     if (use_compute_raytracing_ &&
-        descriptor_set &&
+        descriptor_set_ &&
         compute_output_image_ &&
         extent.width > 0 &&
         extent.height > 0)
@@ -3211,20 +2882,6 @@ void Device::RecordCommandBuffer(
             raytracing_pipeline_ &&
             raytracing_pipeline_layout_)
         {
-            if (use_hardware_raytracing_)
-            {
-                vk::MemoryBarrier acceleration_structure_barrier(
-                    vk::AccessFlagBits::eAccelerationStructureWriteKHR,
-                    vk::AccessFlagBits::eAccelerationStructureReadKHR |
-                        vk::AccessFlagBits::eShaderRead);
-                command_buffer.pipelineBarrier(
-                    vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR,
-                    vk::PipelineStageFlagBits::eRayTracingShaderKHR,
-                    {},
-                    acceleration_structure_barrier,
-                    nullptr,
-                    nullptr);
-            }
             command_buffer.bindPipeline(
                 vk::PipelineBindPoint::eRayTracingKHR,
                 *raytracing_pipeline_);
@@ -3232,7 +2889,7 @@ void Device::RecordCommandBuffer(
                 vk::PipelineBindPoint::eRayTracingKHR,
                 *raytracing_pipeline_layout_,
                 0,
-                descriptor_set,
+                descriptor_set_,
                 {});
             command_buffer.traceRaysKHR(
                 raygen_sbt_region_,
@@ -3252,7 +2909,7 @@ void Device::RecordCommandBuffer(
                 vk::PipelineBindPoint::eCompute,
                 *compute_pipeline_layout_,
                 0,
-                descriptor_set,
+                descriptor_set_,
                 {});
             const std::uint32_t group_x =
                 (extent.width + 7) / 8;
@@ -3301,13 +2958,13 @@ void Device::RecordCommandBuffer(
         vk::Rect2D scissor({0, 0}, extent);
         command_buffer.setScissor(0, 1, &scissor);
 
-        if (descriptor_set_layout_ && descriptor_set)
+        if (descriptor_set_layout_ && descriptor_set_)
         {
             command_buffer.bindDescriptorSets(
                 vk::PipelineBindPoint::eGraphics,
                 *pipeline_layout_,
                 0,
-                descriptor_set,
+                descriptor_set_,
                 {});
         }
 
@@ -4171,8 +3828,7 @@ void Device::DestroyTextureResources()
 
 void Device::DestroyDescriptorResources()
 {
-    descriptor_sets_.fill(VK_NULL_HANDLE);
-    descriptor_scene_indices_.fill(std::nullopt);
+    descriptor_set_ = VK_NULL_HANDLE;
     descriptor_pool_.reset();
     descriptor_set_layout_.reset();
     if (buffer_resources_)
@@ -4188,29 +3844,10 @@ void Device::CreateHardwareRaytracingScene()
     DestroyHardwareRaytracingScene();
 
     if (!use_hardware_raytracing_ || !vk_unique_device_ || !level_ ||
-        !gpu_memory_manager_ || !command_queue_ || !active_program_info_)
+        !gpu_memory_manager_ || !command_queue_)
     {
         return;
     }
-
-    const auto entries = CollectHardwareRaytraceSourceEntries(
-        *level_,
-        static_cast<double>(elapsed_time_seconds_));
-    const auto shared_scene_model =
-        RaytraceSceneRequiresWorldSpaceBuffers(*level_)
-            ? std::nullopt
-            : GetSharedRaytraceSceneTransform(
-                  *level_,
-                  static_cast<double>(elapsed_time_seconds_));
-    if (entries.empty())
-    {
-        use_hardware_raytracing_ = false;
-        logger_->warn(
-            "No eligible meshes found for Vulkan hardware raytracing; falling back to software traversal.");
-        return;
-    }
-
-    const auto instance_data = BuildHardwareRaytracingInstanceData(entries);
 
     const auto create_gpu_input_buffer =
         [&](const std::vector<std::uint8_t>& bytes,
@@ -4290,162 +3927,236 @@ void Device::CreateHardwareRaytracingScene()
                 vk::BufferDeviceAddressInfo(*scratch_buffer));
         };
 
-    hardware_raytracing_geometries_.clear();
-    hardware_raytracing_geometries_.reserve(entries.size());
-    for (const auto& entry : entries)
-    {
-        auto* triangle_buffer = dynamic_cast<frame::vulkan::Buffer*>(
-            &level_->GetBufferFromId(entry.source_buffer_id));
-        if (!triangle_buffer)
-        {
-            continue;
-        }
-        const auto& triangle_bytes = triangle_buffer->GetRawData();
-        const auto vertex_count = static_cast<std::uint32_t>(
-            triangle_bytes.size() / kRaytraceTriangleVertexStrideBytes);
-        const auto primitive_count = vertex_count / 3;
-        if (primitive_count == 0)
-        {
-            continue;
-        }
-        const auto index_bytes = BuildSequentialIndexBytes(vertex_count);
+    std::vector<vk::AccelerationStructureInstanceKHR> instances = {};
+    instances.reserve(2);
 
-        HardwareRaytracingGeometry geometry = {};
-        geometry.source_node_id = entry.source_node_id;
-        geometry.source_material_id = entry.source_material_id;
-        geometry.source_buffer_id = entry.source_buffer_id;
-        geometry.source_generation = entry.source_generation;
-        geometry.triangle_count = entry.triangle_count;
-        geometry.triangle_offset = entry.triangle_offset;
-        geometry.material_id = entry.material_id;
-        create_gpu_input_buffer(
-            triangle_bytes,
-            vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR,
-            geometry.vertex_buffer,
-            geometry.vertex_memory);
-        create_gpu_input_buffer(
-            index_bytes,
-            vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR,
-            geometry.index_buffer,
-            geometry.index_memory);
+    const auto append_geometry =
+        [&](const char* inner_name,
+            std::uint32_t instance_custom_index) {
+            if (!active_program_info_)
+            {
+                return;
+            }
+            const auto it =
+                active_program_info_->buffer_ids_by_inner.find(inner_name);
+            if (it == active_program_info_->buffer_ids_by_inner.end())
+            {
+                return;
+            }
+            auto* triangle_buffer = dynamic_cast<frame::vulkan::Buffer*>(
+                &level_->GetBufferFromId(it->second));
+            if (!triangle_buffer)
+            {
+                return;
+            }
+            const auto& triangle_bytes = triangle_buffer->GetRawData();
+            const auto vertex_count = static_cast<std::uint32_t>(
+                triangle_bytes.size() / kRaytraceTriangleVertexStrideBytes);
+            const auto primitive_count = vertex_count / 3;
+            if (primitive_count == 0)
+            {
+                return;
+            }
+            const auto index_bytes = BuildSequentialIndexBytes(vertex_count);
 
-        const auto vertex_address = vk_unique_device_->getBufferAddress(
-            vk::BufferDeviceAddressInfo(*geometry.vertex_buffer));
-        const auto index_address = vk_unique_device_->getBufferAddress(
-            vk::BufferDeviceAddressInfo(*geometry.index_buffer));
-        geometry.vertex_buffer_size =
-            static_cast<vk::DeviceSize>(triangle_bytes.size());
-        geometry.vertex_count = vertex_count;
-        geometry.index_buffer_size =
-            static_cast<vk::DeviceSize>(index_bytes.size());
+            HardwareRaytracingGeometry geometry = {};
+            geometry.source_inner_name = inner_name;
+            geometry.source_buffer_id = it->second;
+            create_gpu_input_buffer(
+                triangle_bytes,
+                vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR,
+                geometry.vertex_buffer,
+                geometry.vertex_memory);
+            create_gpu_input_buffer(
+                index_bytes,
+                vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR,
+                geometry.index_buffer,
+                geometry.index_memory);
 
-        vk::AccelerationStructureGeometryTrianglesDataKHR triangles(
-            vk::Format::eR32G32B32Sfloat,
-            vk::DeviceOrHostAddressConstKHR(vertex_address),
-            kRaytraceTriangleVertexStrideBytes,
-            vertex_count,
-            vk::IndexType::eUint32,
-            vk::DeviceOrHostAddressConstKHR(index_address));
-        vk::AccelerationStructureGeometryDataKHR geometry_data;
-        geometry_data.setTriangles(triangles);
-        vk::AccelerationStructureGeometryKHR as_geometry(
-            vk::GeometryTypeKHR::eTriangles);
-        as_geometry.setGeometry(geometry_data);
-        as_geometry.setFlags(vk::GeometryFlagBitsKHR::eOpaque);
+            const auto vertex_address = vk_unique_device_->getBufferAddress(
+                vk::BufferDeviceAddressInfo(*geometry.vertex_buffer));
+            const auto index_address = vk_unique_device_->getBufferAddress(
+                vk::BufferDeviceAddressInfo(*geometry.index_buffer));
+            geometry.vertex_buffer_size =
+                static_cast<vk::DeviceSize>(triangle_bytes.size());
+            geometry.vertex_count = vertex_count;
+            geometry.index_buffer_size =
+                static_cast<vk::DeviceSize>(index_bytes.size());
+            geometry.triangle_count = primitive_count;
+            geometry.instance_custom_index = instance_custom_index;
 
-        vk::AccelerationStructureBuildGeometryInfoKHR build_info(
-            vk::AccelerationStructureTypeKHR::eBottomLevel,
-            vk::BuildAccelerationStructureFlagBitsKHR::ePreferFastTrace,
-            vk::BuildAccelerationStructureModeKHR::eBuild,
-            {},
-            {},
-            as_geometry);
+            vk::AccelerationStructureGeometryTrianglesDataKHR triangles(
+                vk::Format::eR32G32B32Sfloat,
+                vk::DeviceOrHostAddressConstKHR(vertex_address),
+                kRaytraceTriangleVertexStrideBytes,
+                vertex_count,
+                vk::IndexType::eUint32,
+                vk::DeviceOrHostAddressConstKHR(index_address));
+            vk::AccelerationStructureGeometryDataKHR geometry_data;
+            geometry_data.setTriangles(triangles);
+            vk::AccelerationStructureGeometryKHR as_geometry(
+                vk::GeometryTypeKHR::eTriangles);
+            as_geometry.setGeometry(geometry_data);
+            as_geometry.setFlags(vk::GeometryFlagBitsKHR::eOpaque);
 
-        const auto size_info =
-            vk_unique_device_->getAccelerationStructureBuildSizesKHR(
-                vk::AccelerationStructureBuildTypeKHR::eDevice,
-                build_info,
-                primitive_count);
+            vk::AccelerationStructureBuildGeometryInfoKHR build_info(
+                vk::AccelerationStructureTypeKHR::eBottomLevel,
+                vk::BuildAccelerationStructureFlagBitsKHR::ePreferFastTrace,
+                vk::BuildAccelerationStructureModeKHR::eBuild,
+                {},
+                {},
+                as_geometry);
 
-        create_acceleration_structure(
-            vk::AccelerationStructureTypeKHR::eBottomLevel,
-            size_info.accelerationStructureSize,
-            geometry.blas,
-            geometry.blas_buffer,
-            geometry.blas_memory);
-
-        vk::UniqueBuffer scratch_buffer;
-        vk::UniqueDeviceMemory scratch_memory;
-        const auto scratch_address = build_scratch_buffer(
-            size_info.buildScratchSize,
-            scratch_buffer,
-            scratch_memory);
-
-        build_info.setDstAccelerationStructure(*geometry.blas);
-        build_info.setScratchData(
-            vk::DeviceOrHostAddressKHR(scratch_address));
-        vk::AccelerationStructureBuildRangeInfoKHR range_info(
-            primitive_count,
-            0,
-            0,
-            0);
-        const vk::AccelerationStructureBuildRangeInfoKHR* range_infos[] = {
-            &range_info};
-        command_queue_->SubmitOneTime(
-            [&](vk::CommandBuffer command_buffer) {
-                command_buffer.buildAccelerationStructuresKHR(
+            const auto size_info =
+                vk_unique_device_->getAccelerationStructureBuildSizesKHR(
+                    vk::AccelerationStructureBuildTypeKHR::eDevice,
                     build_info,
-                    range_infos);
-            });
+                    primitive_count);
 
-        geometry.blas_address =
-            vk_unique_device_->getAccelerationStructureAddressKHR(
-                vk::AccelerationStructureDeviceAddressInfoKHR(*geometry.blas));
-        hardware_raytracing_geometries_.push_back(std::move(geometry));
-    }
+            create_acceleration_structure(
+                vk::AccelerationStructureTypeKHR::eBottomLevel,
+                size_info.accelerationStructureSize,
+                geometry.blas,
+                geometry.blas_buffer,
+                geometry.blas_memory);
 
-    if (hardware_raytracing_geometries_.empty())
+            vk::UniqueBuffer scratch_buffer;
+            vk::UniqueDeviceMemory scratch_memory;
+            const auto scratch_address = build_scratch_buffer(
+                size_info.buildScratchSize,
+                scratch_buffer,
+                scratch_memory);
+
+            build_info.setDstAccelerationStructure(*geometry.blas);
+            build_info.setScratchData(
+                vk::DeviceOrHostAddressKHR(scratch_address));
+            vk::AccelerationStructureBuildRangeInfoKHR range_info(
+                primitive_count,
+                0,
+                0,
+                0);
+            const vk::AccelerationStructureBuildRangeInfoKHR* range_infos[] = {
+                &range_info};
+            command_queue_->SubmitOneTime(
+                [&](vk::CommandBuffer command_buffer) {
+                    command_buffer.buildAccelerationStructuresKHR(
+                        build_info,
+                        range_infos);
+                });
+
+            geometry.blas_address =
+                vk_unique_device_->getAccelerationStructureAddressKHR(
+                    vk::AccelerationStructureDeviceAddressInfoKHR(
+                        *geometry.blas));
+
+            vk::AccelerationStructureInstanceKHR instance{};
+            instance.transform = MakeIdentityTransform();
+            instance.instanceCustomIndex = geometry.instance_custom_index;
+            instance.mask = 0xFF;
+            instance.instanceShaderBindingTableRecordOffset = 0;
+            instance.flags = static_cast<VkGeometryInstanceFlagsKHR>(
+                vk::GeometryInstanceFlagBitsKHR::eTriangleFacingCullDisable);
+            instance.accelerationStructureReference = geometry.blas_address;
+            instances.push_back(instance);
+            hardware_raytracing_geometries_.push_back(std::move(geometry));
+        };
+
+    append_geometry("TriangleBufferTransmissive", 0u);
+    append_geometry("TriangleBufferOpaque", 1u);
+
+    if (instances.empty())
     {
         use_hardware_raytracing_ = false;
         logger_->warn(
             "No eligible meshes found for Vulkan hardware raytracing; falling back to software traversal.");
         return;
     }
-    if (hardware_raytracing_geometries_.size() != entries.size())
-    {
-        throw std::runtime_error(
-            "Vulkan hardware raytracing scene failed to build a BLAS for every source mesh.");
-    }
 
-    active_hardware_raytracing_scene_index_ = 0u;
-    pending_hardware_raytracing_scene_index_.reset();
-    BuildHardwareRaytracingSceneSlot(
-        0u,
-        BuildHardwareRaytracingInstanceData(entries, shared_scene_model),
-        BuildHardwareRaytracingAsInstances(entries, shared_scene_model),
-        BuildCurrentRaytracingUniformBlock(),
-        BuildRaytracingSourceStateHash(
-            *level_,
-            static_cast<double>(elapsed_time_seconds_),
-            !shared_scene_model.has_value()),
-        !shared_scene_model.has_value(),
-        shared_scene_model.has_value(),
-        false);
+    const vk::DeviceSize instance_bytes =
+        static_cast<vk::DeviceSize>(
+            instances.size() * sizeof(vk::AccelerationStructureInstanceKHR));
+    hardware_raytracing_instance_buffer_ = gpu_memory_manager_->CreateBuffer(
+        instance_bytes,
+        vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR |
+            vk::BufferUsageFlagBits::eShaderDeviceAddress,
+        vk::MemoryPropertyFlagBits::eHostVisible |
+            vk::MemoryPropertyFlagBits::eHostCoherent,
+        hardware_raytracing_instance_memory_,
+        vk::MemoryAllocateFlagBits::eDeviceAddress);
+    void* mapped_instances = vk_unique_device_->mapMemory(
+        *hardware_raytracing_instance_memory_,
+        0,
+        instance_bytes);
+    std::memcpy(mapped_instances, instances.data(), static_cast<std::size_t>(instance_bytes));
+    vk_unique_device_->unmapMemory(*hardware_raytracing_instance_memory_);
+
+    const auto instance_address = vk_unique_device_->getBufferAddress(
+        vk::BufferDeviceAddressInfo(*hardware_raytracing_instance_buffer_));
+    vk::AccelerationStructureGeometryInstancesDataKHR instances_data(
+        VK_FALSE,
+        vk::DeviceOrHostAddressConstKHR(instance_address));
+    vk::AccelerationStructureGeometryDataKHR tlas_geometry_data;
+    tlas_geometry_data.setInstances(instances_data);
+    vk::AccelerationStructureGeometryKHR tlas_geometry(
+        vk::GeometryTypeKHR::eInstances);
+    tlas_geometry.setGeometry(tlas_geometry_data);
+
+    vk::AccelerationStructureBuildGeometryInfoKHR tlas_build_info(
+        vk::AccelerationStructureTypeKHR::eTopLevel,
+        vk::BuildAccelerationStructureFlagBitsKHR::ePreferFastTrace,
+        vk::BuildAccelerationStructureModeKHR::eBuild,
+        {},
+        {},
+        tlas_geometry);
+    const std::uint32_t instance_count =
+        static_cast<std::uint32_t>(instances.size());
+    const auto tlas_size = vk_unique_device_->getAccelerationStructureBuildSizesKHR(
+        vk::AccelerationStructureBuildTypeKHR::eDevice,
+        tlas_build_info,
+        instance_count);
+    create_acceleration_structure(
+        vk::AccelerationStructureTypeKHR::eTopLevel,
+        tlas_size.accelerationStructureSize,
+        hardware_raytracing_tlas_,
+        hardware_raytracing_tlas_buffer_,
+        hardware_raytracing_tlas_memory_);
+
+    vk::UniqueBuffer tlas_scratch_buffer;
+    vk::UniqueDeviceMemory tlas_scratch_memory;
+    const auto tlas_scratch_address = build_scratch_buffer(
+        tlas_size.buildScratchSize,
+        tlas_scratch_buffer,
+        tlas_scratch_memory);
+    tlas_build_info.setDstAccelerationStructure(*hardware_raytracing_tlas_);
+    tlas_build_info.setScratchData(
+        vk::DeviceOrHostAddressKHR(tlas_scratch_address));
+    vk::AccelerationStructureBuildRangeInfoKHR tlas_range_info(
+        instance_count,
+        0,
+        0,
+        0);
+    const vk::AccelerationStructureBuildRangeInfoKHR* tlas_ranges[] = {
+        &tlas_range_info};
+    command_queue_->SubmitOneTime(
+        [&](vk::CommandBuffer command_buffer) {
+            command_buffer.buildAccelerationStructuresKHR(
+                tlas_build_info,
+                tlas_ranges);
+        });
 
     logger_->info(
         "Built Vulkan hardware raytracing scene with {} instance(s).",
-        entries.size());
+        instances.size());
     UpdateHardwareRaytracingDescriptor();
 }
 
 void Device::DestroyHardwareRaytracingScene()
 {
-    pending_hardware_raytracing_scene_index_.reset();
-    active_hardware_raytracing_scene_index_.reset();
-    for (auto& scene : hardware_raytracing_scene_slots_)
-    {
-        DestroyHardwareRaytracingSceneSlot(scene);
-    }
+    hardware_raytracing_tlas_.reset();
+    hardware_raytracing_tlas_buffer_.reset();
+    hardware_raytracing_tlas_memory_.reset();
+    hardware_raytracing_instance_buffer_.reset();
+    hardware_raytracing_instance_memory_.reset();
     hardware_raytracing_geometries_.clear();
 }
 
@@ -4684,8 +4395,7 @@ void Device::CreateTextureResources(
 
 void Device::CreateDescriptorResources()
 {
-    descriptor_sets_.fill(VK_NULL_HANDLE);
-    descriptor_scene_indices_.fill(std::nullopt);
+    descriptor_set_ = VK_NULL_HANDLE;
     descriptor_pool_.reset();
     descriptor_set_layout_.reset();
     storage_buffers_ready_ = false;
@@ -4829,8 +4539,7 @@ void Device::CreateDescriptorResources()
 
     if (use_hardware_raytracing_)
     {
-        if (!active_hardware_raytracing_scene_index_ ||
-            !hardware_raytracing_scene_slots_[*active_hardware_raytracing_scene_index_].tlas)
+        if (!hardware_raytracing_tlas_)
         {
             logger_->error(
                 "Program {} requested Vulkan hardware raytracing without a TLAS.",
@@ -4907,25 +4616,15 @@ void Device::CreateDescriptorResources()
     }
 
 
-    std::array<const BufferResource*, kMaxFramesInFlight> uniforms = {};
+    const BufferResource* uniform = nullptr;
     if (!uniform_bindings.empty())
     {
-        buffer_resources_->BuildUniformBuffers(
-            kMaxFramesInFlight,
+        buffer_resources_->BuildUniformBuffer(
             static_cast<vk::DeviceSize>(sizeof(UniformBlock)));
-        bool have_uniforms = true;
-        for (std::size_t frame = 0; frame < uniforms.size(); ++frame)
+        uniform = buffer_resources_->GetUniformBuffer();
+        if (!uniform)
         {
-            uniforms[frame] = buffer_resources_->GetUniformBuffer(frame);
-            if (!uniforms[frame])
-            {
-                have_uniforms = false;
-                break;
-            }
-        }
-        if (!have_uniforms)
-        {
-            logger_->error("Failed to allocate Vulkan uniform buffers.");
+            logger_->error("Failed to allocate Vulkan uniform buffer.");
             return;
         }
     }
@@ -4996,34 +4695,31 @@ void Device::CreateDescriptorResources()
     {
         pool_sizes.emplace_back(
             vk::DescriptorType::eCombinedImageSampler,
-            combined_count * static_cast<std::uint32_t>(kMaxFramesInFlight));
+            combined_count);
     }
     if (!output_image_bindings.empty())
     {
         pool_sizes.emplace_back(
             vk::DescriptorType::eStorageImage,
-            static_cast<std::uint32_t>(
-                output_image_bindings.size() * kMaxFramesInFlight));
+            static_cast<std::uint32_t>(output_image_bindings.size()));
     }
     if (!storage_bindings.empty())
     {
         pool_sizes.emplace_back(
             vk::DescriptorType::eStorageBuffer,
-            static_cast<std::uint32_t>(
-                storage_bindings.size() * kMaxFramesInFlight));
+            static_cast<std::uint32_t>(storage_bindings.size()));
     }
     if (!uniform_bindings.empty())
     {
         pool_sizes.emplace_back(
             vk::DescriptorType::eUniformBuffer,
-            static_cast<std::uint32_t>(
-                uniform_bindings.size() * kMaxFramesInFlight));
+            static_cast<std::uint32_t>(uniform_bindings.size()));
     }
     if (needs_acceleration_structure)
     {
         pool_sizes.emplace_back(
             vk::DescriptorType::eAccelerationStructureKHR,
-            static_cast<std::uint32_t>(kMaxFramesInFlight));
+            1);
     }
     if (pool_sizes.empty())
     {
@@ -5032,155 +4728,128 @@ void Device::CreateDescriptorResources()
 
     vk::DescriptorPoolCreateInfo pool_info(
         vk::DescriptorPoolCreateFlags{},
-        static_cast<std::uint32_t>(kMaxFramesInFlight),
+        1,
         static_cast<std::uint32_t>(pool_sizes.size()),
         pool_sizes.data());
     descriptor_pool_ = vk_unique_device_->createDescriptorPoolUnique(pool_info);
 
-    std::array<vk::DescriptorSetLayout, kMaxFramesInFlight> layouts = {};
-    layouts.fill(*descriptor_set_layout_);
+    const vk::DescriptorSetLayout layouts[] = {*descriptor_set_layout_};
     vk::DescriptorSetAllocateInfo alloc_info(
         *descriptor_pool_,
-        static_cast<std::uint32_t>(layouts.size()),
-        layouts.data());
-    const auto allocated_descriptor_sets =
-        vk_unique_device_->allocateDescriptorSets(alloc_info);
-    for (std::size_t i = 0; i < descriptor_sets_.size(); ++i)
+        1,
+        layouts);
+    descriptor_set_ =
+        vk_unique_device_->allocateDescriptorSets(alloc_info).front();
+
+    std::vector<vk::DescriptorImageInfo> output_image_infos;
+    std::vector<vk::DescriptorImageInfo> output_sampler_infos;
+    std::vector<vk::DescriptorBufferInfo> storage_infos;
+    std::vector<vk::DescriptorBufferInfo> uniform_infos;
+    std::vector<vk::WriteDescriptorSet> descriptor_writes;
+    std::vector<vk::WriteDescriptorSetAccelerationStructureKHR>
+        acceleration_writes;
+    std::vector<vk::AccelerationStructureKHR> acceleration_handles;
+    descriptor_writes.reserve(layout_bindings.size());
+    output_image_infos.reserve(output_image_bindings.size());
+    output_sampler_infos.reserve(output_sampler_bindings.size());
+    storage_infos.reserve(storage_buffers.size());
+    uniform_infos.reserve(uniform_bindings.size());
+    acceleration_writes.reserve(needs_acceleration_structure ? 1u : 0u);
+    acceleration_handles.reserve(needs_acceleration_structure ? 1u : 0u);
+
+    for (auto binding : output_image_bindings)
     {
-        descriptor_sets_[i] = allocated_descriptor_sets[i];
-    }
-
-    const auto active_scene_index =
-        use_hardware_raytracing_ ? active_hardware_raytracing_scene_index_
-                                 : std::nullopt;
-
-    for (std::size_t frame = 0; frame < descriptor_sets_.size(); ++frame)
-    {
-        std::vector<vk::DescriptorImageInfo> output_image_infos;
-        std::vector<vk::DescriptorImageInfo> output_sampler_infos;
-        std::vector<vk::DescriptorBufferInfo> storage_infos;
-        std::vector<vk::DescriptorBufferInfo> uniform_infos;
-        std::vector<vk::WriteDescriptorSet> descriptor_writes;
-        std::vector<vk::WriteDescriptorSetAccelerationStructureKHR>
-            acceleration_writes;
-        std::vector<vk::AccelerationStructureKHR> acceleration_handles;
-        descriptor_writes.reserve(layout_bindings.size());
-        output_image_infos.reserve(output_image_bindings.size());
-        output_sampler_infos.reserve(output_sampler_bindings.size());
-        storage_infos.reserve(storage_buffers.size());
-        uniform_infos.reserve(uniform_bindings.size());
-        acceleration_writes.reserve(needs_acceleration_structure ? 1u : 0u);
-        acceleration_handles.reserve(needs_acceleration_structure ? 1u : 0u);
-
-        const vk::DescriptorSet descriptor_set = descriptor_sets_[frame];
-        for (auto binding : output_image_bindings)
-        {
-            output_image_infos.emplace_back(
-                nullptr,
-                *compute_output_view_,
-                vk::ImageLayout::eGeneral);
-            descriptor_writes.emplace_back(
-                descriptor_set,
-                binding,
-                0,
-                1,
-                vk::DescriptorType::eStorageImage,
-                &output_image_infos.back());
-        }
-
-        for (auto binding : output_sampler_bindings)
-        {
-            output_sampler_infos.emplace_back(
-                *compute_output_sampler_,
-                *compute_output_view_,
-                vk::ImageLayout::eShaderReadOnlyOptimal);
-            descriptor_writes.emplace_back(
-                descriptor_set,
-                binding,
-                0,
-                1,
-                vk::DescriptorType::eCombinedImageSampler,
-                &output_sampler_infos.back());
-        }
-
-        for (std::size_t i = 0; i < texture_infos.size(); ++i)
-        {
-            descriptor_writes.emplace_back(
-                descriptor_set,
-                texture_bindings[i],
-                0,
-                1,
-                vk::DescriptorType::eCombinedImageSampler,
-                &texture_infos[i]);
-        }
-
-        for (std::size_t i = 0; i < storage_buffers.size(); ++i)
-        {
-            vk::Buffer buffer = *storage_buffers[i].buffer;
-            vk::DeviceSize size = storage_buffers[i].size;
-            if (use_hardware_raytracing_ &&
-                active_scene_index &&
-                storage_bindings[i] == kHardwareRaytracingInstanceBinding)
-            {
-                const auto& scene =
-                    hardware_raytracing_scene_slots_[*active_scene_index];
-                buffer = *scene.shader_instance_buffer;
-                size = scene.shader_instance_buffer_size;
-            }
-            storage_infos.emplace_back(
-                buffer,
-                0,
-                size);
-            descriptor_writes.emplace_back(
-                descriptor_set,
-                storage_bindings[i],
-                0,
-                1,
-                vk::DescriptorType::eStorageBuffer,
-                nullptr,
-                &storage_infos.back());
-        }
-
-        if (uniforms[frame] && !uniform_bindings.empty())
-        {
-            uniform_infos.emplace_back(
-                *uniforms[frame]->buffer,
-                0,
-                uniforms[frame]->size);
-            descriptor_writes.emplace_back(
-                descriptor_set,
-                uniform_bindings.front(),
-                0,
-                1,
-                vk::DescriptorType::eUniformBuffer,
-                nullptr,
-                &uniform_infos.back());
-        }
-
-        if (needs_acceleration_structure && active_scene_index)
-        {
-            const auto& scene =
-                hardware_raytracing_scene_slots_[*active_scene_index];
-            acceleration_handles.push_back(scene.tlas.get());
-            acceleration_writes.emplace_back(
-                1,
-                acceleration_handles.data());
-            descriptor_writes.emplace_back(
-                descriptor_set,
-                kHardwareRaytracingAsBinding,
-                0,
-                1,
-                vk::DescriptorType::eAccelerationStructureKHR);
-            descriptor_writes.back().setPNext(&acceleration_writes.back());
-        }
-
-        vk_unique_device_->updateDescriptorSets(
-            static_cast<std::uint32_t>(descriptor_writes.size()),
-            descriptor_writes.data(),
+        output_image_infos.emplace_back(
+            nullptr,
+            *compute_output_view_,
+            vk::ImageLayout::eGeneral);
+        descriptor_writes.emplace_back(
+            descriptor_set_,
+            binding,
             0,
-            nullptr);
-        descriptor_scene_indices_[frame] = active_scene_index;
+            1,
+            vk::DescriptorType::eStorageImage,
+            &output_image_infos.back());
     }
+
+    for (auto binding : output_sampler_bindings)
+    {
+        output_sampler_infos.emplace_back(
+            *compute_output_sampler_,
+            *compute_output_view_,
+            vk::ImageLayout::eShaderReadOnlyOptimal);
+        descriptor_writes.emplace_back(
+            descriptor_set_,
+            binding,
+            0,
+            1,
+            vk::DescriptorType::eCombinedImageSampler,
+            &output_sampler_infos.back());
+    }
+
+    for (std::size_t i = 0; i < texture_infos.size(); ++i)
+    {
+        descriptor_writes.emplace_back(
+            descriptor_set_,
+            texture_bindings[i],
+            0,
+            1,
+            vk::DescriptorType::eCombinedImageSampler,
+            &texture_infos[i]);
+    }
+
+    for (std::size_t i = 0; i < storage_buffers.size(); ++i)
+    {
+        storage_infos.emplace_back(
+            *storage_buffers[i].buffer,
+            0,
+            storage_buffers[i].size);
+        descriptor_writes.emplace_back(
+            descriptor_set_,
+            storage_bindings[i],
+            0,
+            1,
+            vk::DescriptorType::eStorageBuffer,
+            nullptr,
+            &storage_infos.back());
+    }
+
+    if (uniform && !uniform_bindings.empty())
+    {
+        uniform_infos.emplace_back(
+            *uniform->buffer,
+            0,
+            uniform->size);
+        descriptor_writes.emplace_back(
+            descriptor_set_,
+            uniform_bindings.front(),
+            0,
+            1,
+            vk::DescriptorType::eUniformBuffer,
+            nullptr,
+            &uniform_infos.back());
+    }
+
+    if (needs_acceleration_structure)
+    {
+        acceleration_handles.push_back(hardware_raytracing_tlas_.get());
+        acceleration_writes.emplace_back(
+            1,
+            acceleration_handles.data());
+        descriptor_writes.emplace_back(
+            descriptor_set_,
+            kHardwareRaytracingAsBinding,
+            0,
+            1,
+            vk::DescriptorType::eAccelerationStructureKHR);
+        descriptor_writes.back().setPNext(&acceleration_writes.back());
+    }
+
+    vk_unique_device_->updateDescriptorSets(
+        static_cast<std::uint32_t>(descriptor_writes.size()),
+        descriptor_writes.data(),
+        0,
+        nullptr);
 }
 
 

--- a/frame/vulkan/device.cpp
+++ b/frame/vulkan/device.cpp
@@ -382,13 +382,20 @@ void HashByteSamples(
         return;
     }
 
-    constexpr std::array<float, 8> kRatios = {
-        0.0f, 0.11f, 0.23f, 0.37f, 0.53f, 0.67f, 0.83f, 1.0f};
+    constexpr std::array<std::pair<std::size_t, std::size_t>, 8> kRatios = {{
+        {0u, 1u},
+        {11u, 100u},
+        {23u, 100u},
+        {37u, 100u},
+        {53u, 100u},
+        {67u, 100u},
+        {83u, 100u},
+        {1u, 1u},
+    }};
     const std::size_t max_index = bytes.size() - 1;
-    for (const float ratio : kRatios)
+    for (const auto& [numerator, denominator] : kRatios)
     {
-        const auto index = static_cast<std::size_t>(
-            ratio * static_cast<float>(max_index));
+        const auto index = (max_index * numerator) / denominator;
         HashCombine(seed, bytes[index]);
     }
 }

--- a/frame/vulkan/device.cpp
+++ b/frame/vulkan/device.cpp
@@ -481,6 +481,11 @@ bool RaytraceSceneRequiresWorldSpaceBuffers(frame::LevelInterface& level)
     return false;
 }
 
+bool HasRaytracingSourceMeshes(frame::LevelInterface& level)
+{
+    return !GetRaytracingSourceMeshMaterials(level).empty();
+}
+
 constexpr std::size_t kRaytraceFloatsPerVertex = 12;
 constexpr std::size_t kRaytraceTriangleVertexStrideBytes =
     sizeof(float) * kRaytraceFloatsPerVertex;
@@ -1950,7 +1955,7 @@ void Device::UpdateRaytraceBuffers()
         }
     }
     bool updated_aggregate_scene = false;
-    if (RaytraceSceneRequiresWorldSpaceBuffers(*level_))
+    if (HasRaytracingSourceMeshes(*level_))
     {
         updated_aggregate_scene = UpdateAggregateRaytracingSceneBuffers(
             !use_hardware_raytracing_);
@@ -2670,7 +2675,7 @@ void Device::RecordCommandBuffer(
     const bool use_world_space_raytrace_scene =
         level_ &&
         (use_compute_raytracing_ || use_raytracing_pipeline_) &&
-        RaytraceSceneRequiresWorldSpaceBuffers(*level_);
+        HasRaytracingSourceMeshes(*level_);
     std::string preferred_scene_root;
     if (!use_world_space_raytrace_scene &&
         level_ &&

--- a/frame/vulkan/device.cpp
+++ b/frame/vulkan/device.cpp
@@ -642,6 +642,13 @@ vk::TransformMatrixKHR MakeIdentityTransform()
     return transform;
 }
 
+struct alignas(16) HardwareRaytraceInstanceStorageData
+{
+    glm::mat4 object_to_world = glm::mat4(1.0f);
+    glm::mat4 world_to_object = glm::mat4(1.0f);
+    glm::uvec4 metadata = glm::uvec4(0u);
+};
+
 bool AreTexturesCompatibleForReuse(
     const frame::vulkan::Texture& old_texture,
     const frame::vulkan::Texture& new_texture)
@@ -2138,6 +2145,81 @@ bool Device::UpdateAggregateRaytracingSceneBuffers(bool build_software_bvh)
     return updated;
 }
 
+bool Device::UpdateHardwareRaytracingInstanceStorageBuffer()
+{
+    if (!level_ || !active_program_info_)
+    {
+        return false;
+    }
+
+    const auto it =
+        active_program_info_->buffer_ids_by_inner.find("RaytraceInstanceBuffer");
+    if (it == active_program_info_->buffer_ids_by_inner.end())
+    {
+        return false;
+    }
+
+    auto* instance_buffer = dynamic_cast<frame::vulkan::Buffer*>(
+        &level_->GetBufferFromId(it->second));
+    if (!instance_buffer)
+    {
+        return false;
+    }
+
+    const bool use_shared_scene_transform =
+        CanUseSharedTransformHardwareRaytraceScene(
+            *level_,
+            static_cast<double>(elapsed_time_seconds_));
+    std::vector<HardwareRaytraceInstanceStorageData> instances = {};
+    instances.reserve(hardware_raytracing_geometries_.size());
+    for (const auto& geometry : hardware_raytracing_geometries_)
+    {
+        HardwareRaytraceInstanceStorageData instance = {};
+        instance.metadata.y = geometry.material_id;
+        instance.metadata.z = use_shared_scene_transform ? 1u : 0u;
+        instances.push_back(instance);
+    }
+
+    std::vector<std::uint8_t> bytes(
+        instances.size() * sizeof(HardwareRaytraceInstanceStorageData));
+    if (!bytes.empty())
+    {
+        std::memcpy(bytes.data(), instances.data(), bytes.size());
+    }
+
+    const auto previous_bytes = instance_buffer->GetRawData();
+    if (previous_bytes == bytes)
+    {
+        return true;
+    }
+
+    instance_buffer->Copy(bytes);
+
+    if (buffer_resources_ && !bytes.empty())
+    {
+        const auto buffer_name = level_->GetNameFromId(it->second);
+        if (previous_bytes.size() == bytes.size())
+        {
+            if (!buffer_resources_->UpdateStorageBuffer(buffer_name, bytes))
+            {
+                logger_->warn(
+                    "Failed to upload Vulkan raytrace instance buffer '{}'.",
+                    buffer_name);
+            }
+        }
+        else if (!previous_bytes.empty())
+        {
+            logger_->warn(
+                "Vulkan raytrace instance buffer '{}' changed size from {} to {}; GPU upload requires a resource rebuild.",
+                buffer_name,
+                previous_bytes.size(),
+                bytes.size());
+        }
+    }
+
+    return true;
+}
+
 void Device::UpdateHardwareRaytracingScene()
 {
     if (!use_hardware_raytracing_ || !vk_unique_device_ || !level_ ||
@@ -2287,6 +2369,8 @@ void Device::UpdateHardwareRaytracingScene()
                     range_infos);
             });
     }
+
+    UpdateHardwareRaytracingInstanceStorageBuffer();
 
     const std::uint32_t instance_count =
         static_cast<std::uint32_t>(hardware_raytracing_geometries_.size());
@@ -3930,9 +4014,10 @@ void Device::CreateHardwareRaytracingScene()
     std::vector<vk::AccelerationStructureInstanceKHR> instances = {};
     instances.reserve(2);
 
+    std::uint32_t next_instance_custom_index = 0;
     const auto append_geometry =
         [&](const char* inner_name,
-            std::uint32_t instance_custom_index) {
+            std::uint32_t material_id) {
             if (!active_program_info_)
             {
                 return;
@@ -3983,7 +4068,8 @@ void Device::CreateHardwareRaytracingScene()
             geometry.index_buffer_size =
                 static_cast<vk::DeviceSize>(index_bytes.size());
             geometry.triangle_count = primitive_count;
-            geometry.instance_custom_index = instance_custom_index;
+            geometry.instance_custom_index = next_instance_custom_index++;
+            geometry.material_id = material_id;
 
             vk::AccelerationStructureGeometryTrianglesDataKHR triangles(
                 vk::Format::eR32G32B32Sfloat,
@@ -4143,6 +4229,8 @@ void Device::CreateHardwareRaytracingScene()
                 tlas_build_info,
                 tlas_ranges);
         });
+
+    UpdateHardwareRaytracingInstanceStorageBuffer();
 
     logger_->info(
         "Built Vulkan hardware raytracing scene with {} instance(s).",

--- a/frame/vulkan/device.h
+++ b/frame/vulkan/device.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <array>
 #include <cstdint>
 #include <filesystem>
 #include <functional>
@@ -18,7 +17,6 @@
 #include "frame/logger.h"
 #include "frame/vulkan/buffer_resources.h"
 #include "frame/vulkan/mesh_resources.h"
-#include "frame/vulkan/scene_state.h"
 #include "frame/vulkan/vulkan_dispatch.h"
  
 namespace frame::vulkan
@@ -39,9 +37,6 @@ class Device : public DeviceInterface
 {
   public:
     using GuiRenderCallback = std::function<void(vk::CommandBuffer)>;
-    struct HardwareRaytracingGeometry;
-    struct HardwareRaytracingSceneSlot;
-    struct HardwareRaytracingInstanceData;
 
     Device(
         void* vk_instance,
@@ -166,32 +161,7 @@ class Device : public DeviceInterface
     void UpdateRaytraceBuffers();
     bool UpdateAggregateRaytracingSceneBuffers(bool build_software_bvh);
     void UpdateHardwareRaytracingScene();
-    void UpdateHardwareRaytracingDescriptor(
-        std::optional<std::size_t> frame_index = std::nullopt);
-    void WaitForAllInFlightFrames();
-    void PollHardwareRaytracingSceneBuilds();
-    bool IsHardwareRaytracingSceneSlotInUse(std::size_t slot_index) const;
-    std::optional<std::size_t> AcquireHardwareRaytracingSceneSlot() const;
-    void DestroyHardwareRaytracingSceneSlot(
-        struct HardwareRaytracingSceneSlot& scene);
-    void EnsureHardwareRaytracingSceneSlotResources(
-        struct HardwareRaytracingSceneSlot& scene,
-        std::uint32_t instance_count,
-        vk::DeviceSize shader_instance_bytes,
-        vk::DeviceSize build_instance_bytes,
-        vk::AccelerationStructureBuildGeometryInfoKHR build_info,
-        const vk::AccelerationStructureBuildSizesInfoKHR& size_info);
-    void BuildHardwareRaytracingSceneSlot(
-        std::size_t slot_index,
-        const std::vector<HardwareRaytracingInstanceData>& instance_data,
-        const std::vector<vk::AccelerationStructureInstanceKHR>& instances,
-        const UniformBlock& uniform_block,
-        std::size_t state_hash,
-        bool use_uniform_snapshot,
-        bool use_shared_scene_transform,
-        bool async_submit);
-    UniformBlock BuildCurrentRaytracingUniformBlock() const;
-    vk::DescriptorSet GetDescriptorSet(std::size_t frame_index) const;
+    void UpdateHardwareRaytracingDescriptor();
     void CopyBuffer(vk::Buffer src, vk::Buffer dst, vk::DeviceSize size);
     void TransitionImageLayout(
         vk::Image image,
@@ -242,19 +212,12 @@ class Device : public DeviceInterface
     std::unique_ptr<class CommandQueue> command_queue_;
     std::unique_ptr<class BufferResourceManager> buffer_resources_;
     std::unique_ptr<class MeshResources> mesh_resources_;
-    static constexpr std::size_t kMaxFramesInFlight = 2;
-    static constexpr std::size_t kHardwareRaytracingSceneSlotCount =
-        kMaxFramesInFlight + 1;
     vk::UniqueDescriptorSetLayout descriptor_set_layout_;
     vk::UniqueDescriptorPool descriptor_pool_;
-    std::array<vk::DescriptorSet, kMaxFramesInFlight> descriptor_sets_ = {};
+    vk::DescriptorSet descriptor_set_ = VK_NULL_HANDLE;
     std::unique_ptr<TextureResources> texture_resources_;
+    static constexpr std::size_t kMaxFramesInFlight = 2;
     std::size_t current_frame_ = 0;
-    std::array<bool, kMaxFramesInFlight> frame_in_flight_ = {};
-    std::array<std::optional<std::size_t>, kMaxFramesInFlight>
-        frame_scene_indices_ = {};
-    std::array<std::optional<std::size_t>, kMaxFramesInFlight>
-        descriptor_scene_indices_ = {};
     bool framebuffer_resized_ = false;
     bool use_compute_raytracing_ = false;
     bool use_raytracing_pipeline_ = false;
@@ -320,13 +283,10 @@ class Device : public DeviceInterface
         raytracing_pipeline_features_ = {};
     vk::PhysicalDeviceRayTracingPipelinePropertiesKHR
         raytracing_pipeline_properties_ = {};
-  public:
     struct HardwareRaytracingGeometry
     {
-        EntityId source_node_id = NullId;
-        EntityId source_material_id = NullId;
+        std::string source_inner_name;
         EntityId source_buffer_id = NullId;
-        std::uint64_t source_generation = 0;
         vk::UniqueBuffer vertex_buffer;
         vk::UniqueDeviceMemory vertex_memory;
         vk::DeviceSize vertex_buffer_size = 0;
@@ -339,44 +299,14 @@ class Device : public DeviceInterface
         vk::UniqueAccelerationStructureKHR blas;
         vk::DeviceAddress blas_address = 0;
         std::uint32_t triangle_count = 0;
-        std::uint32_t triangle_offset = 0;
-        std::uint32_t material_id = 0;
+        std::uint32_t instance_custom_index = 0;
     };
-    struct HardwareRaytracingSceneSlot
-    {
-        vk::UniqueBuffer shader_instance_buffer;
-        vk::UniqueDeviceMemory shader_instance_memory;
-        vk::DeviceSize shader_instance_buffer_size = 0;
-        vk::UniqueBuffer build_instance_buffer;
-        vk::UniqueDeviceMemory build_instance_memory;
-        vk::DeviceSize build_instance_buffer_size = 0;
-        vk::UniqueBuffer tlas_buffer;
-        vk::UniqueDeviceMemory tlas_memory;
-        vk::UniqueAccelerationStructureKHR tlas;
-        vk::DeviceSize tlas_size = 0;
-        std::uint32_t instance_count = 0;
-        std::size_t state_hash = 0;
-        bool ready = false;
-        vk::CommandBuffer pending_command_buffer = VK_NULL_HANDLE;
-        vk::UniqueFence pending_fence;
-        vk::UniqueBuffer pending_scratch_buffer;
-        vk::UniqueDeviceMemory pending_scratch_memory;
-        UniformBlock uniform_block = {};
-        bool has_uniform_block = false;
-        bool uses_shared_scene_transform = false;
-    };
-    struct HardwareRaytracingInstanceData
-    {
-        glm::mat4 object_to_world = glm::mat4(1.0f);
-        glm::mat4 world_to_object = glm::mat4(1.0f);
-        glm::uvec4 metadata = glm::uvec4(0u);
-    };
-  private:
     std::vector<HardwareRaytracingGeometry> hardware_raytracing_geometries_;
-    std::array<HardwareRaytracingSceneSlot, kHardwareRaytracingSceneSlotCount>
-        hardware_raytracing_scene_slots_ = {};
-    std::optional<std::size_t> active_hardware_raytracing_scene_index_;
-    std::optional<std::size_t> pending_hardware_raytracing_scene_index_;
+    vk::UniqueBuffer hardware_raytracing_instance_buffer_;
+    vk::UniqueDeviceMemory hardware_raytracing_instance_memory_;
+    vk::UniqueBuffer hardware_raytracing_tlas_buffer_;
+    vk::UniqueDeviceMemory hardware_raytracing_tlas_memory_;
+    vk::UniqueAccelerationStructureKHR hardware_raytracing_tlas_;
     vk::UniqueBuffer raytracing_sbt_buffer_;
     vk::UniqueDeviceMemory raytracing_sbt_memory_;
     vk::StridedDeviceAddressRegionKHR raygen_sbt_region_ = {};

--- a/frame/vulkan/device.h
+++ b/frame/vulkan/device.h
@@ -162,6 +162,7 @@ class Device : public DeviceInterface
     bool UpdateAggregateRaytracingSceneBuffers(bool build_software_bvh);
     void UpdateHardwareRaytracingScene();
     void UpdateHardwareRaytracingDescriptor();
+    bool UpdateHardwareRaytracingInstanceStorageBuffer();
     void CopyBuffer(vk::Buffer src, vk::Buffer dst, vk::DeviceSize size);
     void TransitionImageLayout(
         vk::Image image,
@@ -300,6 +301,7 @@ class Device : public DeviceInterface
         vk::DeviceAddress blas_address = 0;
         std::uint32_t triangle_count = 0;
         std::uint32_t instance_custom_index = 0;
+        std::uint32_t material_id = 0;
     };
     std::vector<HardwareRaytracingGeometry> hardware_raytracing_geometries_;
     vk::UniqueBuffer hardware_raytracing_instance_buffer_;

--- a/frame/vulkan/device.h
+++ b/frame/vulkan/device.h
@@ -148,6 +148,7 @@ class Device : public DeviceInterface
     void CreateSwapchainPreviewImage();
     void DestroySwapchainPreviewImage();
     void RecreateSwapchain();
+    void LogRuntimeConfiguration() const;
     vk::UniqueShaderModule CreateShaderModule(
         const std::vector<std::uint32_t>& code) const;
     void RecordCommandBuffer(

--- a/frame/vulkan/device.h
+++ b/frame/vulkan/device.h
@@ -270,7 +270,8 @@ class Device : public DeviceInterface
     std::optional<ProgramPipelineInfo> active_program_info_;
     bool use_procedural_quad_pipeline_ = false;
     float elapsed_time_seconds_ = 0.0f;
-    float last_raytrace_scene_buffer_update_time_ = -1.0f;
+    std::size_t last_raytrace_scene_state_hash_ = 0;
+    bool has_raytrace_scene_state_hash_ = false;
     vk::ShaderStageFlags push_constant_stages_ = {};
     std::uint32_t push_constant_size_ = 0;
     GuiRenderCallback gui_render_callback_;

--- a/frame/vulkan/sdl_vulkan_window.cpp
+++ b/frame/vulkan/sdl_vulkan_window.cpp
@@ -152,7 +152,8 @@ SDLVulkanWindow::SDLVulkanWindow(glm::uvec2 size) : size_(size)
     }
     VULKAN_HPP_DEFAULT_DISPATCHER.init(vk_get_instance_proc_addr);
 
-    const Uint32 window_flags = SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE;
+    const Uint32 window_flags =
+        SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIDDEN;
     sdl_window_ =
         SDL_CreateWindow(kDefaultTitle, size_.x, size_.y, window_flags);
     if (!sdl_window_)
@@ -309,6 +310,9 @@ WindowReturnEnum SDLVulkanWindow::Run(std::function<bool()> lambda)
             }
         }
     }
+
+    SDL_ShowWindow(sdl_window_);
+    SDL_RaiseWindow(sdl_window_);
 
     WindowReturnEnum window_return_enum = WindowReturnEnum::CONTINUE;
     auto start = std::chrono::steady_clock::now();
@@ -509,7 +513,8 @@ glm::vec2 SDLVulkanWindow::GetPixelPerInch(std::uint32_t screen) const
 
 bool SDLVulkanWindow::RunEvent(const SDL_Event& event, const double dt)
 {
-    if (event.type == SDL_EVENT_QUIT)
+    if (event.type == SDL_EVENT_QUIT ||
+        event.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED)
     {
         return false;
     }

--- a/frame/vulkan/swapchain_resources.cpp
+++ b/frame/vulkan/swapchain_resources.cpp
@@ -128,7 +128,7 @@ void SwapchainResources::Create(glm::uvec2 size)
     vk::SubpassDependency dependency(
         VK_SUBPASS_EXTERNAL,
         0,
-        vk::PipelineStageFlagBits::eColorAttachmentOutput,
+        vk::PipelineStageFlagBits::eTopOfPipe,
         vk::PipelineStageFlagBits::eColorAttachmentOutput,
         {},
         vk::AccessFlagBits::eColorAttachmentWrite);

--- a/frame/vulkan/swapchain_resources.h
+++ b/frame/vulkan/swapchain_resources.h
@@ -16,7 +16,7 @@ class SwapchainResources
   public:
     static constexpr vk::ImageLayout ScenePassInitialLayout()
     {
-        return vk::ImageLayout::ePresentSrcKHR;
+        return vk::ImageLayout::eUndefined;
     }
     static constexpr vk::ImageLayout ScenePassFinalLayout()
     {

--- a/frame/vulkan/sync_resources.cpp
+++ b/frame/vulkan/sync_resources.cpp
@@ -3,9 +3,12 @@
 namespace frame::vulkan
 {
 
-SyncResources::SyncResources(vk::Device device, std::size_t max_frames_in_flight)
+SyncResources::SyncResources(vk::Device device,
+                             std::size_t max_frames_in_flight,
+                             std::size_t swapchain_image_count)
     : device_(device),
-      frame_count_(max_frames_in_flight)
+      frame_count_(max_frames_in_flight),
+      swapchain_image_count_(swapchain_image_count)
 {
 }
 
@@ -17,18 +20,27 @@ void SyncResources::Create()
     }
 
     image_available_.resize(frame_count_);
-    render_finished_.resize(frame_count_);
+    render_finished_.resize(swapchain_image_count_);
     in_flight_.resize(frame_count_);
 
     for (std::size_t i = 0; i < frame_count_; ++i)
     {
         image_available_[i] = device_.createSemaphoreUnique({});
-        render_finished_[i] = device_.createSemaphoreUnique({});
         vk::FenceCreateInfo fence_info(vk::FenceCreateFlagBits::eSignaled);
         in_flight_[i] = device_.createFenceUnique(fence_info);
     }
 
+    for (std::size_t i = 0; i < swapchain_image_count_; ++i)
+    {
+        render_finished_[i] = device_.createSemaphoreUnique({});
+    }
+
     created_ = true;
+}
+
+void SyncResources::SetSwapchainImageCount(std::size_t swapchain_image_count)
+{
+    swapchain_image_count_ = swapchain_image_count;
 }
 
 void SyncResources::Destroy()

--- a/frame/vulkan/sync_resources.h
+++ b/frame/vulkan/sync_resources.h
@@ -11,10 +11,13 @@ namespace frame::vulkan
 class SyncResources
 {
   public:
-    SyncResources(vk::Device device, std::size_t max_frames_in_flight);
+    SyncResources(vk::Device device,
+                  std::size_t max_frames_in_flight,
+                  std::size_t swapchain_image_count);
 
     void Create();
     void Destroy();
+    void SetSwapchainImageCount(std::size_t swapchain_image_count);
 
     bool IsCreated() const
     {
@@ -26,14 +29,19 @@ class SyncResources
         return frame_count_;
     }
 
+    std::size_t GetSwapchainImageCount() const
+    {
+        return swapchain_image_count_;
+    }
+
     vk::Semaphore GetImageAvailable(std::size_t frame) const
     {
         return *image_available_.at(frame);
     }
 
-    vk::Semaphore GetRenderFinished(std::size_t frame) const
+    vk::Semaphore GetRenderFinished(std::size_t image_index) const
     {
-        return *render_finished_.at(frame);
+        return *render_finished_.at(image_index);
     }
 
     vk::Fence GetInFlightFence(std::size_t frame) const
@@ -44,6 +52,7 @@ class SyncResources
   private:
     vk::Device device_;
     std::size_t frame_count_ = 0;
+    std::size_t swapchain_image_count_ = 0;
     bool created_ = false;
     std::vector<vk::UniqueSemaphore> image_available_;
     std::vector<vk::UniqueSemaphore> render_finished_;

--- a/tests/frame/vulkan/gui_test.cpp
+++ b/tests/frame/vulkan/gui_test.cpp
@@ -18,7 +18,7 @@ TEST(VulkanGuiTest, SwapchainGuiStackLayoutsAreStable)
 {
     EXPECT_EQ(
         frame::vulkan::SwapchainResources::ScenePassInitialLayout(),
-        vk::ImageLayout::ePresentSrcKHR);
+        vk::ImageLayout::eUndefined);
     EXPECT_EQ(
         frame::vulkan::SwapchainResources::ScenePassFinalLayout(),
         vk::ImageLayout::eTransferSrcOptimal);


### PR DESCRIPTION
## Summary
- fix Vulkan swapchain image layout and present-semaphore lifetime handling
- treat SDL window close requests as quit events in both Vulkan and OpenGL backends
- hide the SDL window until blocking startup work has completed to avoid the white not-responding flash

## Details
The Vulkan path was reusing render-finished semaphores by frame-in-flight instead of by swapchain image, which could trip validation when a previously presented image had not yet been reacquired. This change allocates present semaphores per swapchain image and reinitializes them correctly on swapchain recreation.

The scene pass also assumed acquired swapchain images started in `VK_IMAGE_LAYOUT_PRESENT_SRC_KHR`, which is not guaranteed for first use. This updates the initial layout/dependency to start from `VK_IMAGE_LAYOUT_UNDEFINED`.

On the SDL side, clicking the window close button was not handled as a quit request under SDL3, which could leave the process running after the window closed. Both backends now treat `SDL_EVENT_WINDOW_CLOSE_REQUESTED` as quit. The window is also created hidden and only shown after plugin/device startup has completed, which removes the brief white unresponsive startup window.

## Validation
- `cmake --build --preset windows-debug` from the grpcMMO superproject
- local auth/game/client smoke run with Vulkan validation enabled no longer reproduced the pasted swapchain layout and semaphore reuse validation errors