### PR TITLE
Suppress warnings for optional texture lookups

### DIFF
--- a/frame/opengl/file/load_mesh.cpp
+++ b/frame/opengl/file/load_mesh.cpp
@@ -65,6 +65,20 @@ bool IsRaytracingProgram(const ProgramInterface* program)
     return frame::json::IsRaytracingProgramKey(key);
 }
 
+EntityId FindTextureIdByName(
+    LevelInterface& level,
+    std::string_view texture_name)
+{
+    for (const auto texture_id : level.GetTextures())
+    {
+        if (level.GetNameFromId(texture_id) == texture_name)
+        {
+            return texture_id;
+        }
+    }
+    return NullId;
+}
+
 constexpr float kMaterialFactorEpsilon = 0.01f;
 constexpr float kDefaultIor = 1.5f;
 constexpr float kDefaultAttenuationDistance = 1000000.0f;
@@ -1369,8 +1383,9 @@ std::vector<std::pair<EntityId, EntityId>> LoadMeshesFromGltfFile(
         -> EntityId {
             for (const auto name_view : names)
             {
-                const auto texture_id = level.GetIdFromName(
-                    std::string(name_view));
+                const auto texture_id = FindTextureIdByName(
+                    level,
+                    name_view);
                 if (texture_id != NullId)
                 {
                     return texture_id;
@@ -1713,7 +1728,7 @@ std::vector<std::pair<EntityId, EntityId>> LoadMeshesFromGltfFile(
                     }
                     else
                     {
-                        texture_id = level.GetIdFromName(binding_name);
+                        texture_id = FindTextureIdByName(level, binding_name);
                     }
                     if (texture_id == NullId)
                     {

--- a/frame/opengl/json/parse_program.cpp
+++ b/frame/opengl/json/parse_program.cpp
@@ -26,6 +26,20 @@ bool EndsWith(std::string_view value, std::string_view suffix)
            value.substr(value.size() - suffix.size()) == suffix;
 }
 
+EntityId FindTextureIdByName(
+    LevelInterface& level,
+    std::string_view texture_name)
+{
+    for (const auto texture_id : level.GetTextures())
+    {
+        if (level.GetNameFromId(texture_id) == texture_name)
+        {
+            return texture_id;
+        }
+    }
+    return NullId;
+}
+
 struct GeneratedTextureSpec
 {
     std::array<float, 4> color = {0.0f, 0.0f, 0.0f, 1.0f};
@@ -173,7 +187,7 @@ std::unique_ptr<frame::ProgramInterface> ParseProgramOpenGL(
     }
     for (const auto& texture_name : proto_program.input_texture_names())
     {
-        EntityId texture_id = level.GetIdFromName(texture_name);
+        EntityId texture_id = FindTextureIdByName(level, texture_name);
         if (!texture_id)
         {
             texture_id = EnsureRaytracingDefaultTexture(
@@ -187,7 +201,7 @@ std::unique_ptr<frame::ProgramInterface> ParseProgramOpenGL(
     }
     for (const auto& texture_name : proto_program.output_texture_names())
     {
-        EntityId texture_id = level.GetIdFromName(texture_name);
+        EntityId texture_id = FindTextureIdByName(level, texture_name);
         if (!texture_id)
         {
             return nullptr;

--- a/frame/vulkan/json/parse_program.cpp
+++ b/frame/vulkan/json/parse_program.cpp
@@ -24,6 +24,20 @@ bool EndsWith(std::string_view value, std::string_view suffix)
            value.substr(value.size() - suffix.size()) == suffix;
 }
 
+frame::EntityId FindTextureIdByName(
+    frame::LevelInterface& level,
+    std::string_view texture_name)
+{
+    for (const auto texture_id : level.GetTextures())
+    {
+        if (level.GetNameFromId(texture_id) == texture_name)
+        {
+            return texture_id;
+        }
+    }
+    return frame::NullId;
+}
+
 struct GeneratedTextureSpec
 {
     std::array<float, 4> color = {0.0f, 0.0f, 0.0f, 1.0f};
@@ -269,7 +283,7 @@ std::unique_ptr<frame::ProgramInterface> ParseProgram(
 
     for (const auto& texture_name : proto_program.input_texture_names())
     {
-        auto texture_id = level.GetIdFromName(texture_name);
+        auto texture_id = FindTextureIdByName(level, texture_name);
         if (texture_id == frame::NullId)
         {
             texture_id = EnsureRaytracingDefaultTexture(
@@ -287,7 +301,7 @@ std::unique_ptr<frame::ProgramInterface> ParseProgram(
 
     for (const auto& texture_name : proto_program.output_texture_names())
     {
-        auto texture_id = level.GetIdFromName(texture_name);
+        auto texture_id = FindTextureIdByName(level, texture_name);
         if (texture_id == frame::NullId)
         {
             throw std::runtime_error(std::format(

--- a/frame/vulkan/json/parse_scene_tree.cpp
+++ b/frame/vulkan/json/parse_scene_tree.cpp
@@ -2761,7 +2761,8 @@ bool ParseNodeMesh(
             [&](std::initializer_list<std::string_view> names) -> EntityId {
                 for (const auto name_view : names)
                 {
-                    const auto texture_id = level.GetIdFromName(
+                    const auto texture_id = FindTextureIdByName(
+                        level,
                         std::string(name_view));
                     if (texture_id != NullId)
                     {
@@ -3109,7 +3110,7 @@ bool ParseNodeMesh(
                     }
                     else
                     {
-                        texture_id = level.GetIdFromName(binding_name);
+                        texture_id = FindTextureIdByName(level, binding_name);
                     }
                     if (texture_id == NullId)
                     {


### PR DESCRIPTION
## Summary
- add quiet texture-name lookup helpers for OpenGL and Vulkan program parsing
- use the quiet lookup path when probing optional glTF/material texture bindings
- preserve the existing fallback behavior without emitting warning spam for expected misses

## Why
Some render paths intentionally probe optional texture names such as `opaque_*`, `transmissive_*`, and material-specific bindings. Those probes were using `GetIdFromName(...)`, which logs a warning on every miss. In scenes that rely on imported material bindings instead of predeclared level textures, this produced a large amount of misleading log noise even though rendering still worked.

## Validation
- rebuilt `grpcmmo_client` against this Frame change
- reran the client and checked the generated `log.txt`
- confirmed the `No id for name ...` warning flood is gone
- remaining warnings are only the unrelated Vulkan validation-layer environment warnings