### PR TITLE
Treat bind-pose skinned meshes as static raytrace sources

### DIFF
--- a/frame/opengl/build_level.cpp
+++ b/frame/opengl/build_level.cpp
@@ -89,8 +89,9 @@ bool RaytraceSceneRequiresWorldSpaceBuffers(frame::LevelInterface& level)
         {
             continue;
         }
-        if (skinned_mesh->HasSkinning() ||
-            skinned_mesh->HasRaytraceTriangleCallback())
+        if (skinned_mesh->HasActiveSkinning() ||
+            skinned_mesh->HasActiveRaytraceTriangleCallback() ||
+            skinned_mesh->HasActiveRaytraceBvhCallback())
         {
             return true;
         }

--- a/frame/opengl/renderer.cpp
+++ b/frame/opengl/renderer.cpp
@@ -122,8 +122,9 @@ bool RaytraceSceneRequiresWorldSpaceBuffers(frame::LevelInterface& level)
         {
             continue;
         }
-        if (skinned_mesh->HasSkinning() ||
-            skinned_mesh->HasRaytraceTriangleCallback())
+        if (skinned_mesh->HasActiveSkinning() ||
+            skinned_mesh->HasActiveRaytraceTriangleCallback() ||
+            skinned_mesh->HasActiveRaytraceBvhCallback())
         {
             return true;
         }
@@ -699,7 +700,7 @@ void Renderer::UpdateRaytraceBuffersIfNeeded(SkinnedMesh& skinned_mesh)
 {
     const double skinning_time = skinned_mesh.GetSkinningTime(delta_time_);
 
-    if (skinned_mesh.HasRaytraceTriangleCallback())
+    if (skinned_mesh.HasActiveRaytraceTriangleCallback())
     {
         const EntityId triangle_buffer_id = skinned_mesh.GetTriangleBufferId();
         if (triangle_buffer_id)
@@ -715,7 +716,7 @@ void Renderer::UpdateRaytraceBuffersIfNeeded(SkinnedMesh& skinned_mesh)
         }
     }
 
-    if (skinned_mesh.HasRaytraceBvhCallback())
+    if (skinned_mesh.HasActiveRaytraceBvhCallback())
     {
         const EntityId bvh_buffer_id = skinned_mesh.GetBvhBufferId();
         if (bvh_buffer_id)
@@ -979,7 +980,7 @@ void Renderer::RenderMesh(
     program.Use(uniform_collection_wrapper, &level_);
     int skinning_enabled = 0;
     auto& gl_program = dynamic_cast<opengl::Program&>(program);
-    if (gl_skinned_mesh && gl_skinned_mesh->HasSkinning())
+    if (gl_skinned_mesh && gl_skinned_mesh->HasActiveSkinning())
     {
         const double skinning_time =
             gl_skinned_mesh->GetSkinningTime(delta_time_);

--- a/frame/opengl/skinned_mesh.cpp
+++ b/frame/opengl/skinned_mesh.cpp
@@ -109,6 +109,11 @@ bool SkinnedMesh::HasSkinning() const
     return static_cast<bool>(skinning_callback_);
 }
 
+bool SkinnedMesh::HasActiveSkinning() const
+{
+    return HasSkinning() && skinning_animation_enabled_;
+}
+
 bool SkinnedMesh::IsSkinningAnimationEnabled() const
 {
     return skinning_animation_enabled_;
@@ -152,6 +157,11 @@ bool SkinnedMesh::HasRaytraceTriangleCallback() const
     return static_cast<bool>(raytrace_triangle_callback_);
 }
 
+bool SkinnedMesh::HasActiveRaytraceTriangleCallback() const
+{
+    return HasRaytraceTriangleCallback() && skinning_animation_enabled_;
+}
+
 std::vector<float> SkinnedMesh::EvaluateRaytraceTriangles(double time_s) const
 {
     if (!raytrace_triangle_callback_)
@@ -164,6 +174,11 @@ std::vector<float> SkinnedMesh::EvaluateRaytraceTriangles(double time_s) const
 bool SkinnedMesh::HasRaytraceBvhCallback() const
 {
     return static_cast<bool>(raytrace_bvh_callback_);
+}
+
+bool SkinnedMesh::HasActiveRaytraceBvhCallback() const
+{
+    return HasRaytraceBvhCallback() && skinning_animation_enabled_;
 }
 
 std::vector<BVHNode> SkinnedMesh::EvaluateRaytraceBvh(double time_s) const

--- a/frame/opengl/skinned_mesh.h
+++ b/frame/opengl/skinned_mesh.h
@@ -42,6 +42,7 @@ class SkinnedMesh : public Mesh
         std::function<std::vector<BVHNode>(double)> callback);
 
     bool HasSkinning() const;
+    bool HasActiveSkinning() const;
     bool IsSkinningAnimationEnabled() const;
     float GetSkinningAnimationSpeed() const;
     const std::string& GetSkinningAnimationClipName() const;
@@ -49,8 +50,10 @@ class SkinnedMesh : public Mesh
     double GetSkinningTime(double time_s) const;
     std::vector<glm::mat4> EvaluateSkinning(double time_s) const;
     bool HasRaytraceTriangleCallback() const;
+    bool HasActiveRaytraceTriangleCallback() const;
     std::vector<float> EvaluateRaytraceTriangles(double time_s) const;
     bool HasRaytraceBvhCallback() const;
+    bool HasActiveRaytraceBvhCallback() const;
     std::vector<BVHNode> EvaluateRaytraceBvh(double time_s) const;
 
   private:

--- a/frame/vulkan/device.cpp
+++ b/frame/vulkan/device.cpp
@@ -487,8 +487,8 @@ bool RaytraceSceneRequiresWorldSpaceBuffers(frame::LevelInterface& level)
         {
             continue;
         }
-        if (skinned_mesh->IsSkinningAnimationEnabled() ||
-            skinned_mesh->HasRaytraceTriangleCallback())
+        if (skinned_mesh->HasActiveRaytraceTriangleCallback() ||
+            skinned_mesh->HasActiveRaytraceBvhCallback())
         {
             return true;
         }
@@ -2074,7 +2074,8 @@ void Device::UpdateRaytraceBuffers()
             static_cast<double>(elapsed_time_seconds_));
 
         const auto triangle_buffer_id = skinned_mesh->GetTriangleBufferId();
-        if (triangle_buffer_id && skinned_mesh->HasRaytraceTriangleCallback())
+        if (triangle_buffer_id &&
+            skinned_mesh->HasActiveRaytraceTriangleCallback())
         {
             auto triangles = skinned_mesh->EvaluateRaytraceTriangles(skinning_time);
             if (!triangles.empty())
@@ -2118,7 +2119,7 @@ void Device::UpdateRaytraceBuffers()
         }
 
         const auto bvh_buffer_id = skinned_mesh->GetBvhBufferId();
-        if (bvh_buffer_id && skinned_mesh->HasRaytraceBvhCallback())
+        if (bvh_buffer_id && skinned_mesh->HasActiveRaytraceBvhCallback())
         {
             auto bvh_nodes = skinned_mesh->EvaluateRaytraceBvh(skinning_time);
             if (!bvh_nodes.empty())

--- a/frame/vulkan/skinned_mesh.h
+++ b/frame/vulkan/skinned_mesh.h
@@ -80,6 +80,11 @@ class SkinnedMesh : public StaticMesh
         return static_cast<bool>(raytrace_triangle_callback_);
     }
 
+    bool HasActiveRaytraceTriangleCallback() const
+    {
+        return HasRaytraceTriangleCallback() && skinning_animation_enabled_;
+    }
+
     std::vector<float> EvaluateRaytraceTriangles(double time_s) const
     {
         if (!raytrace_triangle_callback_)
@@ -98,6 +103,11 @@ class SkinnedMesh : public StaticMesh
     bool HasRaytraceBvhCallback() const
     {
         return static_cast<bool>(raytrace_bvh_callback_);
+    }
+
+    bool HasActiveRaytraceBvhCallback() const
+    {
+        return HasRaytraceBvhCallback() && skinning_animation_enabled_;
     }
 
     std::vector<BVHNode> EvaluateRaytraceBvh(double time_s) const

--- a/tests/frame/opengl/raytracing_test.cpp
+++ b/tests/frame/opengl/raytracing_test.cpp
@@ -19,6 +19,28 @@ namespace test
 namespace
 {
 
+frame::proto::Level LoadLevelProtoWithFoxAnimationEnabled(bool enabled)
+{
+    auto level_proto = frame::json::LoadLevelProto(
+        frame::file::FindFile("asset/json/skinned_mesh.json"));
+    auto* scene_tree = level_proto.mutable_scene_tree();
+    for (auto& node_mesh : *scene_tree->mutable_node_meshes())
+    {
+        if (node_mesh.name() != "FoxMesh")
+        {
+            continue;
+        }
+        node_mesh.set_play_animation(enabled);
+        if (!enabled)
+        {
+            node_mesh.clear_animation_speed();
+            node_mesh.clear_animation_clip_name();
+            node_mesh.clear_animation_clip_index();
+        }
+    }
+    return level_proto;
+}
+
 struct RaytraceVertex
 {
     float px;
@@ -914,6 +936,44 @@ TEST_F(OpenGLRayTracingLevelTest, SkinnedMeshPreRenderUpdatesAggregateSceneBuffe
 
     EXPECT_NE(triangle_buffer->GetRawData(), triangles_before);
     EXPECT_NE(bvh_buffer->GetRawData(), bvh_before);
+}
+
+TEST_F(OpenGLRayTracingLevelTest, SkinnedMeshBindPoseDoesNotUpdateAggregateSceneBuffers)
+{
+    auto level = frame::json::ParseLevel(
+        {1280u, 720u},
+        LoadLevelProtoWithFoxAnimationEnabled(false));
+    ASSERT_NE(level, nullptr);
+
+    const auto material_id = level->GetIdFromName("RayTraceMaterial");
+    ASSERT_NE(material_id, frame::NullId);
+    const auto& material = level->GetMaterialFromId(material_id);
+
+    const auto triangle_id = FindBufferByInnerName(
+        *level, material, "TriangleBufferOpaque");
+    const auto bvh_id = FindBufferByInnerName(
+        *level, material, "BvhBufferOpaque");
+    ASSERT_NE(triangle_id, frame::NullId);
+    ASSERT_NE(bvh_id, frame::NullId);
+
+    auto* triangle_buffer = dynamic_cast<frame::opengl::Buffer*>(
+        &level->GetBufferFromId(triangle_id));
+    auto* bvh_buffer = dynamic_cast<frame::opengl::Buffer*>(
+        &level->GetBufferFromId(bvh_id));
+    ASSERT_NE(triangle_buffer, nullptr);
+    ASSERT_NE(bvh_buffer, nullptr);
+
+    const auto triangles_before = triangle_buffer->GetRawData();
+    const auto bvh_before = bvh_buffer->GetRawData();
+
+    frame::opengl::Renderer renderer(
+        *level,
+        glm::uvec4(0, 0, 1280, 720));
+    renderer.SetDeltaTime(0.35);
+    renderer.PreRender();
+
+    EXPECT_EQ(triangle_buffer->GetRawData(), triangles_before);
+    EXPECT_EQ(bvh_buffer->GetRawData(), bvh_before);
 }
 
 TEST_F(OpenGLRayTracingLevelTest, SkinnedMeshSceneMaterialUsesImportedFoxTextures)

--- a/tests/frame/vulkan/raytracing_test.cpp
+++ b/tests/frame/vulkan/raytracing_test.cpp
@@ -57,6 +57,28 @@ bool EndsWith(const std::string& value, const std::string& suffix)
     return value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
+frame::proto::Level LoadSkinnedMeshLevelProtoWithFoxAnimationEnabled(bool enabled)
+{
+    auto level_proto = frame::json::LoadLevelProto(
+        frame::file::FindFile("asset/json/skinned_mesh.json"));
+    auto* scene_tree = level_proto.mutable_scene_tree();
+    for (auto& node_mesh : *scene_tree->mutable_node_meshes())
+    {
+        if (node_mesh.name() != "FoxMesh")
+        {
+            continue;
+        }
+        node_mesh.set_play_animation(enabled);
+        if (!enabled)
+        {
+            node_mesh.clear_animation_speed();
+            node_mesh.clear_animation_clip_name();
+            node_mesh.clear_animation_clip_index();
+        }
+    }
+    return level_proto;
+}
+
 const frame::json::ProgramInfo* FindProgramInfoByName(
     const frame::json::LevelData& level_data,
     const std::string& name)
@@ -776,6 +798,42 @@ TEST_F(VulkanSkinnedRayTracingParseTest, FoxAnimationChangesRaytraceTriangles)
         }
     }
     EXPECT_TRUE(found_difference);
+}
+
+TEST_F(VulkanSkinnedRayTracingParseTest, FoxBindPoseDisablesDynamicRaytraceCallbacks)
+{
+    auto level_proto = LoadSkinnedMeshLevelProtoWithFoxAnimationEnabled(false);
+    auto level_data = frame::json::ParseLevelData(
+        glm::uvec2(512, 288),
+        level_proto,
+        asset_root_);
+    auto built = frame::vulkan::BuildLevel(
+        glm::uvec2(512, 288),
+        level_data,
+        {.prefer_hardware_raytracing = true});
+    ASSERT_NE(built.level, nullptr);
+    auto& level = *built.level;
+
+    const auto fox_node_id = level.GetIdFromName("FoxMesh");
+    ASSERT_NE(fox_node_id, frame::NullId);
+    auto& fox_node = level.GetSceneNodeFromId(fox_node_id);
+    const auto fox_mesh_id = fox_node.GetLocalMesh();
+    ASSERT_NE(fox_mesh_id, frame::NullId);
+    auto* skinned_mesh = dynamic_cast<frame::vulkan::SkinnedMesh*>(
+        &level.GetMeshFromId(fox_mesh_id));
+    ASSERT_NE(skinned_mesh, nullptr);
+
+    EXPECT_FALSE(skinned_mesh->IsSkinningAnimationEnabled());
+    EXPECT_TRUE(skinned_mesh->HasRaytraceTriangleCallback());
+    EXPECT_FALSE(skinned_mesh->HasActiveRaytraceTriangleCallback());
+    EXPECT_FALSE(skinned_mesh->HasActiveRaytraceBvhCallback());
+
+    const auto triangles_at_start =
+        skinned_mesh->EvaluateRaytraceTriangles(skinned_mesh->GetSkinningTime(0.0));
+    const auto triangles_later =
+        skinned_mesh->EvaluateRaytraceTriangles(skinned_mesh->GetSkinningTime(0.35));
+    ASSERT_FALSE(triangles_at_start.empty());
+    EXPECT_EQ(triangles_at_start, triangles_later);
 }
 
 TEST_F(VulkanSkinnedRayTracingParseTest, SceneMaterialUsesImportedFoxTextures)


### PR DESCRIPTION
## Summary
- keep skinned meshes with `play_animation = false` on the static bind-pose raytracing path
- gate OpenGL/Vulkan skinning and raytrace buffer updates on active animation instead of bone presence alone
- add regressions covering animated fox vs bind-pose fox behavior

## Verification
- built `FrameOpenGLTest`
- built `FrameVulkanTest`
- ran `FrameOpenGLTest --gtest_filter='OpenGLRayTracingLevelTest.SkinnedMeshPreRenderUpdatesAggregateSceneBuffers:OpenGLRayTracingLevelTest.SkinnedMeshBindPoseDoesNotUpdateAggregateSceneBuffers:SkinnedMeshTest.LoadFoxGlbCreatesSkinnedMeshWithAnimationData'`
- ran `FrameVulkanTest --gtest_filter='VulkanSkinnedRayTracingParseTest.FoxAnimationChangesRaytraceTriangles:VulkanSkinnedRayTracingParseTest.FoxBindPoseDisablesDynamicRaytraceCallbacks'`
- rebuilt `grpcmmo_client` against the updated Frame submodule