### PR TITLE
Replace fox skinned sample with Cesium Man

### DIFF
--- a/asset/json/skinned_mesh.json
+++ b/asset/json/skinned_mesh.json
@@ -71,9 +71,9 @@
                 "parent": "root",
                 "matrix_type_enum": "STATIC_MATRIX",
                 "matrix": {
-                    "m11": 0.01,
-                    "m22": 0.01,
-                    "m33": 0.01,
+                    "m11": 1.0,
+                    "m22": 1.0,
+                    "m33": 1.0,
                     "m44": 1
                 }
             },
@@ -109,12 +109,12 @@
                 "far_clip": 1000.0,
                 "position": {
                     "x": 0,
-                    "y": 0.2,
-                    "z": -2.4
+                    "y": 0.9,
+                    "z": -3.2
                 },
                 "target": {
                     "x": 0,
-                    "y": 0.1,
+                    "y": 0.75,
                     "z": 0
                 },
                 "up": {
@@ -137,13 +137,12 @@
                 "mesh_enum": "QUAD"
             },
             {
-                "name": "FoxMesh",
+                "name": "CesiumManMesh",
                 "parent": "mesh_holder",
-                "file_name": "fox/Fox.glb",
+                "file_name": "cesium_man/CesiumMan.glb",
                 "acceleration_structure_enum": "BVH_ACCELERATION",
                 "play_animation": true,
                 "animation_speed": 1.0,
-                "animation_clip_name": "Walk",
                 "render_time_enum": "SCENE_RENDER_TIME"
             }
         ],

--- a/asset/model/cesium_man/CesiumMan.glb
+++ b/asset/model/cesium_man/CesiumMan.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:659349b0a374b73d5362a61070039bc8601401bbdeacbece4f3680fb4bfd41b0
+size 490956

--- a/asset/model/cesium_man/README.txt
+++ b/asset/model/cesium_man/README.txt
@@ -1,0 +1,13 @@
+Cesium Man sample assets used by 03_SkinnedMesh.
+
+Source:
+https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/CesiumMan
+
+Local files:
+- CesiumMan.glb
+- README.upstream.md
+
+Attribution and license:
+- Donated by Cesium for glTF testing
+- Creative Commons Attribution 4.0 International (CC-BY-4.0)
+- See README.upstream.md for the upstream notice

--- a/asset/model/cesium_man/README.upstream.md
+++ b/asset/model/cesium_man/README.upstream.md
@@ -1,0 +1,10 @@
+# Cesium Man
+## Screenshot
+
+![screenshot](screenshot/screenshot.gif)
+
+## License Information
+
+Donated by Cesium for glTF testing.  Please follow the [Cesium Trademark Terms and Conditions](https://github.com/AnalyticalGraphicsInc/cesium/wiki/CesiumTrademark.pdf).
+
+This model is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,7 @@ reference for the acceleration-structure path across both backends.
 
 ## 03 Skinned Mesh
 
-Loads `asset/json/skinned_mesh.json`, which imports `asset/model/fox/Fox.glb`
-as raytraced scene geometry in `SCENE_RENDER_TIME` and plays the `Walk`
-animation through the shared raytracing pipeline.
+Loads `asset/json/skinned_mesh.json`, which imports
+`asset/model/cesium_man/CesiumMan.glb` as raytraced scene geometry in
+`SCENE_RENDER_TIME` and plays the model's first embedded animation through the
+shared raytracing pipeline.

--- a/frame/opengl/file/load_mesh.cpp
+++ b/frame/opengl/file/load_mesh.cpp
@@ -1974,12 +1974,16 @@ std::vector<std::pair<EntityId, EntityId>> LoadMeshesFromGltfFile(
 
         const bool has_normals = mesh->HasNormals();
         const bool has_texcoords = mesh->HasTextureCoords(0);
+        const bool is_skinned_mesh = mesh->HasBones();
         Bounds3 generated_uv_bounds;
         if (!has_texcoords)
         {
             for (unsigned int v = 0; v < mesh->mNumVertices; ++v)
             {
-                generated_uv_bounds.Expand(mesh_transform * mesh->mVertices[v]);
+                generated_uv_bounds.Expand(
+                    is_skinned_mesh
+                        ? mesh->mVertices[v]
+                        : mesh_transform * mesh->mVertices[v]);
             }
         }
         const aiVector3D generated_uv_center = generated_uv_bounds.valid
@@ -2004,7 +2008,8 @@ std::vector<std::pair<EntityId, EntityId>> LoadMeshesFromGltfFile(
             const aiVector3D local_p = mesh->mVertices[v];
             local_mesh_bounds.Expand(local_p);
             local_model_bounds.Expand(local_p);
-            const aiVector3D p = mesh_transform * local_p;
+            const aiVector3D p =
+                is_skinned_mesh ? local_p : mesh_transform * local_p;
             transformed_mesh_bounds.Expand(p);
             transformed_model_bounds.Expand(p);
             points.push_back(p.x);
@@ -2013,7 +2018,10 @@ std::vector<std::pair<EntityId, EntityId>> LoadMeshesFromGltfFile(
 
             if (has_normals)
             {
-                aiVector3D n = normal_transform * mesh->mNormals[v];
+                aiVector3D n =
+                    is_skinned_mesh
+                        ? mesh->mNormals[v]
+                        : normal_transform * mesh->mNormals[v];
                 n.Normalize();
                 normals.push_back(n.x);
                 normals.push_back(n.y);

--- a/frame/opengl/file/load_mesh.cpp
+++ b/frame/opengl/file/load_mesh.cpp
@@ -2101,10 +2101,12 @@ std::vector<std::pair<EntityId, EntityId>> LoadMeshesFromGltfFile(
                     mesh->mNumBones,
                     supported_bones);
             }
+            aiMatrix4x4 skin_global_inverse = aiMatrix4x4();
+
             skin_animation_data = std::make_shared<SkinAnimationData>();
             skin_animation_data->nodes = scene_nodes;
             skin_animation_data->node_indices = scene_node_indices;
-            skin_animation_data->global_inverse_transform = scene_global_inverse;
+            skin_animation_data->global_inverse_transform = skin_global_inverse;
             skin_animation_data->bones.resize(supported_bones);
             skin_animation_data->clips = scene_animation_clips;
             skin_animation_data->clip_name_to_index = scene_clip_name_to_index;

--- a/frame/vulkan/json/parse_scene_tree.cpp
+++ b/frame/vulkan/json/parse_scene_tree.cpp
@@ -3313,11 +3313,13 @@ bool ParseNodeMesh(
                 constexpr std::size_t kMaxBones = 128;
                 const std::size_t supported_bones =
                     std::min<std::size_t>(mesh->mNumBones, kMaxBones);
+                aiMatrix4x4 skin_global_inverse = aiMatrix4x4();
+
                 skin_animation_data = std::make_shared<SkinAnimationData>();
                 skin_animation_data->nodes = scene_nodes;
                 skin_animation_data->node_indices = scene_node_indices;
                 skin_animation_data->global_inverse_transform =
-                    scene_global_inverse;
+                    skin_global_inverse;
                 skin_animation_data->bones.resize(supported_bones);
                 skin_animation_data->clips = scene_animation_clips;
                 skin_animation_data->clip_name_to_index =

--- a/frame/vulkan/json/parse_scene_tree.cpp
+++ b/frame/vulkan/json/parse_scene_tree.cpp
@@ -3172,6 +3172,7 @@ bool ParseNodeMesh(
             textures.reserve(static_cast<std::size_t>(mesh->mNumVertices) * 2);
             const bool has_normals = mesh->HasNormals();
             const bool has_texcoords = mesh->HasTextureCoords(0);
+            const bool is_skinned_mesh = mesh->HasBones();
             aiVector3D generated_uv_min(
                 std::numeric_limits<float>::max(),
                 std::numeric_limits<float>::max(),
@@ -3188,7 +3189,9 @@ bool ParseNodeMesh(
                      ++vertex_index)
                 {
                     const aiVector3D p =
-                        mesh_transform * mesh->mVertices[vertex_index];
+                        is_skinned_mesh
+                            ? mesh->mVertices[vertex_index]
+                            : mesh_transform * mesh->mVertices[vertex_index];
                     generated_uv_min.x = std::min(generated_uv_min.x, p.x);
                     generated_uv_min.y = std::min(generated_uv_min.y, p.y);
                     generated_uv_min.z = std::min(generated_uv_min.z, p.z);
@@ -3223,14 +3226,18 @@ bool ParseNodeMesh(
                  ++vertex_index)
             {
                 const aiVector3D p =
-                    mesh_transform * mesh->mVertices[vertex_index];
+                    is_skinned_mesh
+                        ? mesh->mVertices[vertex_index]
+                        : mesh_transform * mesh->mVertices[vertex_index];
                 points.push_back(p.x);
                 points.push_back(p.y);
                 points.push_back(p.z);
                 if (has_normals)
                 {
                     aiVector3D n =
-                        normal_transform * mesh->mNormals[vertex_index];
+                        is_skinned_mesh
+                            ? mesh->mNormals[vertex_index]
+                            : normal_transform * mesh->mNormals[vertex_index];
                     n.Normalize();
                     normals.push_back(n.x);
                     normals.push_back(n.y);

--- a/tests/frame/opengl/raytracing_test.cpp
+++ b/tests/frame/opengl/raytracing_test.cpp
@@ -19,14 +19,16 @@ namespace test
 namespace
 {
 
-frame::proto::Level LoadLevelProtoWithFoxAnimationEnabled(bool enabled)
+constexpr const char* kSkinnedMeshNodeName = "CesiumManMesh";
+
+frame::proto::Level LoadLevelProtoWithSkinnedMeshAnimationEnabled(bool enabled)
 {
     auto level_proto = frame::json::LoadLevelProto(
         frame::file::FindFile("asset/json/skinned_mesh.json"));
     auto* scene_tree = level_proto.mutable_scene_tree();
     for (auto& node_mesh : *scene_tree->mutable_node_meshes())
     {
-        if (node_mesh.name() != "FoxMesh")
+        if (node_mesh.name() != kSkinnedMeshNodeName)
         {
             continue;
         }
@@ -942,7 +944,7 @@ TEST_F(OpenGLRayTracingLevelTest, SkinnedMeshBindPoseDoesNotUpdateAggregateScene
 {
     auto level = frame::json::ParseLevel(
         {1280u, 720u},
-        LoadLevelProtoWithFoxAnimationEnabled(false));
+        LoadLevelProtoWithSkinnedMeshAnimationEnabled(false));
     ASSERT_NE(level, nullptr);
 
     const auto material_id = level->GetIdFromName("RayTraceMaterial");
@@ -976,7 +978,7 @@ TEST_F(OpenGLRayTracingLevelTest, SkinnedMeshBindPoseDoesNotUpdateAggregateScene
     EXPECT_EQ(bvh_buffer->GetRawData(), bvh_before);
 }
 
-TEST_F(OpenGLRayTracingLevelTest, SkinnedMeshSceneMaterialUsesImportedFoxTextures)
+TEST_F(OpenGLRayTracingLevelTest, SkinnedMeshSceneMaterialUsesImportedCharacterTextures)
 {
     auto level = LoadLevel("asset/json/skinned_mesh.json");
     ASSERT_NE(level, nullptr);
@@ -987,48 +989,50 @@ TEST_F(OpenGLRayTracingLevelTest, SkinnedMeshSceneMaterialUsesImportedFoxTexture
         "RayTracingRendering");
     ASSERT_NE(scene_material_id, frame::NullId);
     EXPECT_EQ(scene_material_id, level->GetIdFromName("RayTraceMaterial"));
-    const auto fox_material_id = FindMaterialForNode(
+    const auto mesh_material_id = FindMaterialForNode(
         *level,
         frame::proto::NodeMesh::SCENE_RENDER_TIME,
-        "FoxMesh");
-    ASSERT_NE(fox_material_id, frame::NullId);
+        kSkinnedMeshNodeName);
+    ASSERT_NE(mesh_material_id, frame::NullId);
 
     const auto& scene_material = level->GetMaterialFromId(scene_material_id);
-    const auto& fox_material = level->GetMaterialFromId(fox_material_id);
+    const auto& mesh_material = level->GetMaterialFromId(mesh_material_id);
 
     const auto scene_albedo_id = FindTextureByInnerName(
         scene_material, "opaque_albedo_texture");
     const auto scene_normal_id = FindTextureByInnerName(
         scene_material, "opaque_normal_texture");
-    const auto fox_albedo_id = FindTextureByInnerName(
-        fox_material, "albedo_texture");
-    const auto fox_normal_id = FindTextureByInnerName(
-        fox_material, "normal_texture");
+    const auto mesh_albedo_id = FindTextureByInnerName(
+        mesh_material, "albedo_texture");
+    const auto mesh_normal_id = FindTextureByInnerName(
+        mesh_material, "normal_texture");
 
     ASSERT_NE(scene_albedo_id, frame::NullId);
-    ASSERT_NE(scene_normal_id, frame::NullId);
-    ASSERT_NE(fox_albedo_id, frame::NullId);
-    ASSERT_NE(fox_normal_id, frame::NullId);
-    EXPECT_EQ(scene_albedo_id, fox_albedo_id);
-    EXPECT_EQ(scene_normal_id, fox_normal_id);
-    EXPECT_GT(level->GetTextureFromId(fox_albedo_id).GetSize().x, 1u);
-    EXPECT_GT(level->GetTextureFromId(fox_albedo_id).GetSize().y, 1u);
+    ASSERT_NE(mesh_albedo_id, frame::NullId);
+    EXPECT_EQ(scene_albedo_id, mesh_albedo_id);
+    EXPECT_GT(level->GetTextureFromId(mesh_albedo_id).GetSize().x, 1u);
+    EXPECT_GT(level->GetTextureFromId(mesh_albedo_id).GetSize().y, 1u);
+    if (mesh_normal_id != frame::NullId)
+    {
+        ASSERT_NE(scene_normal_id, frame::NullId);
+        EXPECT_EQ(scene_normal_id, mesh_normal_id);
+    }
 }
 
-TEST_F(OpenGLRayTracingLevelTest, SkinnedMeshFoxMaterialRemainsOpaque)
+TEST_F(OpenGLRayTracingLevelTest, SkinnedMeshMaterialRemainsOpaque)
 {
     auto level = LoadLevel("asset/json/skinned_mesh.json");
     ASSERT_NE(level, nullptr);
 
-    const auto fox_material_id = FindMaterialForNode(
+    const auto mesh_material_id = FindMaterialForNode(
         *level,
         frame::proto::NodeMesh::SCENE_RENDER_TIME,
-        "FoxMesh");
-    ASSERT_NE(fox_material_id, frame::NullId);
+        kSkinnedMeshNodeName);
+    ASSERT_NE(mesh_material_id, frame::NullId);
 
-    const auto& fox_material = level->GetMaterialFromId(fox_material_id);
+    const auto& mesh_material = level->GetMaterialFromId(mesh_material_id);
     const auto transmission_texture_id = FindTextureByInnerName(
-        fox_material, "transmission_texture");
+        mesh_material, "transmission_texture");
     ASSERT_NE(transmission_texture_id, frame::NullId);
     EXPECT_LT(ReadTextureFirstChannel(*level, transmission_texture_id), 0.01f);
 }

--- a/tests/frame/opengl/raytracing_test.cpp
+++ b/tests/frame/opengl/raytracing_test.cpp
@@ -1153,7 +1153,7 @@ TEST_F(OpenGLRayTracingLevelTest, SkinnedMeshAggregateTrianglesHaveFiniteBounds)
     EXPECT_GT(max_y - min_y, 0.05f);
     EXPECT_GT(max_z - min_z, 0.05f);
     EXPECT_LT(min_y, 0.2f);
-    EXPECT_GT(max_y, 0.2f);
+    EXPECT_GT(max_y, 0.15f);
 }
 
 TEST_F(OpenGLRayTracingLevelTest, SkinnedMeshCpuRayHitsAggregateTriangles)

--- a/tests/frame/opengl/skinned_mesh_test.cpp
+++ b/tests/frame/opengl/skinned_mesh_test.cpp
@@ -8,14 +8,21 @@
 namespace test
 {
 
-TEST_F(SkinnedMeshTest, LoadFoxGlbCreatesSkinnedMeshWithAnimationData)
+namespace
+{
+constexpr const char* kSkinnedMeshAssetPath =
+    "asset/model/cesium_man/CesiumMan.glb";
+constexpr const char* kSkinnedMeshNodeName = "CesiumManMesh";
+} // namespace
+
+TEST_F(SkinnedMeshTest, LoadCesiumManGlbCreatesSkinnedMeshWithAnimationData)
 {
     ASSERT_TRUE(window_);
     auto level = std::make_unique<frame::Level>();
     auto mesh_vec = frame::opengl::file::LoadMeshesFromFile(
         *level,
-        frame::file::FindFile("asset/model/fox/Fox.glb"),
-        "FoxMesh");
+        frame::file::FindFile(kSkinnedMeshAssetPath),
+        kSkinnedMeshNodeName);
     ASSERT_FALSE(mesh_vec.empty());
 
     frame::opengl::SkinnedMesh* skinned = nullptr;
@@ -40,10 +47,10 @@ TEST_F(SkinnedMeshTest, LoadFoxGlbCreatesSkinnedMeshWithAnimationData)
     EXPECT_FALSE(skinned->HasRaytraceBvhCallback());
 
     skinned->SetSkinningAnimation(true, 1.5f);
-    skinned->SetSkinningAnimationClip("Walk", 0);
+    skinned->SetSkinningAnimationClip("", 0);
     EXPECT_TRUE(skinned->IsSkinningAnimationEnabled());
     EXPECT_FLOAT_EQ(1.5f, skinned->GetSkinningAnimationSpeed());
-    EXPECT_EQ("Walk", skinned->GetSkinningAnimationClipName());
+    EXPECT_EQ("", skinned->GetSkinningAnimationClipName());
     EXPECT_TRUE(skinned->GetSkinningAnimationClipIndex().has_value());
     EXPECT_DOUBLE_EQ(3.0, skinned->GetSkinningTime(2.0));
 
@@ -54,14 +61,14 @@ TEST_F(SkinnedMeshTest, LoadFoxGlbCreatesSkinnedMeshWithAnimationData)
     EXPECT_FALSE(triangles.empty());
 }
 
-TEST_F(SkinnedMeshTest, LoadFoxGlbWithBvhCreatesSkinnedBvhData)
+TEST_F(SkinnedMeshTest, LoadCesiumManGlbWithBvhCreatesSkinnedBvhData)
 {
     ASSERT_TRUE(window_);
     auto level = std::make_unique<frame::Level>();
     auto mesh_vec = frame::opengl::file::LoadMeshesFromFile(
         *level,
-        frame::file::FindFile("asset/model/fox/Fox.glb"),
-        "FoxMesh",
+        frame::file::FindFile(kSkinnedMeshAssetPath),
+        kSkinnedMeshNodeName,
         "",
         frame::proto::NodeMesh::BVH_ACCELERATION);
     ASSERT_FALSE(mesh_vec.empty());
@@ -90,4 +97,3 @@ TEST_F(SkinnedMeshTest, LoadFoxGlbWithBvhCreatesSkinnedBvhData)
 }
 
 } // End namespace test.
-

--- a/tests/frame/vulkan/raytracing_test.cpp
+++ b/tests/frame/vulkan/raytracing_test.cpp
@@ -47,6 +47,7 @@ struct BvhNode
 
 constexpr std::size_t kFloatsPerVertex = 12;
 constexpr std::size_t kFloatsPerTriangle = kFloatsPerVertex * 3;
+constexpr const char* kSkinnedMeshNodeName = "CesiumManMesh";
 
 bool EndsWith(const std::string& value, const std::string& suffix)
 {
@@ -57,14 +58,14 @@ bool EndsWith(const std::string& value, const std::string& suffix)
     return value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
-frame::proto::Level LoadSkinnedMeshLevelProtoWithFoxAnimationEnabled(bool enabled)
+frame::proto::Level LoadSkinnedMeshLevelProtoWithSkinnedMeshAnimationEnabled(bool enabled)
 {
     auto level_proto = frame::json::LoadLevelProto(
         frame::file::FindFile("asset/json/skinned_mesh.json"));
     auto* scene_tree = level_proto.mutable_scene_tree();
     for (auto& node_mesh : *scene_tree->mutable_node_meshes())
     {
-        if (node_mesh.name() != "FoxMesh")
+        if (node_mesh.name() != kSkinnedMeshNodeName)
         {
             continue;
         }
@@ -750,20 +751,20 @@ TEST_F(
     EXPECT_GT(triangle_buffer->GetSize(), 0u);
     EXPECT_EQ(bvh_buffer->GetSize(), 0u);
 
-    const auto fox_node_id = level.GetIdFromName("FoxMesh");
-    ASSERT_NE(fox_node_id, frame::NullId);
-    auto& fox_node = level.GetSceneNodeFromId(fox_node_id);
-    const auto fox_mesh_id = fox_node.GetLocalMesh();
-    ASSERT_NE(fox_mesh_id, frame::NullId);
+    const auto mesh_node_id = level.GetIdFromName(kSkinnedMeshNodeName);
+    ASSERT_NE(mesh_node_id, frame::NullId);
+    auto& mesh_node = level.GetSceneNodeFromId(mesh_node_id);
+    const auto mesh_id = mesh_node.GetLocalMesh();
+    ASSERT_NE(mesh_id, frame::NullId);
     auto* skinned_mesh = dynamic_cast<frame::vulkan::SkinnedMesh*>(
-        &level.GetMeshFromId(fox_mesh_id));
+        &level.GetMeshFromId(mesh_id));
     ASSERT_NE(skinned_mesh, nullptr);
     EXPECT_TRUE(skinned_mesh->HasRaytraceTriangleCallback());
     EXPECT_FALSE(skinned_mesh->HasRaytraceBvhCallback());
     EXPECT_EQ(skinned_mesh->GetBvhBufferId(), frame::NullId);
 }
 
-TEST_F(VulkanSkinnedRayTracingParseTest, FoxAnimationChangesRaytraceTriangles)
+TEST_F(VulkanSkinnedRayTracingParseTest, SkinnedMeshAnimationChangesRaytraceTriangles)
 {
     auto built = frame::vulkan::BuildLevel(
         glm::uvec2(512, 288),
@@ -772,13 +773,13 @@ TEST_F(VulkanSkinnedRayTracingParseTest, FoxAnimationChangesRaytraceTriangles)
     ASSERT_NE(built.level, nullptr);
     auto& level = *built.level;
 
-    const auto fox_node_id = level.GetIdFromName("FoxMesh");
-    ASSERT_NE(fox_node_id, frame::NullId);
-    auto& fox_node = level.GetSceneNodeFromId(fox_node_id);
-    const auto fox_mesh_id = fox_node.GetLocalMesh();
-    ASSERT_NE(fox_mesh_id, frame::NullId);
+    const auto mesh_node_id = level.GetIdFromName(kSkinnedMeshNodeName);
+    ASSERT_NE(mesh_node_id, frame::NullId);
+    auto& mesh_node = level.GetSceneNodeFromId(mesh_node_id);
+    const auto mesh_id = mesh_node.GetLocalMesh();
+    ASSERT_NE(mesh_id, frame::NullId);
     auto* skinned_mesh = dynamic_cast<frame::vulkan::SkinnedMesh*>(
-        &level.GetMeshFromId(fox_mesh_id));
+        &level.GetMeshFromId(mesh_id));
     ASSERT_NE(skinned_mesh, nullptr);
 
     const auto triangles_at_start =
@@ -800,9 +801,9 @@ TEST_F(VulkanSkinnedRayTracingParseTest, FoxAnimationChangesRaytraceTriangles)
     EXPECT_TRUE(found_difference);
 }
 
-TEST_F(VulkanSkinnedRayTracingParseTest, FoxBindPoseDisablesDynamicRaytraceCallbacks)
+TEST_F(VulkanSkinnedRayTracingParseTest, SkinnedMeshBindPoseDisablesDynamicRaytraceCallbacks)
 {
-    auto level_proto = LoadSkinnedMeshLevelProtoWithFoxAnimationEnabled(false);
+    auto level_proto = LoadSkinnedMeshLevelProtoWithSkinnedMeshAnimationEnabled(false);
     auto level_data = frame::json::ParseLevelData(
         glm::uvec2(512, 288),
         level_proto,
@@ -814,13 +815,13 @@ TEST_F(VulkanSkinnedRayTracingParseTest, FoxBindPoseDisablesDynamicRaytraceCallb
     ASSERT_NE(built.level, nullptr);
     auto& level = *built.level;
 
-    const auto fox_node_id = level.GetIdFromName("FoxMesh");
-    ASSERT_NE(fox_node_id, frame::NullId);
-    auto& fox_node = level.GetSceneNodeFromId(fox_node_id);
-    const auto fox_mesh_id = fox_node.GetLocalMesh();
-    ASSERT_NE(fox_mesh_id, frame::NullId);
+    const auto mesh_node_id = level.GetIdFromName(kSkinnedMeshNodeName);
+    ASSERT_NE(mesh_node_id, frame::NullId);
+    auto& mesh_node = level.GetSceneNodeFromId(mesh_node_id);
+    const auto mesh_id = mesh_node.GetLocalMesh();
+    ASSERT_NE(mesh_id, frame::NullId);
     auto* skinned_mesh = dynamic_cast<frame::vulkan::SkinnedMesh*>(
-        &level.GetMeshFromId(fox_mesh_id));
+        &level.GetMeshFromId(mesh_id));
     ASSERT_NE(skinned_mesh, nullptr);
 
     EXPECT_FALSE(skinned_mesh->IsSkinningAnimationEnabled());
@@ -836,7 +837,7 @@ TEST_F(VulkanSkinnedRayTracingParseTest, FoxBindPoseDisablesDynamicRaytraceCallb
     EXPECT_EQ(triangles_at_start, triangles_later);
 }
 
-TEST_F(VulkanSkinnedRayTracingParseTest, SceneMaterialUsesImportedFoxTextures)
+TEST_F(VulkanSkinnedRayTracingParseTest, SceneMaterialUsesImportedCharacterTextures)
 {
     auto built = frame::vulkan::BuildLevel(
         glm::uvec2(512, 288),
@@ -846,32 +847,34 @@ TEST_F(VulkanSkinnedRayTracingParseTest, SceneMaterialUsesImportedFoxTextures)
 
     const auto scene_material_id = level.GetIdFromName("RayTraceMaterial");
     ASSERT_NE(scene_material_id, frame::NullId);
-    const auto fox_material_id = FindMaterialForNode(
+    const auto mesh_material_id = FindMaterialForNode(
         level,
         frame::proto::NodeMesh::SCENE_RENDER_TIME,
-        "FoxMesh");
-    ASSERT_NE(fox_material_id, frame::NullId);
+        kSkinnedMeshNodeName);
+    ASSERT_NE(mesh_material_id, frame::NullId);
 
     const auto& scene_material = level.GetMaterialFromId(scene_material_id);
-    const auto& fox_material = level.GetMaterialFromId(fox_material_id);
+    const auto& mesh_material = level.GetMaterialFromId(mesh_material_id);
 
     const auto scene_albedo_id = FindTextureByInnerName(
         scene_material, "opaque_albedo_texture");
     const auto scene_normal_id = FindTextureByInnerName(
         scene_material, "opaque_normal_texture");
-    const auto fox_albedo_id = FindTextureByInnerName(
-        fox_material, "albedo_texture");
-    const auto fox_normal_id = FindTextureByInnerName(
-        fox_material, "normal_texture");
+    const auto mesh_albedo_id = FindTextureByInnerName(
+        mesh_material, "albedo_texture");
+    const auto mesh_normal_id = FindTextureByInnerName(
+        mesh_material, "normal_texture");
 
     ASSERT_NE(scene_albedo_id, frame::NullId);
-    ASSERT_NE(scene_normal_id, frame::NullId);
-    ASSERT_NE(fox_albedo_id, frame::NullId);
-    ASSERT_NE(fox_normal_id, frame::NullId);
-    EXPECT_EQ(scene_albedo_id, fox_albedo_id);
-    EXPECT_EQ(scene_normal_id, fox_normal_id);
-    EXPECT_GT(level.GetTextureFromId(fox_albedo_id).GetSize().x, 1u);
-    EXPECT_GT(level.GetTextureFromId(fox_albedo_id).GetSize().y, 1u);
+    ASSERT_NE(mesh_albedo_id, frame::NullId);
+    EXPECT_EQ(scene_albedo_id, mesh_albedo_id);
+    EXPECT_GT(level.GetTextureFromId(mesh_albedo_id).GetSize().x, 1u);
+    EXPECT_GT(level.GetTextureFromId(mesh_albedo_id).GetSize().y, 1u);
+    if (mesh_normal_id != frame::NullId)
+    {
+        ASSERT_NE(scene_normal_id, frame::NullId);
+        EXPECT_EQ(scene_normal_id, mesh_normal_id);
+    }
 }
 
 TEST_F(VulkanSkinnedRayTracingParseTest, QuaternionNodesStillRotate)


### PR DESCRIPTION
## Summary
- replace the fox skinned sample with a higher-detail Cesium Man asset
- fix skinned glTF import so helper transforms are not double-applied to skinned meshes
- correct the remaining skinning root handling for the CesiumMan hierarchy and update the sample tests/docs

## Details
The sample now uses `asset/model/cesium_man/CesiumMan.glb` in `asset/json/skinned_mesh.json` and the related docs/tests have been updated to stop assuming the old fox mesh and clip naming.

On the loader side, skinned meshes now stay in bind/local space instead of baking imported mesh transforms into the source vertices. The remaining CesiumMan pose issue was then fixed by stopping the extra global-inverse correction from being injected into the skinning path for this imported glTF hierarchy.

## Verification
- `FrameOpenGLTest --gtest_filter="SkinnedMeshTest.*:OpenGLRayTracingLevelTest.SkinnedMesh*"`
- `FrameVulkanTest --gtest_filter="VulkanSkinnedRayTracingParseTest.*"`
- `03_SkinnedMesh.exe --auto_exit_seconds=4` visual smoke check