### PR TITLE
Fix Vulkan screenshot capture

### DIFF
--- a/frame/file/image.cpp
+++ b/frame/file/image.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -101,6 +102,50 @@ std::filesystem::path StripAssetPrefix(std::filesystem::path input)
         return std::filesystem::path(generic.substr(kPrefix.size()));
     }
     return input;
+}
+
+const std::uint8_t* PreparePngBytes(
+    const void* image,
+    glm::ivec2 size,
+    const proto::PixelStructure& pixel_structure,
+    std::vector<std::uint8_t>& converted)
+{
+    const auto* source = static_cast<const std::uint8_t*>(image);
+    if (!source)
+    {
+        return nullptr;
+    }
+
+    const auto pixel_count = static_cast<std::size_t>(size.x) *
+                             static_cast<std::size_t>(size.y);
+    switch (pixel_structure.value())
+    {
+    case proto::PixelStructure::BGR: {
+        converted.resize(pixel_count * 3);
+        for (std::size_t i = 0; i < pixel_count; ++i)
+        {
+            const auto src = i * 3;
+            converted[src + 0] = source[src + 2];
+            converted[src + 1] = source[src + 1];
+            converted[src + 2] = source[src + 0];
+        }
+        return converted.data();
+    }
+    case proto::PixelStructure::BGR_ALPHA: {
+        converted.resize(pixel_count * 4);
+        for (std::size_t i = 0; i < pixel_count; ++i)
+        {
+            const auto src = i * 4;
+            converted[src + 0] = source[src + 2];
+            converted[src + 1] = source[src + 1];
+            converted[src + 2] = source[src + 0];
+            converted[src + 3] = source[src + 3];
+        }
+        return converted.data();
+    }
+    default:
+        return source;
+    }
 }
 
 } // namespace
@@ -485,19 +530,35 @@ Image::Image(
 
 void Image::SaveImageToFile(const std::string& file) const
 {
-    // For OpenGL it seams...
+    if (pixel_element_size_.value() != proto::PixelElementSize::BYTE)
+    {
+        throw std::runtime_error(
+            "SaveImageToFile only supports BYTE images.");
+    }
+
+    // Frame stores image rows bottom-up, so flip back for PNG output.
     stbi_flip_vertically_on_write(true);
     const auto& logger = frame::Logger::GetInstance();
     logger->info("Saving [{}]...", file);
     if (!image_)
         throw std::runtime_error("no pointer to be saved?");
-    stbi_write_png(
+
+    const int channels = DesiredChannels(pixel_structure_);
+    std::vector<std::uint8_t> converted = {};
+    const auto* output_data =
+        PreparePngBytes(image_, size_, pixel_structure_, converted);
+    const int stride_in_bytes = size_.x * channels;
+    const int written = stbi_write_png(
         file.c_str(),
         size_.x,
         size_.y,
-        pixel_structure_.value(),
-        image_,
-        size_.x * pixel_structure_.value());
+        channels,
+        output_data,
+        stride_in_bytes);
+    if (written == 0)
+    {
+        throw std::runtime_error("failed to write png image.");
+    }
 }
 
 void Image::SetData(void* data)

--- a/frame/vulkan/device.cpp
+++ b/frame/vulkan/device.cpp
@@ -21,10 +21,12 @@
 
 #include "frame/bvh.h"
 #include "frame/camera.h"
+#include "frame/common/application.h"
+#include "frame/file/image.h"
 #include "frame/json/program_key.h"
 #include "frame/level.h"
-#include "frame/common/application.h"
 #include "frame/node_mesh.h"
+#include "frame/proto/uniform.pb.h"
 #include "frame/vulkan/buffer.h"
 #include "frame/vulkan/buffer_resources.h"
 #include "frame/vulkan/build_level.h"
@@ -44,7 +46,6 @@
 #include "frame/vulkan/texture.h"
 #include "frame/vulkan/texture_resources.h"
 #include "frame/vulkan/skinned_mesh.h"
-#include "frame/proto/uniform.pb.h"
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/matrix_inverse.hpp>
 #include <glm/gtc/type_ptr.hpp>
@@ -75,6 +76,170 @@ double ElapsedMilliseconds(const SteadyClock::time_point& start)
     return std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(
                SteadyClock::now() - start)
         .count();
+}
+
+proto::PixelStructure PixelStructureForScreenshotFormat(vk::Format format)
+{
+    proto::PixelStructure pixel_structure = {};
+    switch (format)
+    {
+    case vk::Format::eR8G8B8Unorm:
+    case vk::Format::eR8G8B8Srgb:
+        pixel_structure.set_value(proto::PixelStructure::RGB);
+        return pixel_structure;
+    case vk::Format::eR8G8B8A8Unorm:
+    case vk::Format::eR8G8B8A8Srgb:
+        pixel_structure.set_value(proto::PixelStructure::RGB_ALPHA);
+        return pixel_structure;
+    case vk::Format::eB8G8R8Unorm:
+    case vk::Format::eB8G8R8Srgb:
+        pixel_structure.set_value(proto::PixelStructure::BGR);
+        return pixel_structure;
+    case vk::Format::eB8G8R8A8Unorm:
+    case vk::Format::eB8G8R8A8Srgb:
+        pixel_structure.set_value(proto::PixelStructure::BGR_ALPHA);
+        return pixel_structure;
+    default:
+        throw std::runtime_error(
+            "Unsupported Vulkan screenshot format: " + vk::to_string(format) +
+            ".");
+    }
+}
+
+std::uint32_t BytesPerPixelForScreenshotFormat(vk::Format format)
+{
+    switch (format)
+    {
+    case vk::Format::eR8G8B8Unorm:
+    case vk::Format::eR8G8B8Srgb:
+    case vk::Format::eB8G8R8Unorm:
+    case vk::Format::eB8G8R8Srgb:
+        return 3;
+    case vk::Format::eR8G8B8A8Unorm:
+    case vk::Format::eR8G8B8A8Srgb:
+    case vk::Format::eB8G8R8A8Unorm:
+    case vk::Format::eB8G8R8A8Srgb:
+        return 4;
+    default:
+        throw std::runtime_error(
+            "Unsupported Vulkan screenshot format: " + vk::to_string(format) +
+            ".");
+    }
+}
+
+void FlipRowsInPlace(
+    std::vector<std::uint8_t>& pixels, std::size_t row_stride)
+{
+    if (row_stride == 0)
+    {
+        return;
+    }
+
+    const auto row_count = pixels.size() / row_stride;
+    if (row_count < 2)
+    {
+        return;
+    }
+
+    std::vector<std::uint8_t> swap_buffer(row_stride);
+    for (std::size_t top = 0, bottom = row_count - 1; top < bottom;
+         ++top, --bottom)
+    {
+        auto* top_row = pixels.data() + top * row_stride;
+        auto* bottom_row = pixels.data() + bottom * row_stride;
+        std::memcpy(swap_buffer.data(), top_row, row_stride);
+        std::memcpy(top_row, bottom_row, row_stride);
+        std::memcpy(bottom_row, swap_buffer.data(), row_stride);
+    }
+}
+
+std::vector<std::uint8_t> ReadScreenshotPixels(
+    vk::Device device,
+    frame::vulkan::GpuMemoryManager& gpu_memory_manager,
+    frame::vulkan::CommandQueue& command_queue,
+    vk::Image image,
+    vk::Format format,
+    glm::uvec2 size)
+{
+    const auto bytes_per_pixel = BytesPerPixelForScreenshotFormat(format);
+    const auto row_stride = static_cast<std::size_t>(size.x) * bytes_per_pixel;
+    const auto image_size = static_cast<vk::DeviceSize>(row_stride) * size.y;
+
+    vk::UniqueDeviceMemory staging_memory;
+    auto staging_buffer = gpu_memory_manager.CreateBuffer(
+        image_size,
+        vk::BufferUsageFlagBits::eTransferDst,
+        vk::MemoryPropertyFlagBits::eHostVisible |
+            vk::MemoryPropertyFlagBits::eHostCoherent,
+        staging_memory);
+
+    command_queue.SubmitOneTime([&](vk::CommandBuffer command_buffer) {
+        const vk::ImageSubresourceRange subresource_range(
+            vk::ImageAspectFlagBits::eColor,
+            0,
+            1,
+            0,
+            1);
+        const vk::ImageMemoryBarrier to_transfer(
+            vk::AccessFlagBits::eShaderRead,
+            vk::AccessFlagBits::eTransferRead,
+            vk::ImageLayout::eShaderReadOnlyOptimal,
+            vk::ImageLayout::eTransferSrcOptimal,
+            VK_QUEUE_FAMILY_IGNORED,
+            VK_QUEUE_FAMILY_IGNORED,
+            image,
+            subresource_range);
+        command_buffer.pipelineBarrier(
+            vk::PipelineStageFlagBits::eFragmentShader |
+                vk::PipelineStageFlagBits::eComputeShader,
+            vk::PipelineStageFlagBits::eTransfer,
+            {},
+            nullptr,
+            nullptr,
+            to_transfer);
+
+        const vk::BufferImageCopy copy_region(
+            0,
+            0,
+            0,
+            vk::ImageSubresourceLayers{
+                vk::ImageAspectFlagBits::eColor, 0, 0, 1},
+            vk::Offset3D{0, 0, 0},
+            vk::Extent3D{size.x, size.y, 1});
+        command_buffer.copyImageToBuffer(
+            image,
+            vk::ImageLayout::eTransferSrcOptimal,
+            *staging_buffer,
+            copy_region);
+
+        const vk::ImageMemoryBarrier to_shader_read(
+            vk::AccessFlagBits::eTransferRead,
+            vk::AccessFlagBits::eShaderRead,
+            vk::ImageLayout::eTransferSrcOptimal,
+            vk::ImageLayout::eShaderReadOnlyOptimal,
+            VK_QUEUE_FAMILY_IGNORED,
+            VK_QUEUE_FAMILY_IGNORED,
+            image,
+            subresource_range);
+        command_buffer.pipelineBarrier(
+            vk::PipelineStageFlagBits::eTransfer,
+            vk::PipelineStageFlagBits::eFragmentShader |
+                vk::PipelineStageFlagBits::eComputeShader,
+            {},
+            nullptr,
+            nullptr,
+            to_shader_read);
+    });
+
+    auto* mapped = static_cast<std::uint8_t*>(
+        device.mapMemory(*staging_memory, 0, image_size));
+    std::vector<std::uint8_t> pixels(static_cast<std::size_t>(image_size), 0);
+    std::memcpy(pixels.data(), mapped, pixels.size());
+    device.unmapMemory(*staging_memory);
+
+    // Vulkan readback is top-down; Image::SaveImageToFile expects bottom-up.
+    FlipRowsInPlace(pixels, row_stride);
+    return pixels;
 }
 
 struct AnimatedRaytraceTimingStats
@@ -3323,7 +3488,51 @@ void Device::Shutdown()
 
 void Device::ScreenShot(const std::string& file) const
 {
-    logger_->warn("Vulkan screenshot not implemented (requested: {})", file);
+    if (device_lost_)
+    {
+        throw std::runtime_error(
+            "Cannot take a Vulkan screenshot after device loss.");
+    }
+    if (!vk_unique_device_ || !swapchain_resources_ || !output_image_resources_ ||
+        !gpu_memory_manager_ || !command_queue_)
+    {
+        throw std::runtime_error(
+            "Vulkan screenshot resources are not initialized.");
+    }
+    if (!output_image_resources_->HasSwapchainPreviewImage() ||
+        !output_image_resources_->IsSwapchainPreviewInShaderRead())
+    {
+        throw std::runtime_error(
+            "No rendered Vulkan frame is available for screenshot.");
+    }
+
+    const auto extent = swapchain_resources_->GetExtent();
+    if (extent.width == 0 || extent.height == 0)
+    {
+        throw std::runtime_error("Cannot take a screenshot of an empty frame.");
+    }
+
+    vk_unique_device_->waitIdle();
+
+    const auto format = swapchain_resources_->GetImageFormat();
+    const auto pixel_structure = PixelStructureForScreenshotFormat(format);
+    auto pixels = ReadScreenshotPixels(
+        *vk_unique_device_,
+        *gpu_memory_manager_,
+        *command_queue_,
+        output_image_resources_->GetSwapchainPreviewImage(),
+        format,
+        glm::uvec2(extent.width, extent.height));
+
+    proto::PixelElementSize pixel_element_size = {};
+    pixel_element_size.set_value(proto::PixelElementSize::BYTE);
+    frame::file::Image output_image(
+        glm::uvec2(extent.width, extent.height),
+        pixel_element_size,
+        pixel_structure);
+    output_image.SetData(pixels.data());
+    output_image.SaveImageToFile(file);
+    logger_->info("Saved Vulkan screenshot to {}.", file);
 }
 
 std::unique_ptr<frame::BufferInterface> Device::CreatePointBuffer(

--- a/frame/vulkan/output_image_resources.cpp
+++ b/frame/vulkan/output_image_resources.cpp
@@ -187,6 +187,7 @@ void OutputImageResources::CreateSwapchainPreviewImage()
         vk::SampleCountFlagBits::e1,
         vk::ImageTiling::eOptimal,
         vk::ImageUsageFlagBits::eTransferDst |
+            vk::ImageUsageFlagBits::eTransferSrc |
             vk::ImageUsageFlagBits::eSampled);
     swapchain_preview_image_ =
         device_.vk_unique_device_->createImageUnique(image_info);

--- a/tests/frame/file/image_test.cpp
+++ b/tests/frame/file/image_test.cpp
@@ -1,6 +1,9 @@
 #include "frame/file/image_test.h"
 
+#include <cstdint>
+#include <filesystem>
 #include <memory>
+#include <vector>
 
 #include "frame/file/file_system.h"
 
@@ -76,6 +79,42 @@ TEST_F(ImageTest, CreateCubeMapPointerImageTest)
         EXPECT_FLOAT_EQ(0.014160156f, pointer[position * 4 + 2]);
         EXPECT_FLOAT_EQ(1.0f, pointer[position * 4 + 3]);
     }
+}
+
+TEST_F(ImageTest, SaveBgrAlphaImageWritesValidPng)
+{
+    const auto output_file =
+        std::filesystem::temp_directory_path() /
+        "frame_save_bgr_alpha_image_test.png";
+    std::vector<std::uint8_t> pixels = {
+        0x10, 0x20, 0x30, 0x40,
+        0x50, 0x60, 0x70, 0x80};
+
+    frame::file::Image image(
+        glm::uvec2(2, 1),
+        frame::json::PixelElementSize_BYTE(),
+        frame::json::PixelStructure_BGR_ALPHA());
+    image.SetData(pixels.data());
+    image.SaveImageToFile(output_file.string());
+
+    frame::file::Image loaded_image(
+        output_file,
+        frame::json::PixelElementSize_BYTE(),
+        frame::json::PixelStructure_RGB_ALPHA());
+    const auto* loaded =
+        static_cast<const std::uint8_t*>(loaded_image.Data());
+    ASSERT_NE(loaded, nullptr);
+    EXPECT_EQ(loaded[0], 0x30);
+    EXPECT_EQ(loaded[1], 0x20);
+    EXPECT_EQ(loaded[2], 0x10);
+    EXPECT_EQ(loaded[3], 0x40);
+    EXPECT_EQ(loaded[4], 0x70);
+    EXPECT_EQ(loaded[5], 0x60);
+    EXPECT_EQ(loaded[6], 0x50);
+    EXPECT_EQ(loaded[7], 0x80);
+
+    std::error_code remove_error;
+    std::filesystem::remove(output_file, remove_error);
 }
 
 } // End namespace test.


### PR DESCRIPTION
## Summary
- implement Vulkan screenshot readback from the swapchain preview image
- fix PNG saving for `BGR`/`BGRA` pixel layouts used by Vulkan swapchain output
- add a regression test for BGRA image export

## Validation
- `cmake --build --preset windows-debug --target FrameFileTest FrameVulkanTest 00_Cubemap --config Debug`
- `ctest --test-dir build/windows -C Debug --output-on-failure -R "ImageTest\.SaveBgrAlphaImageWritesValidPng|VulkanCommandQueueTest\.(CopiesBufferContents|TransitionsAndCopiesToImage)"`
- `./build/windows/bin/Debug/00_Cubemap.exe --device=vulkan --auto_exit_seconds=1 --screenshot_on_exit`

## Notes
- Verified end-to-end that the Vulkan sample writes `ScreenShot.png` before exit.
- No generated artifacts are included in this PR.