### PR TITLE
Fix raytracing material texture selection

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ name: Linux CI
 
 on:
   push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -2,6 +2,7 @@ name: Windows CI
 
 on:
   push:
+    branches: [ master ]
   pull_request:
 
 jobs:
@@ -59,7 +60,9 @@ jobs:
       run: cmake --build --preset windows-debug --parallel
 
     - name: Run tests using CTest
-      run: ctest --test-dir build\windows -C Debug --output-on-failure
+      # GitHub-hosted Windows runners do not provide a reliable OpenGL 4.5
+      # context. Linux runs those tests under xvfb/Mesa.
+      run: ctest --test-dir build\windows -C Debug --output-on-failure -LE requires-opengl
 
     - name: Show sccache stats
       if: always()

--- a/asset/json/CMakeLists.txt
+++ b/asset/json/CMakeLists.txt
@@ -10,6 +10,7 @@ add_custom_target(AssetJson
     cubemap.json
     ray_marching.json
     raytracing.json
+    raytracing_multi_material.json
     dragon.json
     skinned_mesh.json
     renderer_test.json

--- a/asset/json/raytracing_multi_material.json
+++ b/asset/json/raytracing_multi_material.json
@@ -1,0 +1,160 @@
+{
+    "name": "RayTracingMultiMaterial",
+    "default_texture_name": "albedo",
+    "textures": [
+        {
+            "name": "albedo",
+            "size": {
+                "x": -1,
+                "y": -1
+            },
+            "pixel_element_size": {
+                "value": "BYTE"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            }
+        },
+        {
+            "name": "skybox",
+            "cubemap": true,
+            "pixel_element_size": {
+                "value": "FLOAT"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            },
+            "file_name": "asset/cubemap/hamarikyu.hdr"
+        },
+        {
+            "name": "skybox_env",
+            "cubemap": true,
+            "pixel_element_size": {
+                "value": "FLOAT"
+            },
+            "pixel_structure": {
+                "value": "RGB"
+            },
+            "file_name": "asset/cubemap/hamarikyu.hdr"
+        }
+    ],
+    "scene_tree": {
+        "default_camera_name": "camera",
+        "default_root_name": "root",
+        "node_matrices": [
+            {
+                "name": "root",
+                "matrix_type_enum": "STATIC_MATRIX",
+                "matrix": {
+                    "m11": 1,
+                    "m22": 1,
+                    "m33": 1,
+                    "m44": 1
+                }
+            },
+            {
+                "name": "env_holder",
+                "parent": "root",
+                "matrix_type_enum": "ROTATION_MATRIX",
+                "quaternion": {
+                    "x": 0.0,
+                    "y": 0.0499792,
+                    "z": 0.0,
+                    "w": 0.9987503
+                }
+            },
+            {
+                "name": "mesh_holder",
+                "parent": "env_holder",
+                "matrix_type_enum": "STATIC_MATRIX",
+                "quaternion": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0,
+                    "w": 1.0
+                }
+            },
+            {
+                "name": "glass_holder",
+                "parent": "mesh_holder",
+                "matrix_type_enum": "STATIC_MATRIX",
+                "matrix": {
+                    "m11": 1,
+                    "m22": 1,
+                    "m33": 1,
+                    "m41": 0.0,
+                    "m42": 1.4,
+                    "m43": -4.0,
+                    "m44": 1
+                }
+            }
+        ],
+        "node_cameras": [
+            {
+                "name": "camera",
+                "parent": "root",
+                "fov_degrees": 65.0,
+                "near_clip": 0.01,
+                "far_clip": 1000.0,
+                "position": {
+                    "x": 0.0,
+                    "y": 2.5,
+                    "z": -12.0
+                },
+                "target": {
+                    "x": 0.0,
+                    "y": 1.2,
+                    "z": 0.0
+                },
+                "up": {
+                    "x": 0.0,
+                    "y": 1.0,
+                    "z": 0.0
+                }
+            }
+        ],
+        "node_meshes": [
+            {
+                "name": "CubeMapMesh",
+                "parent": "env_holder",
+                "mesh_enum": "CUBE",
+                "render_time_enum": "SKYBOX_RENDER_TIME"
+            },
+            {
+                "name": "RayTracingRendering",
+                "parent": "root",
+                "mesh_enum": "QUAD"
+            },
+            {
+                "name": "Ico",
+                "parent": "glass_holder",
+                "file_name": "ico.glb",
+                "render_time_enum": "SCENE_RENDER_TIME"
+            },
+            {
+                "name": "TexturedScene",
+                "parent": "mesh_holder",
+                "file_name": "scene.glb",
+                "render_time_enum": "SCENE_RENDER_TIME"
+            }
+        ],
+        "node_lights": [
+            {
+                "name": "sun",
+                "parent": "root",
+                "light_type": "DIRECTIONAL_LIGHT",
+                "shadow_type": "HARD_SHADOW",
+                "direction": {
+                    "x": 1.0,
+                    "y": -1.0,
+                    "z": 0.0
+                },
+                "color": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            }
+        ]
+    }
+}

--- a/asset/shader/opengl/raytrace_triangle_copy.comp
+++ b/asset/shader/opengl/raytrace_triangle_copy.comp
@@ -22,6 +22,7 @@ layout(std430, binding = 1) writeonly buffer AggregateTriangleBuffer
 uniform int source_vertex_count;
 uniform int destination_vertex_offset;
 uniform vec4 color_multiplier;
+uniform vec4 atlas_uv_bounds;
 
 void main()
 {
@@ -34,6 +35,9 @@ void main()
     OutputVertex vertex = source_vertices[source_vertex_index];
     vertex.position_color0.w = color_multiplier.x;
     vertex.normal_color1.w = color_multiplier.y;
+    vertex.uv_color23.xy = vec2(
+        mix(atlas_uv_bounds.x, atlas_uv_bounds.y, clamp(vertex.uv_color23.x, 0.0, 1.0)),
+        mix(atlas_uv_bounds.z, atlas_uv_bounds.w, clamp(vertex.uv_color23.y, 0.0, 1.0)));
     vertex.uv_color23.z = color_multiplier.z;
     vertex.uv_color23.w = color_multiplier.w;
     aggregate_vertices[destination_vertex_offset + int(source_vertex_index)] =

--- a/asset/shader/vulkan/skinning.comp
+++ b/asset/shader/vulkan/skinning.comp
@@ -45,6 +45,7 @@ layout(push_constant, std430) uniform PushConstants
     uint pad1;
     uint pad2;
     vec4 color_multiplier;
+    vec4 atlas_uv_bounds;
 } pc;
 
 mat4 BuildSkinMatrix(const SourceVertex source_vertex)
@@ -104,8 +105,11 @@ void main()
     output_vertex.normal_color1 = vec4(
         normal,
         pc.color_multiplier.y);
+    const vec2 atlas_uv = vec2(
+        mix(pc.atlas_uv_bounds.x, pc.atlas_uv_bounds.y, clamp(source_vertex.uv.x, 0.0, 1.0)),
+        mix(pc.atlas_uv_bounds.z, pc.atlas_uv_bounds.w, clamp(source_vertex.uv.y, 0.0, 1.0)));
     output_vertex.uv_color23 = vec4(
-        source_vertex.uv.xy,
+        atlas_uv,
         pc.color_multiplier.z,
         pc.color_multiplier.w);
     output_vertices[output_vertex_index] = output_vertex;

--- a/frame/opengl/json/parse_scene_tree.cpp
+++ b/frame/opengl/json/parse_scene_tree.cpp
@@ -1,13 +1,18 @@
 #include "frame/opengl/json/parse_scene_tree.h"
 
+#include <algorithm>
 #include <array>
 #include <cctype>
+#include <cmath>
 #include <cstring>
 #include <format>
 #include <optional>
+#include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 
 #include "frame/file/file_system.h"
+#include "frame/json/parse_pixel.h"
 #include "frame/json/parse_uniform.h"
 #include "frame/json/program_key.h"
 #include "frame/logger.h"
@@ -316,6 +321,66 @@ std::string GetAutoMaterialName(
 
 constexpr const char* kRaytracingResolveNodeName = "RayTracingRendering";
 constexpr const char* kRaytracingResolveMaterialName = "RayTraceMaterial";
+
+struct RaytracingTextureMapping
+{
+    const char* source_name;
+    const char* fallback_name;
+    const char* target_name;
+};
+
+constexpr std::array<RaytracingTextureMapping, 7>
+    kOpaqueRaytracingTextureMappings = {{
+        {"albedo_texture", "Color", "opaque_albedo_texture"},
+        {"normal_texture", nullptr, "opaque_normal_texture"},
+        {"roughness_texture", nullptr, "opaque_roughness_texture"},
+        {"metallic_texture", nullptr, "opaque_metallic_texture"},
+        {"ao_texture", nullptr, "opaque_ao_texture"},
+        {"specular_factor_texture", nullptr, "opaque_specular_factor_texture"},
+        {"specular_color_texture", nullptr, "opaque_specular_color_texture"},
+    }};
+
+constexpr std::array<RaytracingTextureMapping, 10>
+    kTransmissiveRaytracingTextureMappings = {{
+        {"albedo_texture", "Color", "transmissive_albedo_texture"},
+        {"normal_texture", nullptr, "transmissive_normal_texture"},
+        {"roughness_texture", nullptr, "transmissive_roughness_texture"},
+        {"metallic_texture", nullptr, "transmissive_metallic_texture"},
+        {"ao_texture", nullptr, "transmissive_ao_texture"},
+        {"transmission_texture", nullptr, "transmissive_transmission_texture"},
+        {"ior_texture", nullptr, "transmissive_ior_texture"},
+        {"thickness_texture", nullptr, "transmissive_thickness_texture"},
+        {"attenuation_color_texture", nullptr, "transmissive_attenuation_color_texture"},
+        {"attenuation_distance_texture", nullptr, "transmissive_attenuation_distance_texture"},
+    }};
+
+struct RaytracingTextureAtlasLayout
+{
+    std::vector<EntityId> material_ids = {};
+    std::unordered_map<EntityId, std::uint32_t> slot_by_material_id = {};
+    std::uint32_t columns = 1u;
+    std::uint32_t rows = 1u;
+    std::uint32_t tile_width = 1u;
+    std::uint32_t tile_height = 1u;
+    std::uint32_t atlas_width = 1u;
+    std::uint32_t atlas_height = 1u;
+};
+
+std::string GetRaytracingAtlasTextureName(
+    LevelInterface& level,
+    EntityId material_id,
+    const std::string_view target_name)
+{
+    return std::format(
+        "{}.__raytrace_atlas_{}",
+        level.GetNameFromId(material_id),
+        target_name);
+}
+
+bool IsRaytracingAtlasTextureName(const std::string& texture_name)
+{
+    return texture_name.find(".__raytrace_atlas_") != std::string::npos;
+}
 
 bool EqualsIgnoreCaseAscii(
     const std::string& lhs, const std::string& rhs)
@@ -640,6 +705,519 @@ bool IsGeneratedGltfTextureName(const std::string& texture_name)
            texture_name.find(".__gltf_solid_") != std::string::npos;
 }
 
+std::array<float, 4> GetDefaultRaytracingTextureColor(
+    const std::string_view binding_name)
+{
+    if (binding_name.ends_with("normal_texture"))
+    {
+        return {0.5f, 0.5f, 1.0f, 1.0f};
+    }
+    if (binding_name.ends_with("metallic_texture") ||
+        binding_name.ends_with("transmission_texture") ||
+        binding_name.ends_with("thickness_texture"))
+    {
+        return {0.0f, 0.0f, 0.0f, 1.0f};
+    }
+    if (binding_name.ends_with("ior_texture"))
+    {
+        return {1.5f, 1.5f, 1.5f, 1.0f};
+    }
+    if (binding_name.ends_with("attenuation_distance_texture"))
+    {
+        return {1000000.0f, 1000000.0f, 1000000.0f, 1.0f};
+    }
+    return {1.0f, 1.0f, 1.0f, 1.0f};
+}
+
+EntityId ResolveRaytracingMappedTextureId(
+    const MaterialInterface& material,
+    const RaytracingTextureMapping& mapping)
+{
+    EntityId texture_id = FindTextureIdByInnerName(material, mapping.source_name);
+    if (!texture_id && mapping.fallback_name)
+    {
+        texture_id = FindTextureIdByInnerName(material, mapping.fallback_name);
+    }
+    return texture_id;
+}
+
+bool ShouldReplaceRaytracingSceneTextureBinding(
+    LevelInterface& level,
+    const MaterialInterface& material,
+    const std::string_view target_name)
+{
+    const EntityId texture_id = FindTextureIdByInnerName(
+        material,
+        std::string(target_name));
+    if (texture_id == NullId)
+    {
+        return true;
+    }
+
+    const auto texture_name = level.GetNameFromId(texture_id);
+    const auto& texture = level.GetTextureFromId(texture_id);
+    return IsGeneratedGltfTextureName(texture_name) ||
+           IsRaytracingAtlasTextureName(texture_name) ||
+           !texture.SerializeEnable() ||
+           texture_name.find(".__raytrace_default_") != std::string::npos;
+}
+
+template <typename MappingArray>
+std::vector<EntityId> GatherRaytracingAtlasMaterialIds(
+    LevelInterface& level,
+    bool transmissive,
+    const MappingArray& mappings)
+{
+    (void)mappings;
+    std::vector<EntityId> material_ids = {};
+    std::unordered_set<EntityId> seen_material_ids = {};
+    for (const auto& [source_node_id, source_material_id] :
+         GetRaytracingSourceMeshMaterials(level))
+    {
+        (void)source_node_id;
+        if (IsTransmissiveRaytracingSourceMaterial(level, source_material_id) !=
+                transmissive ||
+            !source_material_id ||
+            !seen_material_ids.insert(source_material_id).second)
+        {
+            continue;
+        }
+        material_ids.push_back(source_material_id);
+    }
+    return material_ids;
+}
+
+template <typename MappingArray>
+std::optional<RaytracingTextureAtlasLayout> BuildRaytracingTextureAtlasLayout(
+    LevelInterface& level,
+    bool transmissive,
+    const MappingArray& mappings)
+{
+    auto material_ids = GatherRaytracingAtlasMaterialIds(
+        level,
+        transmissive,
+        mappings);
+    if (material_ids.size() <= 1u)
+    {
+        return std::nullopt;
+    }
+
+    RaytracingTextureAtlasLayout layout = {};
+    layout.material_ids = std::move(material_ids);
+    for (std::size_t i = 0; i < layout.material_ids.size(); ++i)
+    {
+        layout.slot_by_material_id.emplace(
+            layout.material_ids[i],
+            static_cast<std::uint32_t>(i));
+    }
+
+    for (const auto material_id : layout.material_ids)
+    {
+        const auto& material = level.GetMaterialFromId(material_id);
+        for (const auto& mapping : mappings)
+        {
+            const EntityId texture_id = ResolveRaytracingMappedTextureId(
+                material,
+                mapping);
+            if (!texture_id)
+            {
+                continue;
+            }
+            const auto size = level.GetTextureFromId(texture_id).GetSize();
+            layout.tile_width = std::max(layout.tile_width, std::max(1u, size.x));
+            layout.tile_height = std::max(
+                layout.tile_height,
+                std::max(1u, size.y));
+        }
+    }
+
+    const auto material_count = static_cast<double>(layout.material_ids.size());
+    layout.columns = std::max(
+        1u,
+        static_cast<std::uint32_t>(std::ceil(std::sqrt(material_count))));
+    layout.rows = std::max(
+        1u,
+        static_cast<std::uint32_t>(
+            (layout.material_ids.size() + layout.columns - 1u) /
+            layout.columns));
+    layout.atlas_width = std::max(1u, layout.columns * layout.tile_width);
+    layout.atlas_height = std::max(1u, layout.rows * layout.tile_height);
+    return layout;
+}
+
+std::array<float, 4> GetRaytracingAtlasUvBounds(
+    const RaytracingTextureAtlasLayout& layout,
+    EntityId material_id)
+{
+    const auto it = layout.slot_by_material_id.find(material_id);
+    if (it == layout.slot_by_material_id.end())
+    {
+        return {0.0f, 1.0f, 0.0f, 1.0f};
+    }
+
+    const std::uint32_t slot = it->second;
+    const std::uint32_t column = slot % layout.columns;
+    const std::uint32_t row = slot / layout.columns;
+    const float atlas_width = static_cast<float>(layout.atlas_width);
+    const float atlas_height = static_cast<float>(layout.atlas_height);
+    const float u0 =
+        (static_cast<float>(column * layout.tile_width) + 0.5f) / atlas_width;
+    const float u1 =
+        (static_cast<float>((column + 1u) * layout.tile_width) - 0.5f) /
+        atlas_width;
+    const float v0 =
+        (static_cast<float>(row * layout.tile_height) + 0.5f) / atlas_height;
+    const float v1 =
+        (static_cast<float>((row + 1u) * layout.tile_height) - 0.5f) /
+        atlas_height;
+    return {u0, std::max(u0, u1), v0, std::max(v0, v1)};
+}
+
+std::vector<float> RemapRaytracingAtlasUvs(
+    const std::vector<float>& textures,
+    const std::optional<RaytracingTextureAtlasLayout>& layout,
+    EntityId material_id)
+{
+    if (!layout || textures.empty() ||
+        !layout->slot_by_material_id.contains(material_id))
+    {
+        return textures;
+    }
+
+    const auto bounds = GetRaytracingAtlasUvBounds(*layout, material_id);
+    std::vector<float> remapped = textures;
+    for (std::size_t i = 0; i + 1u < remapped.size(); i += 2u)
+    {
+        const float u = std::clamp(remapped[i], 0.0f, 1.0f);
+        const float v = std::clamp(remapped[i + 1u], 0.0f, 1.0f);
+        remapped[i] = bounds[0] + (bounds[1] - bounds[0]) * u;
+        remapped[i + 1u] = bounds[2] + (bounds[3] - bounds[2]) * v;
+    }
+    return remapped;
+}
+
+template <typename SampleType>
+std::vector<float> ConvertTextureDataToFloatRgba(
+    const std::vector<SampleType>& data,
+    std::size_t pixel_count,
+    frame::proto::PixelStructure::Enum structure,
+    float scale)
+{
+    std::vector<float> rgba(pixel_count * 4u, 1.0f);
+    std::size_t channel_count = 4u;
+    switch (structure)
+    {
+    case frame::proto::PixelStructure::GREY:
+        channel_count = 1u;
+        break;
+    case frame::proto::PixelStructure::GREY_ALPHA:
+        channel_count = 2u;
+        break;
+    case frame::proto::PixelStructure::RGB:
+    case frame::proto::PixelStructure::BGR:
+        channel_count = 3u;
+        break;
+    case frame::proto::PixelStructure::RGB_ALPHA:
+    case frame::proto::PixelStructure::BGR_ALPHA:
+    default:
+        channel_count = 4u;
+        break;
+    }
+    if (data.size() < pixel_count * channel_count)
+    {
+        return rgba;
+    }
+
+    for (std::size_t pixel = 0; pixel < pixel_count; ++pixel)
+    {
+        const std::size_t src = pixel * channel_count;
+        const auto sample = [&](std::size_t index) {
+            return static_cast<float>(data[src + index]) / scale;
+        };
+
+        float red = 1.0f;
+        float green = 1.0f;
+        float blue = 1.0f;
+        float alpha = 1.0f;
+        switch (structure)
+        {
+        case frame::proto::PixelStructure::GREY:
+            red = green = blue = sample(0u);
+            break;
+        case frame::proto::PixelStructure::GREY_ALPHA:
+            red = green = blue = sample(0u);
+            alpha = sample(1u);
+            break;
+        case frame::proto::PixelStructure::RGB:
+            red = sample(0u);
+            green = sample(1u);
+            blue = sample(2u);
+            break;
+        case frame::proto::PixelStructure::RGB_ALPHA:
+            red = sample(0u);
+            green = sample(1u);
+            blue = sample(2u);
+            alpha = sample(3u);
+            break;
+        case frame::proto::PixelStructure::BGR:
+            red = sample(2u);
+            green = sample(1u);
+            blue = sample(0u);
+            break;
+        case frame::proto::PixelStructure::BGR_ALPHA:
+            red = sample(2u);
+            green = sample(1u);
+            blue = sample(0u);
+            alpha = sample(3u);
+            break;
+        default:
+            break;
+        }
+
+        const std::size_t dst = pixel * 4u;
+        rgba[dst + 0u] = red;
+        rgba[dst + 1u] = green;
+        rgba[dst + 2u] = blue;
+        rgba[dst + 3u] = alpha;
+    }
+    return rgba;
+}
+
+std::vector<float> ConvertTextureToFloatRgba(TextureInterface& texture)
+{
+    const auto size = texture.GetSize();
+    const std::size_t pixel_count =
+        static_cast<std::size_t>(size.x) * size.y;
+    const auto structure = texture.GetData().pixel_structure().value();
+    switch (texture.GetData().pixel_element_size().value())
+    {
+    case frame::proto::PixelElementSize::FLOAT:
+        return ConvertTextureDataToFloatRgba(
+            texture.GetTextureFloat(),
+            pixel_count,
+            structure,
+            1.0f);
+    case frame::proto::PixelElementSize::SHORT:
+    case frame::proto::PixelElementSize::HALF:
+        return ConvertTextureDataToFloatRgba(
+            texture.GetTextureWord(),
+            pixel_count,
+            structure,
+            65535.0f);
+    case frame::proto::PixelElementSize::BYTE:
+    default:
+        return ConvertTextureDataToFloatRgba(
+            texture.GetTextureByte(),
+            pixel_count,
+            structure,
+            255.0f);
+    }
+}
+
+void FillRaytracingAtlasTile(
+    std::vector<float>& atlas_pixels,
+    const RaytracingTextureAtlasLayout& layout,
+    std::uint32_t slot,
+    const std::array<float, 4>& color)
+{
+    const std::uint32_t column = slot % layout.columns;
+    const std::uint32_t row = slot / layout.columns;
+    const std::uint32_t start_x = column * layout.tile_width;
+    const std::uint32_t start_y = row * layout.tile_height;
+    for (std::uint32_t y = 0; y < layout.tile_height; ++y)
+    {
+        for (std::uint32_t x = 0; x < layout.tile_width; ++x)
+        {
+            const std::size_t dst =
+                (static_cast<std::size_t>(start_y + y) * layout.atlas_width +
+                 (start_x + x)) *
+                4u;
+            atlas_pixels[dst + 0u] = color[0];
+            atlas_pixels[dst + 1u] = color[1];
+            atlas_pixels[dst + 2u] = color[2];
+            atlas_pixels[dst + 3u] = color[3];
+        }
+    }
+}
+
+void CopyTextureIntoRaytracingAtlas(
+    std::vector<float>& atlas_pixels,
+    const RaytracingTextureAtlasLayout& layout,
+    std::uint32_t slot,
+    TextureInterface& texture)
+{
+    const auto size = texture.GetSize();
+    if (size.x == 0u || size.y == 0u)
+    {
+        return;
+    }
+
+    const auto rgba = ConvertTextureToFloatRgba(texture);
+    const std::uint32_t column = slot % layout.columns;
+    const std::uint32_t row = slot / layout.columns;
+    const std::uint32_t start_x = column * layout.tile_width;
+    const std::uint32_t start_y = row * layout.tile_height;
+    for (std::uint32_t y = 0; y < layout.tile_height; ++y)
+    {
+        const std::uint32_t source_y = std::min(
+            size.y - 1u,
+            static_cast<std::uint32_t>(
+                (static_cast<std::uint64_t>(y) * size.y) /
+                layout.tile_height));
+        for (std::uint32_t x = 0; x < layout.tile_width; ++x)
+        {
+            const std::uint32_t source_x = std::min(
+                size.x - 1u,
+                static_cast<std::uint32_t>(
+                    (static_cast<std::uint64_t>(x) * size.x) /
+                    layout.tile_width));
+            const std::size_t src =
+                (static_cast<std::size_t>(source_y) * size.x + source_x) * 4u;
+            const std::size_t dst =
+                (static_cast<std::size_t>(start_y + y) * layout.atlas_width +
+                 (start_x + x)) *
+                4u;
+            atlas_pixels[dst + 0u] = rgba[src + 0u];
+            atlas_pixels[dst + 1u] = rgba[src + 1u];
+            atlas_pixels[dst + 2u] = rgba[src + 2u];
+            atlas_pixels[dst + 3u] = rgba[src + 3u];
+        }
+    }
+}
+
+EntityId CreateRaytracingAtlasTexture(
+    LevelInterface& level,
+    const std::string& texture_name,
+    const RaytracingTextureAtlasLayout& layout,
+    const std::vector<float>& atlas_pixels)
+{
+    frame::proto::Texture proto_texture;
+    proto_texture.set_name(texture_name);
+    proto_texture.mutable_pixel_element_size()->CopyFrom(
+        frame::json::PixelElementSize_FLOAT());
+    proto_texture.mutable_pixel_structure()->CopyFrom(
+        frame::json::PixelStructure_RGB_ALPHA());
+    proto_texture.mutable_size()->set_x(static_cast<int>(layout.atlas_width));
+    proto_texture.mutable_size()->set_y(static_cast<int>(layout.atlas_height));
+    proto_texture.set_pixels(
+        reinterpret_cast<const char*>(atlas_pixels.data()),
+        static_cast<int>(atlas_pixels.size() * sizeof(float)));
+
+    auto atlas_texture = frame::json::ParseTexture(
+        proto_texture,
+        {layout.atlas_width, layout.atlas_height});
+    atlas_texture->SetName(texture_name);
+    atlas_texture->SetSerializeEnable(false);
+    return level.AddTexture(std::move(atlas_texture));
+}
+
+template <typename MappingArray>
+bool BuildAndBindRaytracingTextureAtlases(
+    LevelInterface& level,
+    EntityId scene_material_id,
+    const MappingArray& mappings,
+    bool transmissive)
+{
+    if (!scene_material_id)
+    {
+        return false;
+    }
+
+    auto layout = BuildRaytracingTextureAtlasLayout(
+        level,
+        transmissive,
+        mappings);
+    if (!layout)
+    {
+        return false;
+    }
+
+    auto& scene_material = level.GetMaterialFromId(scene_material_id);
+    for (const auto& mapping : mappings)
+    {
+        if (!ShouldReplaceRaytracingSceneTextureBinding(
+                level,
+                scene_material,
+                mapping.target_name))
+        {
+            return false;
+        }
+    }
+
+    for (const auto& mapping : mappings)
+    {
+        std::vector<float> atlas_pixels(
+            static_cast<std::size_t>(layout->atlas_width) *
+                layout->atlas_height * 4u,
+            0.0f);
+        const auto fallback_color = GetDefaultRaytracingTextureColor(
+            mapping.target_name);
+        for (const auto material_id : layout->material_ids)
+        {
+            const std::uint32_t slot = layout->slot_by_material_id.at(material_id);
+            const auto& source_material = level.GetMaterialFromId(material_id);
+            const EntityId texture_id = ResolveRaytracingMappedTextureId(
+                source_material,
+                mapping);
+            if (!texture_id)
+            {
+                FillRaytracingAtlasTile(
+                    atlas_pixels,
+                    *layout,
+                    slot,
+                    fallback_color);
+                continue;
+            }
+
+            auto& texture = level.GetTextureFromId(texture_id);
+            CopyTextureIntoRaytracingAtlas(
+                atlas_pixels,
+                *layout,
+                slot,
+                texture);
+        }
+
+        const auto atlas_texture_id = CreateRaytracingAtlasTexture(
+            level,
+            GetRaytracingAtlasTextureName(
+                level,
+                scene_material_id,
+                mapping.target_name),
+            *layout,
+            atlas_pixels);
+        ReplaceTextureBindingByInnerName(
+            level,
+            scene_material,
+            mapping.target_name,
+            atlas_texture_id);
+    }
+    return true;
+}
+
+bool HasBoundRaytracingTextureAtlas(
+    LevelInterface& level,
+    EntityId scene_material_id,
+    bool transmissive)
+{
+    if (!scene_material_id)
+    {
+        return false;
+    }
+
+    const auto& scene_material = level.GetMaterialFromId(scene_material_id);
+    const auto target_name = transmissive
+        ? "transmissive_albedo_texture"
+        : "opaque_albedo_texture";
+    const EntityId texture_id = FindTextureIdByInnerName(
+        scene_material,
+        target_name);
+    if (!texture_id)
+    {
+        return false;
+    }
+    return IsRaytracingAtlasTextureName(level.GetNameFromId(texture_id));
+}
+
 bool IsTransmissiveRaytracingSourceMaterial(
     LevelInterface& level, EntityId material_id)
 {
@@ -669,35 +1247,6 @@ void AdoptRaytracingSceneTextures(
     auto& source = level.GetMaterialFromId(source_material_id);
     auto& target = level.GetMaterialFromId(target_material_id);
 
-    struct Mapping
-    {
-        const char* source_name;
-        const char* fallback_name;
-        const char* target_name;
-    };
-
-    const std::array<Mapping, 7> opaque_mappings = {{
-        {"albedo_texture", "Color", "opaque_albedo_texture"},
-        {"normal_texture", nullptr, "opaque_normal_texture"},
-        {"roughness_texture", nullptr, "opaque_roughness_texture"},
-        {"metallic_texture", nullptr, "opaque_metallic_texture"},
-        {"ao_texture", nullptr, "opaque_ao_texture"},
-        {"specular_factor_texture", nullptr, "opaque_specular_factor_texture"},
-        {"specular_color_texture", nullptr, "opaque_specular_color_texture"},
-    }};
-    const std::array<Mapping, 10> transmissive_mappings = {{
-        {"albedo_texture", "Color", "transmissive_albedo_texture"},
-        {"normal_texture", nullptr, "transmissive_normal_texture"},
-        {"roughness_texture", nullptr, "transmissive_roughness_texture"},
-        {"metallic_texture", nullptr, "transmissive_metallic_texture"},
-        {"ao_texture", nullptr, "transmissive_ao_texture"},
-        {"transmission_texture", nullptr, "transmissive_transmission_texture"},
-        {"ior_texture", nullptr, "transmissive_ior_texture"},
-        {"thickness_texture", nullptr, "transmissive_thickness_texture"},
-        {"attenuation_color_texture", nullptr, "transmissive_attenuation_color_texture"},
-        {"attenuation_distance_texture", nullptr, "transmissive_attenuation_distance_texture"},
-    }};
-
     const auto copy_mapping =
         [&](const char* source_name,
             const char* fallback_name,
@@ -711,21 +1260,12 @@ void AdoptRaytracingSceneTextures(
             {
                 return;
             }
-            const EntityId existing_target_id =
-                FindTextureIdByInnerName(target, target_name);
-            if (existing_target_id != NullId)
+            if (!ShouldReplaceRaytracingSceneTextureBinding(
+                    level,
+                    target,
+                    target_name))
             {
-                const auto existing_target_texture_name =
-                    level.GetNameFromId(existing_target_id);
-                const auto& existing_target_texture =
-                    level.GetTextureFromId(existing_target_id);
-                const bool replace_generated_target =
-                    IsGeneratedGltfTextureName(existing_target_texture_name) ||
-                    !existing_target_texture.SerializeEnable();
-                if (!replace_generated_target)
-                {
-                    return;
-                }
+                return;
             }
             ReplaceTextureBindingByInnerName(
                 level, target, target_name, source_id);
@@ -733,7 +1273,7 @@ void AdoptRaytracingSceneTextures(
 
     if (transmissive)
     {
-        for (const auto& mapping : transmissive_mappings)
+        for (const auto& mapping : kTransmissiveRaytracingTextureMappings)
         {
             copy_mapping(
                 mapping.source_name,
@@ -742,7 +1282,7 @@ void AdoptRaytracingSceneTextures(
         }
         return;
     }
-    for (const auto& mapping : opaque_mappings)
+    for (const auto& mapping : kOpaqueRaytracingTextureMappings)
     {
         copy_mapping(
             mapping.source_name,
@@ -878,6 +1418,7 @@ struct RaytraceAggregateBuffers
 
 RaytraceAggregateBuffers BuildRaytraceAggregateBuffers(
     LevelInterface& level,
+    EntityId scene_material_id,
     bool transmissive,
     const std::string& base_name)
 {
@@ -888,6 +1429,20 @@ RaytraceAggregateBuffers BuildRaytraceAggregateBuffers(
     std::vector<std::uint32_t> aggregate_indices = {};
     const auto reference_color =
         ResolveRaytracingReferenceColor(level, transmissive);
+    const auto atlas_layout = HasBoundRaytracingTextureAtlas(
+        level,
+        scene_material_id,
+        transmissive)
+        ? (transmissive
+               ? BuildRaytracingTextureAtlasLayout(
+                     level,
+                     true,
+                     kTransmissiveRaytracingTextureMappings)
+               : BuildRaytracingTextureAtlasLayout(
+                     level,
+                     false,
+                     kOpaqueRaytracingTextureMappings))
+        : std::nullopt;
 
     for (const auto& [source_node_id, source_material_id] :
          GetRaytracingSourceMeshMaterials(level))
@@ -937,6 +1492,10 @@ RaytraceAggregateBuffers BuildRaytraceAggregateBuffers(
         {
             continue;
         }
+        const auto remapped_textures = RemapRaytracingAtlasUvs(
+            textures,
+            atlas_layout,
+            source_material_id);
         const auto source_color = ResolveRaytracingSourceMaterialColor(
             level, source_material_id);
         const auto color_multiplier = ResolveRaytracingColorMultiplier(
@@ -953,8 +1512,8 @@ RaytraceAggregateBuffers BuildRaytraceAggregateBuffers(
             normals.end());
         aggregate_textures.insert(
             aggregate_textures.end(),
-            textures.begin(),
-            textures.end());
+            remapped_textures.begin(),
+            remapped_textures.end());
         for (const auto index : indices)
         {
             aggregate_indices.push_back(base_index + index);
@@ -962,7 +1521,7 @@ RaytraceAggregateBuffers BuildRaytraceAggregateBuffers(
         const auto mesh_triangles = BuildRaytraceTriangles(
             points,
             normals,
-            textures,
+            remapped_textures,
             indices,
             color_multiplier);
         aggregate_triangles.insert(
@@ -1064,8 +1623,16 @@ void FinalizeRaytracingSceneMaterials(LevelInterface& level)
             continue;
         }
 
-        bool adopted_transmissive = false;
-        bool adopted_opaque = false;
+        bool adopted_transmissive = BuildAndBindRaytracingTextureAtlases(
+            level,
+            scene_material_id,
+            kTransmissiveRaytracingTextureMappings,
+            true);
+        bool adopted_opaque = BuildAndBindRaytracingTextureAtlases(
+            level,
+            scene_material_id,
+            kOpaqueRaytracingTextureMappings,
+            false);
         for (const auto& [source_node_id, source_material_id] :
              GetRaytracingSourceMeshMaterials(level))
         {
@@ -1101,10 +1668,12 @@ void FinalizeRaytracingSceneMaterials(LevelInterface& level)
             std::format("{}.scene", scene_material.GetData().name());
         const auto transmissive_buffers = BuildRaytraceAggregateBuffers(
             level,
+            scene_material_id,
             true,
             buffer_base_name + "_transmissive");
         const auto opaque_buffers = BuildRaytraceAggregateBuffers(
             level,
+            scene_material_id,
             false,
             buffer_base_name + "_opaque");
         scene_material.AddBufferName(

--- a/frame/opengl/renderer.cpp
+++ b/frame/opengl/renderer.cpp
@@ -15,6 +15,7 @@
 #include <glm/gtc/type_ptr.hpp>
 #include <numeric>
 #include <stdexcept>
+#include <unordered_map>
 
 #include "frame/bvh.h"
 #include "frame/file/file_system.h"
@@ -431,6 +432,152 @@ std::array<float, 4> ResolveRaytracingColorMultiplier(
     return multiplier;
 }
 
+struct RaytracingTextureMapping
+{
+    const char* source_name;
+    const char* fallback_name;
+    const char* target_name;
+};
+
+constexpr std::array<RaytracingTextureMapping, 7>
+    kOpaqueRaytracingTextureMappings = {{
+        {"albedo_texture", "Color", "opaque_albedo_texture"},
+        {"normal_texture", nullptr, "opaque_normal_texture"},
+        {"roughness_texture", nullptr, "opaque_roughness_texture"},
+        {"metallic_texture", nullptr, "opaque_metallic_texture"},
+        {"ao_texture", nullptr, "opaque_ao_texture"},
+        {"specular_factor_texture", nullptr, "opaque_specular_factor_texture"},
+        {"specular_color_texture", nullptr, "opaque_specular_color_texture"},
+    }};
+
+constexpr std::array<RaytracingTextureMapping, 10>
+    kTransmissiveRaytracingTextureMappings = {{
+        {"albedo_texture", "Color", "transmissive_albedo_texture"},
+        {"normal_texture", nullptr, "transmissive_normal_texture"},
+        {"roughness_texture", nullptr, "transmissive_roughness_texture"},
+        {"metallic_texture", nullptr, "transmissive_metallic_texture"},
+        {"ao_texture", nullptr, "transmissive_ao_texture"},
+        {"transmission_texture", nullptr, "transmissive_transmission_texture"},
+        {"ior_texture", nullptr, "transmissive_ior_texture"},
+        {"thickness_texture", nullptr, "transmissive_thickness_texture"},
+        {"attenuation_color_texture", nullptr, "transmissive_attenuation_color_texture"},
+        {"attenuation_distance_texture", nullptr, "transmissive_attenuation_distance_texture"},
+    }};
+
+struct RaytracingTextureAtlasLayout
+{
+    std::vector<frame::EntityId> material_ids = {};
+    std::unordered_map<frame::EntityId, std::uint32_t> slot_by_material_id = {};
+    std::uint32_t columns = 1u;
+    std::uint32_t rows = 1u;
+    std::uint32_t tile_width = 1u;
+    std::uint32_t tile_height = 1u;
+    std::uint32_t atlas_width = 1u;
+    std::uint32_t atlas_height = 1u;
+};
+
+frame::EntityId ResolveRaytracingMappedTextureId(
+    const frame::MaterialInterface& material,
+    const RaytracingTextureMapping& mapping)
+{
+    auto texture_id = FindTextureIdByInnerName(material, mapping.source_name);
+    if (!texture_id && mapping.fallback_name)
+    {
+        texture_id = FindTextureIdByInnerName(material, mapping.fallback_name);
+    }
+    return texture_id;
+}
+
+template <typename MappingArray>
+std::optional<RaytracingTextureAtlasLayout> BuildRaytracingTextureAtlasLayout(
+    frame::LevelInterface& level,
+    bool transmissive,
+    const MappingArray& mappings)
+{
+    std::vector<frame::EntityId> material_ids = {};
+    std::unordered_set<frame::EntityId> seen_material_ids = {};
+    for (const auto& [source_node_id, source_material_id] :
+         GetRaytracingSourceMeshMaterials(level))
+    {
+        (void)source_node_id;
+        if (IsTransmissiveMaterial(level, source_material_id) != transmissive ||
+            !source_material_id ||
+            !seen_material_ids.insert(source_material_id).second)
+        {
+            continue;
+        }
+        material_ids.push_back(source_material_id);
+    }
+    if (material_ids.size() <= 1u)
+    {
+        return std::nullopt;
+    }
+
+    RaytracingTextureAtlasLayout layout = {};
+    layout.material_ids = std::move(material_ids);
+    for (std::size_t i = 0; i < layout.material_ids.size(); ++i)
+    {
+        layout.slot_by_material_id.emplace(
+            layout.material_ids[i],
+            static_cast<std::uint32_t>(i));
+    }
+
+    for (const auto material_id : layout.material_ids)
+    {
+        const auto& material = level.GetMaterialFromId(material_id);
+        for (const auto& mapping : mappings)
+        {
+            const auto texture_id = ResolveRaytracingMappedTextureId(
+                material,
+                mapping);
+            if (!texture_id)
+            {
+                continue;
+            }
+            const auto size = level.GetTextureFromId(texture_id).GetSize();
+            layout.tile_width = std::max(layout.tile_width, std::max(1u, size.x));
+            layout.tile_height = std::max(
+                layout.tile_height,
+                std::max(1u, size.y));
+        }
+    }
+
+    const auto material_count = static_cast<double>(layout.material_ids.size());
+    layout.columns = std::max(
+        1u,
+        static_cast<std::uint32_t>(std::ceil(std::sqrt(material_count))));
+    layout.rows = std::max(
+        1u,
+        static_cast<std::uint32_t>(
+            (layout.material_ids.size() + layout.columns - 1u) /
+            layout.columns));
+    layout.atlas_width = std::max(1u, layout.columns * layout.tile_width);
+    layout.atlas_height = std::max(1u, layout.rows * layout.tile_height);
+    return layout;
+}
+
+bool HasBoundRaytracingTextureAtlas(
+    frame::LevelInterface& level,
+    bool transmissive)
+{
+    const auto scene_material_id = level.GetIdFromName("RayTraceMaterial");
+    if (scene_material_id == frame::NullId)
+    {
+        return false;
+    }
+    const auto& scene_material = level.GetMaterialFromId(scene_material_id);
+    const auto* target_name = transmissive
+        ? "transmissive_albedo_texture"
+        : "opaque_albedo_texture";
+    const auto texture_id = FindTextureIdByInnerName(scene_material, target_name);
+    if (texture_id == frame::NullId)
+    {
+        return false;
+    }
+    return level.GetNameFromId(texture_id).find(".__raytrace_atlas_") !=
+        std::string::npos;
+}
+
 template <typename T>
 std::vector<T> ReadTypedBufferData(const opengl::Buffer& buffer)
 {
@@ -514,7 +661,11 @@ struct RaytracingSourceGeometryData
     std::uint32_t bvh_node_offset = 0u;
     std::uint32_t bvh_node_count = 0u;
     std::array<float, 4> color_multiplier = {1.0f, 1.0f, 1.0f, 1.0f};
+    std::array<float, 4> atlas_uv_bounds = {0.0f, 1.0f, 0.0f, 1.0f};
 };
+
+std::array<float, 4> GetRaytracingAtlasUvBounds(
+    const RaytracingTextureAtlasLayout& layout, EntityId material_id);
 
 std::uint64_t BuildSourceGeometryKey(
     EntityId source_node_id, EntityId source_material_id)
@@ -527,6 +678,20 @@ std::vector<RaytracingSourceGeometryData> BuildRaytracingSourceGeometryData(
     frame::LevelInterface& level)
 {
     std::vector<RaytracingSourceGeometryData> geometries = {};
+    const auto transmissive_atlas_layout =
+        HasBoundRaytracingTextureAtlas(level, true)
+            ? BuildRaytracingTextureAtlasLayout(
+                  level,
+                  true,
+                  kTransmissiveRaytracingTextureMappings)
+            : std::nullopt;
+    const auto opaque_atlas_layout =
+        HasBoundRaytracingTextureAtlas(level, false)
+            ? BuildRaytracingTextureAtlasLayout(
+                  level,
+                  false,
+                  kOpaqueRaytracingTextureMappings)
+            : std::nullopt;
     std::uint32_t next_transmissive_triangle_offset = 0u;
     std::uint32_t next_opaque_triangle_offset = 0u;
     std::uint32_t next_transmissive_bvh_offset = 0u;
@@ -595,6 +760,15 @@ std::vector<RaytracingSourceGeometryData> BuildRaytracingSourceGeometryData(
         geometry.triangle_buffer_id = triangle_buffer_id;
         geometry.bvh_buffer_id = bvh_buffer_id;
         geometry.material_id = transmissive ? 0u : 1u;
+        geometry.atlas_uv_bounds = transmissive && transmissive_atlas_layout
+            ? GetRaytracingAtlasUvBounds(
+                  *transmissive_atlas_layout,
+                  source_material_id)
+            : (!transmissive && opaque_atlas_layout)
+            ? GetRaytracingAtlasUvBounds(
+                  *opaque_atlas_layout,
+                  source_material_id)
+            : std::array<float, 4>{0.0f, 1.0f, 0.0f, 1.0f};
         geometry.triangle_offset = transmissive
             ? next_transmissive_triangle_offset
             : next_opaque_triangle_offset;
@@ -638,6 +812,7 @@ std::size_t BuildSourceInstanceLayoutHash(
         HashCombine(seed, geometry.triangle_count);
         HashCombine(seed, geometry.bvh_node_offset);
         HashCombine(seed, geometry.bvh_node_count);
+        HashColor(seed, geometry.atlas_uv_bounds);
     }
     return seed;
 }
@@ -661,6 +836,7 @@ std::size_t BuildSourceGeometryContentStateHash(
     HashCombine(seed, geometry.bvh_node_offset);
     HashCombine(seed, geometry.bvh_node_count);
     HashColor(seed, geometry.color_multiplier);
+    HashColor(seed, geometry.atlas_uv_bounds);
     return seed;
 }
 
@@ -837,6 +1013,64 @@ struct RaytraceVertex
     float pad3;
 };
 
+std::array<float, 4> GetRaytracingAtlasUvBounds(
+    const RaytracingTextureAtlasLayout& layout,
+    frame::EntityId material_id)
+{
+    const auto it = layout.slot_by_material_id.find(material_id);
+    if (it == layout.slot_by_material_id.end())
+    {
+        return {0.0f, 1.0f, 0.0f, 1.0f};
+    }
+
+    const std::uint32_t slot = it->second;
+    const std::uint32_t column = slot % layout.columns;
+    const std::uint32_t row = slot / layout.columns;
+    const float atlas_width = static_cast<float>(layout.atlas_width);
+    const float atlas_height = static_cast<float>(layout.atlas_height);
+    const float u0 =
+        (static_cast<float>(column * layout.tile_width) + 0.5f) / atlas_width;
+    const float u1 =
+        (static_cast<float>((column + 1u) * layout.tile_width) - 0.5f) /
+        atlas_width;
+    const float v0 =
+        (static_cast<float>(row * layout.tile_height) + 0.5f) / atlas_height;
+    const float v1 =
+        (static_cast<float>((row + 1u) * layout.tile_height) - 0.5f) /
+        atlas_height;
+    return {u0, std::max(u0, u1), v0, std::max(v0, v1)};
+}
+
+std::vector<std::uint8_t> RemapRaytracingAtlasTriangleUvs(
+    const std::vector<std::uint8_t>& raw,
+    const std::optional<RaytracingTextureAtlasLayout>& layout,
+    frame::EntityId material_id)
+{
+    if (!layout || raw.empty() ||
+        !layout->slot_by_material_id.contains(material_id))
+    {
+        return raw;
+    }
+    if (raw.size() % sizeof(RaytraceVertex) != 0u)
+    {
+        throw std::runtime_error(
+            "OpenGL raytrace triangle buffer size is not aligned to the expected vertex stride.");
+    }
+
+    const auto bounds = GetRaytracingAtlasUvBounds(*layout, material_id);
+    std::vector<std::uint8_t> remapped = raw;
+    auto* vertices = reinterpret_cast<RaytraceVertex*>(remapped.data());
+    const std::size_t vertex_count = remapped.size() / sizeof(RaytraceVertex);
+    for (std::size_t i = 0; i < vertex_count; ++i)
+    {
+        const float u = std::clamp(vertices[i].u, 0.0f, 1.0f);
+        const float v = std::clamp(vertices[i].v, 0.0f, 1.0f);
+        vertices[i].u = bounds[0] + (bounds[1] - bounds[0]) * u;
+        vertices[i].v = bounds[2] + (bounds[3] - bounds[2]) * v;
+    }
+    return remapped;
+}
+
 std::vector<std::uint8_t> BuildTriangleBytesFromMeshBuffers(
     frame::LevelInterface& level,
     const frame::MeshInterface& mesh)
@@ -1006,6 +1240,17 @@ std::vector<std::uint8_t> BuildAggregateTriangleBytes(
     std::vector<std::uint8_t> aggregate_triangle_bytes = {};
     const auto reference_color =
         ResolveRaytracingReferenceColor(level, transmissive);
+    const auto atlas_layout = HasBoundRaytracingTextureAtlas(level, transmissive)
+        ? (transmissive
+               ? BuildRaytracingTextureAtlasLayout(
+                     level,
+                     true,
+                     kTransmissiveRaytracingTextureMappings)
+               : BuildRaytracingTextureAtlasLayout(
+                     level,
+                     false,
+                     kOpaqueRaytracingTextureMappings))
+        : std::nullopt;
     for (const auto& [source_node_id, source_material_id] :
          GetRaytracingSourceMeshMaterials(level))
     {
@@ -1052,6 +1297,10 @@ std::vector<std::uint8_t> BuildAggregateTriangleBytes(
         {
             continue;
         }
+        source_triangle_bytes = RemapRaytracingAtlasTriangleUvs(
+            source_triangle_bytes,
+            atlas_layout,
+            source_material_id);
         const auto transformed = TransformTriangleBytes(
             source_triangle_bytes,
             node->GetLocalModel(time_seconds));
@@ -1505,6 +1754,13 @@ void Renderer::UpdateSourceInstanceRaytraceSceneBuffers()
                     geometry.color_multiplier[1],
                     geometry.color_multiplier[2],
                     geometry.color_multiplier[3])));
+            uniforms.AddUniform(std::make_unique<Uniform>(
+                "atlas_uv_bounds",
+                glm::vec4(
+                    geometry.atlas_uv_bounds[0],
+                    geometry.atlas_uv_bounds[1],
+                    geometry.atlas_uv_bounds[2],
+                    geometry.atlas_uv_bounds[3])));
             gpu_raytrace_triangle_copy_program_->Use(uniforms, nullptr);
             glBindBufferBase(
                 GL_SHADER_STORAGE_BUFFER,

--- a/frame/vulkan/device.cpp
+++ b/frame/vulkan/device.cpp
@@ -592,6 +592,152 @@ std::array<float, 4> ResolveRaytracingColorMultiplier(
     return multiplier;
 }
 
+struct RaytracingTextureMapping
+{
+    const char* source_name;
+    const char* fallback_name;
+    const char* target_name;
+};
+
+constexpr std::array<RaytracingTextureMapping, 7>
+    kOpaqueRaytracingTextureMappings = {{
+        {"albedo_texture", "Color", "opaque_albedo_texture"},
+        {"normal_texture", nullptr, "opaque_normal_texture"},
+        {"roughness_texture", nullptr, "opaque_roughness_texture"},
+        {"metallic_texture", nullptr, "opaque_metallic_texture"},
+        {"ao_texture", nullptr, "opaque_ao_texture"},
+        {"specular_factor_texture", nullptr, "opaque_specular_factor_texture"},
+        {"specular_color_texture", nullptr, "opaque_specular_color_texture"},
+    }};
+
+constexpr std::array<RaytracingTextureMapping, 10>
+    kTransmissiveRaytracingTextureMappings = {{
+        {"albedo_texture", "Color", "transmissive_albedo_texture"},
+        {"normal_texture", nullptr, "transmissive_normal_texture"},
+        {"roughness_texture", nullptr, "transmissive_roughness_texture"},
+        {"metallic_texture", nullptr, "transmissive_metallic_texture"},
+        {"ao_texture", nullptr, "transmissive_ao_texture"},
+        {"transmission_texture", nullptr, "transmissive_transmission_texture"},
+        {"ior_texture", nullptr, "transmissive_ior_texture"},
+        {"thickness_texture", nullptr, "transmissive_thickness_texture"},
+        {"attenuation_color_texture", nullptr, "transmissive_attenuation_color_texture"},
+        {"attenuation_distance_texture", nullptr, "transmissive_attenuation_distance_texture"},
+    }};
+
+struct RaytracingTextureAtlasLayout
+{
+    std::vector<frame::EntityId> material_ids = {};
+    std::unordered_map<frame::EntityId, std::uint32_t> slot_by_material_id = {};
+    std::uint32_t columns = 1u;
+    std::uint32_t rows = 1u;
+    std::uint32_t tile_width = 1u;
+    std::uint32_t tile_height = 1u;
+    std::uint32_t atlas_width = 1u;
+    std::uint32_t atlas_height = 1u;
+};
+
+frame::EntityId ResolveRaytracingMappedTextureId(
+    const frame::MaterialInterface& material,
+    const RaytracingTextureMapping& mapping)
+{
+    auto texture_id = FindTextureIdByInnerName(material, mapping.source_name);
+    if (!texture_id && mapping.fallback_name)
+    {
+        texture_id = FindTextureIdByInnerName(material, mapping.fallback_name);
+    }
+    return texture_id;
+}
+
+template <typename MappingArray>
+std::optional<RaytracingTextureAtlasLayout> BuildRaytracingTextureAtlasLayout(
+    frame::LevelInterface& level,
+    bool transmissive,
+    const MappingArray& mappings)
+{
+    std::vector<frame::EntityId> material_ids = {};
+    std::unordered_set<frame::EntityId> seen_material_ids = {};
+    for (const auto& [source_node_id, source_material_id] :
+         GetRaytracingSourceMeshMaterials(level))
+    {
+        (void)source_node_id;
+        if (IsTransmissiveMaterial(level, source_material_id) != transmissive ||
+            !source_material_id ||
+            !seen_material_ids.insert(source_material_id).second)
+        {
+            continue;
+        }
+        material_ids.push_back(source_material_id);
+    }
+    if (material_ids.size() <= 1u)
+    {
+        return std::nullopt;
+    }
+
+    RaytracingTextureAtlasLayout layout = {};
+    layout.material_ids = std::move(material_ids);
+    for (std::size_t i = 0; i < layout.material_ids.size(); ++i)
+    {
+        layout.slot_by_material_id.emplace(
+            layout.material_ids[i],
+            static_cast<std::uint32_t>(i));
+    }
+
+    for (const auto material_id : layout.material_ids)
+    {
+        const auto& material = level.GetMaterialFromId(material_id);
+        for (const auto& mapping : mappings)
+        {
+            const auto texture_id = ResolveRaytracingMappedTextureId(
+                material,
+                mapping);
+            if (!texture_id)
+            {
+                continue;
+            }
+            const auto size = level.GetTextureFromId(texture_id).GetSize();
+            layout.tile_width = std::max(layout.tile_width, std::max(1u, size.x));
+            layout.tile_height = std::max(
+                layout.tile_height,
+                std::max(1u, size.y));
+        }
+    }
+
+    const auto material_count = static_cast<double>(layout.material_ids.size());
+    layout.columns = std::max(
+        1u,
+        static_cast<std::uint32_t>(std::ceil(std::sqrt(material_count))));
+    layout.rows = std::max(
+        1u,
+        static_cast<std::uint32_t>(
+            (layout.material_ids.size() + layout.columns - 1u) /
+            layout.columns));
+    layout.atlas_width = std::max(1u, layout.columns * layout.tile_width);
+    layout.atlas_height = std::max(1u, layout.rows * layout.tile_height);
+    return layout;
+}
+
+bool HasBoundRaytracingTextureAtlas(
+    frame::LevelInterface& level,
+    bool transmissive)
+{
+    const auto scene_material_id = level.GetIdFromName("RayTraceMaterial");
+    if (scene_material_id == frame::NullId)
+    {
+        return false;
+    }
+    const auto& scene_material = level.GetMaterialFromId(scene_material_id);
+    const auto* target_name = transmissive
+        ? "transmissive_albedo_texture"
+        : "opaque_albedo_texture";
+    const auto texture_id = FindTextureIdByInnerName(scene_material, target_name);
+    if (texture_id == frame::NullId)
+    {
+        return false;
+    }
+    return level.GetNameFromId(texture_id).find(".__raytrace_atlas_") !=
+        std::string::npos;
+}
+
 template <typename T>
 void HashCombine(std::size_t& seed, const T& value)
 {
@@ -788,6 +934,64 @@ struct RaytraceVertex
     float pad3;
 };
 
+std::array<float, 4> GetRaytracingAtlasUvBounds(
+    const RaytracingTextureAtlasLayout& layout,
+    frame::EntityId material_id)
+{
+    const auto it = layout.slot_by_material_id.find(material_id);
+    if (it == layout.slot_by_material_id.end())
+    {
+        return {0.0f, 1.0f, 0.0f, 1.0f};
+    }
+
+    const std::uint32_t slot = it->second;
+    const std::uint32_t column = slot % layout.columns;
+    const std::uint32_t row = slot / layout.columns;
+    const float atlas_width = static_cast<float>(layout.atlas_width);
+    const float atlas_height = static_cast<float>(layout.atlas_height);
+    const float u0 =
+        (static_cast<float>(column * layout.tile_width) + 0.5f) / atlas_width;
+    const float u1 =
+        (static_cast<float>((column + 1u) * layout.tile_width) - 0.5f) /
+        atlas_width;
+    const float v0 =
+        (static_cast<float>(row * layout.tile_height) + 0.5f) / atlas_height;
+    const float v1 =
+        (static_cast<float>((row + 1u) * layout.tile_height) - 0.5f) /
+        atlas_height;
+    return {u0, std::max(u0, u1), v0, std::max(v0, v1)};
+}
+
+std::vector<std::uint8_t> RemapRaytracingAtlasTriangleUvs(
+    const std::vector<std::uint8_t>& raw,
+    const std::optional<RaytracingTextureAtlasLayout>& layout,
+    frame::EntityId material_id)
+{
+    if (!layout || raw.empty() ||
+        !layout->slot_by_material_id.contains(material_id))
+    {
+        return raw;
+    }
+    if (raw.size() % sizeof(RaytraceVertex) != 0u)
+    {
+        throw std::runtime_error(
+            "Vulkan raytrace triangle buffer size is not aligned to the expected vertex stride.");
+    }
+
+    const auto bounds = GetRaytracingAtlasUvBounds(*layout, material_id);
+    std::vector<std::uint8_t> remapped = raw;
+    auto* vertices = reinterpret_cast<RaytraceVertex*>(remapped.data());
+    const std::size_t vertex_count = remapped.size() / sizeof(RaytraceVertex);
+    for (std::size_t i = 0; i < vertex_count; ++i)
+    {
+        const float u = std::clamp(vertices[i].u, 0.0f, 1.0f);
+        const float v = std::clamp(vertices[i].v, 0.0f, 1.0f);
+        vertices[i].u = bounds[0] + (bounds[1] - bounds[0]) * u;
+        vertices[i].v = bounds[2] + (bounds[3] - bounds[2]) * v;
+    }
+    return remapped;
+}
+
 struct alignas(16) GpuSkinningSourceVertex
 {
     glm::vec4 position = glm::vec4(0.0f);
@@ -804,6 +1008,7 @@ struct alignas(16) GpuSkinningPushConstants
     std::uint32_t pad1 = 0;
     std::uint32_t pad2 = 0;
     glm::vec4 color_multiplier = glm::vec4(1.0f);
+    glm::vec4 atlas_uv_bounds = glm::vec4(0.0f, 1.0f, 0.0f, 1.0f);
 };
 
 std::vector<std::uint8_t> BuildGpuSkinningSourceVertexBytes(
@@ -1043,12 +1248,27 @@ std::optional<RaytracingSourceGeometryData> BuildRaytracingSourceGeometryDataFor
     const auto color_multiplier = ResolveRaytracingColorMultiplier(
         source_color,
         reference_color);
+    const auto atlas_layout = HasBoundRaytracingTextureAtlas(level, transmissive)
+        ? (transmissive
+               ? BuildRaytracingTextureAtlasLayout(
+                     level,
+                     true,
+                     kTransmissiveRaytracingTextureMappings)
+               : BuildRaytracingTextureAtlasLayout(
+                     level,
+                     false,
+                     kOpaqueRaytracingTextureMappings))
+        : std::nullopt;
+    const auto remapped = RemapRaytracingAtlasTriangleUvs(
+        triangle_buffer->GetRawData(),
+        atlas_layout,
+        source_material_id);
     const auto transformed =
         apply_node_transform
             ? TransformTriangleBytes(
-                  triangle_buffer->GetRawData(),
+                  remapped,
                   node->GetLocalModel(time_seconds))
-            : triangle_buffer->GetRawData();
+            : remapped;
 
     RaytracingSourceGeometryData geometry = {};
     geometry.source_node_id = source_node_id;
@@ -1056,6 +1276,11 @@ std::optional<RaytracingSourceGeometryData> BuildRaytracingSourceGeometryDataFor
     geometry.source_material_id = source_material_id;
     geometry.material_id = transmissive ? 0u : 1u;
     geometry.triangle_offset = triangle_offset;
+    geometry.atlas_uv_bounds = transmissive && atlas_layout
+        ? GetRaytracingAtlasUvBounds(*atlas_layout, source_material_id)
+        : (!transmissive && atlas_layout)
+        ? GetRaytracingAtlasUvBounds(*atlas_layout, source_material_id)
+        : std::array<float, 4>{0.0f, 1.0f, 0.0f, 1.0f};
     geometry.triangle_bytes =
         ApplyTriangleColorMultiplier(transformed, color_multiplier);
     return geometry;
@@ -1403,6 +1628,17 @@ std::vector<std::uint8_t> BuildAggregateTriangleBytes(
     std::vector<std::uint8_t> aggregate_triangle_bytes = {};
     const auto reference_color =
         ResolveRaytracingReferenceColor(level, transmissive);
+    const auto atlas_layout = HasBoundRaytracingTextureAtlas(level, transmissive)
+        ? (transmissive
+               ? BuildRaytracingTextureAtlasLayout(
+                     level,
+                     true,
+                     kTransmissiveRaytracingTextureMappings)
+               : BuildRaytracingTextureAtlasLayout(
+                     level,
+                     false,
+                     kOpaqueRaytracingTextureMappings))
+        : std::nullopt;
     for (const auto& [source_node_id, source_material_id] :
          GetRaytracingSourceMeshMaterials(level))
     {
@@ -1443,12 +1679,16 @@ std::vector<std::uint8_t> BuildAggregateTriangleBytes(
         const auto color_multiplier = ResolveRaytracingColorMultiplier(
             source_color,
             reference_color);
+        const auto remapped = RemapRaytracingAtlasTriangleUvs(
+            triangle_buffer->GetRawData(),
+            atlas_layout,
+            source_material_id);
         const auto transformed =
             apply_node_transform
                 ? TransformTriangleBytes(
-                      triangle_buffer->GetRawData(),
+                      remapped,
                       node->GetLocalModel(time_seconds))
-                : triangle_buffer->GetRawData();
+                : remapped;
         const auto tinted =
             ApplyTriangleColorMultiplier(transformed, color_multiplier);
         aggregate_triangle_bytes.insert(
@@ -3922,6 +4162,7 @@ void Device::CreateGpuSkinningResources()
         std::uint32_t bone_capacity = 0;
         vk::DeviceSize output_buffer_size = 0;
         glm::vec4 color_multiplier = glm::vec4(1.0f);
+        glm::vec4 atlas_uv_bounds = glm::vec4(0.0f, 1.0f, 0.0f, 1.0f);
         std::vector<std::uint8_t> source_vertex_bytes = {};
         std::vector<std::uint8_t> source_index_bytes = {};
     };
@@ -4000,6 +4241,11 @@ void Device::CreateGpuSkinningResources()
             color_multiplier[1],
             color_multiplier[2],
             color_multiplier[3]);
+        pending.atlas_uv_bounds = glm::vec4(
+            source_geometry.atlas_uv_bounds[0],
+            source_geometry.atlas_uv_bounds[1],
+            source_geometry.atlas_uv_bounds[2],
+            source_geometry.atlas_uv_bounds[3]);
 
         if (pending.source_vertex_bytes.empty() ||
             pending.source_index_bytes.empty() ||
@@ -4161,6 +4407,7 @@ void Device::CreateGpuSkinningResources()
         resource.bone_capacity = pending.bone_capacity;
         resource.output_buffer_size = pending.output_buffer_size;
         resource.color_multiplier = pending.color_multiplier;
+        resource.atlas_uv_bounds = pending.atlas_uv_bounds;
         resource.descriptor_set = descriptor_sets[i];
 
         create_device_local_buffer(
@@ -4509,6 +4756,8 @@ std::vector<EntityId> Device::UpdateGpuSkinnedMeshes()
                     pending.resource->output_vertex_count;
                 push_constants.color_multiplier =
                     pending.resource->color_multiplier;
+                push_constants.atlas_uv_bounds =
+                    pending.resource->atlas_uv_bounds;
                 command_buffer.pushConstants(
                     *gpu_skinning_pipeline_layout_,
                     vk::ShaderStageFlagBits::eCompute,

--- a/frame/vulkan/device.h
+++ b/frame/vulkan/device.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <filesystem>
 #include <functional>
@@ -47,6 +48,7 @@ struct RaytracingSourceGeometryData
     EntityId source_material_id = NullId;
     std::uint32_t material_id = 0;
     std::uint32_t triangle_offset = 0;
+    std::array<float, 4> atlas_uv_bounds = {0.0f, 1.0f, 0.0f, 1.0f};
     std::vector<std::uint8_t> triangle_bytes = {};
 };
 
@@ -272,6 +274,7 @@ class Device : public DeviceInterface
         std::uint32_t bone_capacity = 0;
         vk::DeviceSize output_buffer_size = 0;
         glm::vec4 color_multiplier = glm::vec4(1.0f);
+        glm::vec4 atlas_uv_bounds = glm::vec4(0.0f, 1.0f, 0.0f, 1.0f);
         vk::UniqueBuffer source_vertex_buffer;
         vk::UniqueDeviceMemory source_vertex_memory;
         vk::UniqueBuffer source_index_buffer;

--- a/frame/vulkan/json/parse_scene_tree.cpp
+++ b/frame/vulkan/json/parse_scene_tree.cpp
@@ -615,6 +615,66 @@ std::string GetAutoMaterialName(
 constexpr const char* kRaytracingResolveNodeName = "RayTracingRendering";
 constexpr const char* kRaytracingResolveMaterialName = "RayTraceMaterial";
 
+struct RaytracingTextureMapping
+{
+    const char* source_name;
+    const char* fallback_name;
+    const char* target_name;
+};
+
+constexpr std::array<RaytracingTextureMapping, 7>
+    kOpaqueRaytracingTextureMappings = {{
+        {"albedo_texture", "Color", "opaque_albedo_texture"},
+        {"normal_texture", nullptr, "opaque_normal_texture"},
+        {"roughness_texture", nullptr, "opaque_roughness_texture"},
+        {"metallic_texture", nullptr, "opaque_metallic_texture"},
+        {"ao_texture", nullptr, "opaque_ao_texture"},
+        {"specular_factor_texture", nullptr, "opaque_specular_factor_texture"},
+        {"specular_color_texture", nullptr, "opaque_specular_color_texture"},
+    }};
+
+constexpr std::array<RaytracingTextureMapping, 10>
+    kTransmissiveRaytracingTextureMappings = {{
+        {"albedo_texture", "Color", "transmissive_albedo_texture"},
+        {"normal_texture", nullptr, "transmissive_normal_texture"},
+        {"roughness_texture", nullptr, "transmissive_roughness_texture"},
+        {"metallic_texture", nullptr, "transmissive_metallic_texture"},
+        {"ao_texture", nullptr, "transmissive_ao_texture"},
+        {"transmission_texture", nullptr, "transmissive_transmission_texture"},
+        {"ior_texture", nullptr, "transmissive_ior_texture"},
+        {"thickness_texture", nullptr, "transmissive_thickness_texture"},
+        {"attenuation_color_texture", nullptr, "transmissive_attenuation_color_texture"},
+        {"attenuation_distance_texture", nullptr, "transmissive_attenuation_distance_texture"},
+    }};
+
+struct RaytracingTextureAtlasLayout
+{
+    std::vector<EntityId> material_ids = {};
+    std::unordered_map<EntityId, std::uint32_t> slot_by_material_id = {};
+    std::uint32_t columns = 1u;
+    std::uint32_t rows = 1u;
+    std::uint32_t tile_width = 1u;
+    std::uint32_t tile_height = 1u;
+    std::uint32_t atlas_width = 1u;
+    std::uint32_t atlas_height = 1u;
+};
+
+std::string GetRaytracingAtlasTextureName(
+    LevelInterface& level,
+    EntityId material_id,
+    std::string_view target_name)
+{
+    return std::format(
+        "{}.__raytrace_atlas_{}",
+        level.GetNameFromId(material_id),
+        target_name);
+}
+
+bool IsRaytracingAtlasTextureName(const std::string& texture_name)
+{
+    return texture_name.find(".__raytrace_atlas_") != std::string::npos;
+}
+
 bool EqualsIgnoreCaseAscii(
     const std::string& lhs, const std::string& rhs)
 {
@@ -931,6 +991,461 @@ bool IsGeneratedGltfTextureName(const std::string& texture_name)
            texture_name.find(".__gltf_solid_") != std::string::npos;
 }
 
+EntityId ResolveRaytracingMappedTextureId(
+    const MaterialInterface& material,
+    const RaytracingTextureMapping& mapping)
+{
+    EntityId texture_id = FindTextureIdByInnerName(material, mapping.source_name);
+    if (!texture_id && mapping.fallback_name)
+    {
+        texture_id = FindTextureIdByInnerName(material, mapping.fallback_name);
+    }
+    return texture_id;
+}
+
+bool ShouldReplaceRaytracingSceneTextureBinding(
+    LevelInterface& level,
+    const MaterialInterface& material,
+    std::string_view target_name)
+{
+    const EntityId texture_id = FindTextureIdByInnerName(
+        material,
+        std::string(target_name));
+    if (texture_id == NullId)
+    {
+        return true;
+    }
+
+    const auto texture_name = level.GetNameFromId(texture_id);
+    const auto& texture = level.GetTextureFromId(texture_id);
+    return IsGeneratedGltfTextureName(texture_name) ||
+           IsRaytracingAtlasTextureName(texture_name) ||
+           !texture.SerializeEnable() ||
+           texture_name.find(".__raytrace_default_") != std::string::npos;
+}
+
+template <typename MappingArray>
+std::optional<RaytracingTextureAtlasLayout> BuildRaytracingTextureAtlasLayout(
+    LevelInterface& level,
+    bool transmissive,
+    const MappingArray& mappings)
+{
+    std::vector<EntityId> material_ids = {};
+    std::unordered_set<EntityId> seen_material_ids = {};
+    for (const auto& [source_node_id, source_material_id] :
+         GetRaytracingSourceMeshMaterials(level))
+    {
+        (void)source_node_id;
+        if (IsTransmissiveRaytracingSourceMaterial(level, source_material_id) !=
+                transmissive ||
+            !source_material_id ||
+            !seen_material_ids.insert(source_material_id).second)
+        {
+            continue;
+        }
+        material_ids.push_back(source_material_id);
+    }
+    if (material_ids.size() <= 1u)
+    {
+        return std::nullopt;
+    }
+
+    RaytracingTextureAtlasLayout layout = {};
+    layout.material_ids = std::move(material_ids);
+    for (std::size_t i = 0; i < layout.material_ids.size(); ++i)
+    {
+        layout.slot_by_material_id.emplace(
+            layout.material_ids[i],
+            static_cast<std::uint32_t>(i));
+    }
+
+    for (const auto material_id : layout.material_ids)
+    {
+        const auto& material = level.GetMaterialFromId(material_id);
+        for (const auto& mapping : mappings)
+        {
+            EntityId texture_id = ResolveRaytracingMappedTextureId(
+                material,
+                mapping);
+            if (!texture_id)
+            {
+                texture_id = EnsureDefaultRaytracingTexture(
+                    level,
+                    mapping.target_name);
+            }
+            if (!texture_id)
+            {
+                continue;
+            }
+
+            const auto size = level.GetTextureFromId(texture_id).GetSize();
+            layout.tile_width = std::max(layout.tile_width, std::max(1u, size.x));
+            layout.tile_height = std::max(
+                layout.tile_height,
+                std::max(1u, size.y));
+        }
+    }
+
+    const auto material_count = static_cast<double>(layout.material_ids.size());
+    layout.columns = std::max(
+        1u,
+        static_cast<std::uint32_t>(std::ceil(std::sqrt(material_count))));
+    layout.rows = std::max(
+        1u,
+        static_cast<std::uint32_t>(
+            (layout.material_ids.size() + layout.columns - 1u) /
+            layout.columns));
+    layout.atlas_width = std::max(1u, layout.columns * layout.tile_width);
+    layout.atlas_height = std::max(1u, layout.rows * layout.tile_height);
+    return layout;
+}
+
+std::array<float, 4> GetRaytracingAtlasUvBounds(
+    const RaytracingTextureAtlasLayout& layout,
+    EntityId material_id)
+{
+    const auto it = layout.slot_by_material_id.find(material_id);
+    if (it == layout.slot_by_material_id.end())
+    {
+        return {0.0f, 1.0f, 0.0f, 1.0f};
+    }
+
+    const std::uint32_t slot = it->second;
+    const std::uint32_t column = slot % layout.columns;
+    const std::uint32_t row = slot / layout.columns;
+    const float atlas_width = static_cast<float>(layout.atlas_width);
+    const float atlas_height = static_cast<float>(layout.atlas_height);
+    const float u0 =
+        (static_cast<float>(column * layout.tile_width) + 0.5f) / atlas_width;
+    const float u1 =
+        (static_cast<float>((column + 1u) * layout.tile_width) - 0.5f) /
+        atlas_width;
+    const float v0 =
+        (static_cast<float>(row * layout.tile_height) + 0.5f) / atlas_height;
+    const float v1 =
+        (static_cast<float>((row + 1u) * layout.tile_height) - 0.5f) /
+        atlas_height;
+    return {u0, std::max(u0, u1), v0, std::max(v0, v1)};
+}
+
+std::vector<float> RemapRaytracingAtlasUvs(
+    const std::vector<float>& textures,
+    const std::optional<RaytracingTextureAtlasLayout>& layout,
+    EntityId material_id)
+{
+    if (!layout || textures.empty() ||
+        !layout->slot_by_material_id.contains(material_id))
+    {
+        return textures;
+    }
+
+    const auto bounds = GetRaytracingAtlasUvBounds(*layout, material_id);
+    std::vector<float> remapped = textures;
+    for (std::size_t i = 0; i + 1u < remapped.size(); i += 2u)
+    {
+        const float u = std::clamp(remapped[i], 0.0f, 1.0f);
+        const float v = std::clamp(remapped[i + 1u], 0.0f, 1.0f);
+        remapped[i] = bounds[0] + (bounds[1] - bounds[0]) * u;
+        remapped[i + 1u] = bounds[2] + (bounds[3] - bounds[2]) * v;
+    }
+    return remapped;
+}
+
+template <typename SampleType>
+std::vector<float> ConvertTextureDataToFloatRgba(
+    const std::vector<SampleType>& data,
+    std::size_t pixel_count,
+    frame::proto::PixelStructure::Enum structure,
+    float scale)
+{
+    std::vector<float> rgba(pixel_count * 4u, 1.0f);
+    std::size_t channel_count = 4u;
+    switch (structure)
+    {
+    case frame::proto::PixelStructure::GREY:
+        channel_count = 1u;
+        break;
+    case frame::proto::PixelStructure::GREY_ALPHA:
+        channel_count = 2u;
+        break;
+    case frame::proto::PixelStructure::RGB:
+    case frame::proto::PixelStructure::BGR:
+        channel_count = 3u;
+        break;
+    case frame::proto::PixelStructure::RGB_ALPHA:
+    case frame::proto::PixelStructure::BGR_ALPHA:
+    default:
+        channel_count = 4u;
+        break;
+    }
+    if (data.size() < pixel_count * channel_count)
+    {
+        return rgba;
+    }
+
+    for (std::size_t pixel = 0; pixel < pixel_count; ++pixel)
+    {
+        const std::size_t src = pixel * channel_count;
+        const auto sample = [&](std::size_t index) {
+            return static_cast<float>(data[src + index]) / scale;
+        };
+
+        float red = 1.0f;
+        float green = 1.0f;
+        float blue = 1.0f;
+        float alpha = 1.0f;
+        switch (structure)
+        {
+        case frame::proto::PixelStructure::GREY:
+            red = green = blue = sample(0u);
+            break;
+        case frame::proto::PixelStructure::GREY_ALPHA:
+            red = green = blue = sample(0u);
+            alpha = sample(1u);
+            break;
+        case frame::proto::PixelStructure::RGB:
+            red = sample(0u);
+            green = sample(1u);
+            blue = sample(2u);
+            break;
+        case frame::proto::PixelStructure::RGB_ALPHA:
+            red = sample(0u);
+            green = sample(1u);
+            blue = sample(2u);
+            alpha = sample(3u);
+            break;
+        case frame::proto::PixelStructure::BGR:
+            red = sample(2u);
+            green = sample(1u);
+            blue = sample(0u);
+            break;
+        case frame::proto::PixelStructure::BGR_ALPHA:
+            red = sample(2u);
+            green = sample(1u);
+            blue = sample(0u);
+            alpha = sample(3u);
+            break;
+        default:
+            break;
+        }
+
+        const std::size_t dst = pixel * 4u;
+        rgba[dst + 0u] = red;
+        rgba[dst + 1u] = green;
+        rgba[dst + 2u] = blue;
+        rgba[dst + 3u] = alpha;
+    }
+    return rgba;
+}
+
+std::vector<float> ConvertTextureToFloatRgba(TextureInterface& texture)
+{
+    const auto size = texture.GetSize();
+    const std::size_t pixel_count =
+        static_cast<std::size_t>(size.x) * size.y;
+    const auto structure = texture.GetData().pixel_structure().value();
+    switch (texture.GetData().pixel_element_size().value())
+    {
+    case frame::proto::PixelElementSize::FLOAT:
+        return ConvertTextureDataToFloatRgba(
+            texture.GetTextureFloat(),
+            pixel_count,
+            structure,
+            1.0f);
+    case frame::proto::PixelElementSize::SHORT:
+    case frame::proto::PixelElementSize::HALF:
+        return ConvertTextureDataToFloatRgba(
+            texture.GetTextureWord(),
+            pixel_count,
+            structure,
+            65535.0f);
+    case frame::proto::PixelElementSize::BYTE:
+    default:
+        return ConvertTextureDataToFloatRgba(
+            texture.GetTextureByte(),
+            pixel_count,
+            structure,
+            255.0f);
+    }
+}
+
+void CopyTextureIntoRaytracingAtlas(
+    std::vector<float>& atlas_pixels,
+    const RaytracingTextureAtlasLayout& layout,
+    std::uint32_t slot,
+    TextureInterface& texture)
+{
+    const auto size = texture.GetSize();
+    if (size.x == 0u || size.y == 0u)
+    {
+        return;
+    }
+
+    const auto rgba = ConvertTextureToFloatRgba(texture);
+    const std::uint32_t column = slot % layout.columns;
+    const std::uint32_t row = slot / layout.columns;
+    const std::uint32_t start_x = column * layout.tile_width;
+    const std::uint32_t start_y = row * layout.tile_height;
+    for (std::uint32_t y = 0; y < layout.tile_height; ++y)
+    {
+        const std::uint32_t source_y = std::min(
+            size.y - 1u,
+            static_cast<std::uint32_t>(
+                (static_cast<std::uint64_t>(y) * size.y) /
+                layout.tile_height));
+        for (std::uint32_t x = 0; x < layout.tile_width; ++x)
+        {
+            const std::uint32_t source_x = std::min(
+                size.x - 1u,
+                static_cast<std::uint32_t>(
+                    (static_cast<std::uint64_t>(x) * size.x) /
+                    layout.tile_width));
+            const std::size_t src =
+                (static_cast<std::size_t>(source_y) * size.x + source_x) * 4u;
+            const std::size_t dst =
+                (static_cast<std::size_t>(start_y + y) * layout.atlas_width +
+                 (start_x + x)) *
+                4u;
+            atlas_pixels[dst + 0u] = rgba[src + 0u];
+            atlas_pixels[dst + 1u] = rgba[src + 1u];
+            atlas_pixels[dst + 2u] = rgba[src + 2u];
+            atlas_pixels[dst + 3u] = rgba[src + 3u];
+        }
+    }
+}
+
+EntityId CreateRaytracingAtlasTexture(
+    LevelInterface& level,
+    const std::string& texture_name,
+    const RaytracingTextureAtlasLayout& layout,
+    const std::vector<float>& atlas_pixels)
+{
+    frame::proto::Texture proto_texture;
+    proto_texture.set_name(texture_name);
+    proto_texture.mutable_pixel_element_size()->CopyFrom(
+        frame::json::PixelElementSize_FLOAT());
+    proto_texture.mutable_pixel_structure()->CopyFrom(
+        frame::json::PixelStructure_RGB_ALPHA());
+    proto_texture.mutable_size()->set_x(static_cast<int>(layout.atlas_width));
+    proto_texture.mutable_size()->set_y(static_cast<int>(layout.atlas_height));
+    proto_texture.set_pixels(
+        reinterpret_cast<const char*>(atlas_pixels.data()),
+        static_cast<int>(atlas_pixels.size() * sizeof(float)));
+
+    auto atlas_texture = frame::vulkan::json::ParseTexture(
+        proto_texture,
+        {layout.atlas_width, layout.atlas_height});
+    atlas_texture->SetName(texture_name);
+    atlas_texture->SetSerializeEnable(false);
+    return level.AddTexture(std::move(atlas_texture));
+}
+
+template <typename MappingArray>
+bool BuildAndBindRaytracingTextureAtlases(
+    LevelInterface& level,
+    EntityId scene_material_id,
+    const MappingArray& mappings,
+    bool transmissive)
+{
+    if (!scene_material_id)
+    {
+        return false;
+    }
+
+    auto layout = BuildRaytracingTextureAtlasLayout(
+        level,
+        transmissive,
+        mappings);
+    if (!layout)
+    {
+        return false;
+    }
+
+    auto& scene_material = level.GetMaterialFromId(scene_material_id);
+    for (const auto& mapping : mappings)
+    {
+        if (!ShouldReplaceRaytracingSceneTextureBinding(
+                level,
+                scene_material,
+                mapping.target_name))
+        {
+            return false;
+        }
+    }
+
+    for (const auto& mapping : mappings)
+    {
+        std::vector<float> atlas_pixels(
+            static_cast<std::size_t>(layout->atlas_width) *
+                layout->atlas_height * 4u,
+            0.0f);
+        for (const auto material_id : layout->material_ids)
+        {
+            const std::uint32_t slot = layout->slot_by_material_id.at(material_id);
+            const auto& source_material = level.GetMaterialFromId(material_id);
+            EntityId texture_id = ResolveRaytracingMappedTextureId(
+                source_material,
+                mapping);
+            if (!texture_id)
+            {
+                texture_id = EnsureDefaultRaytracingTexture(
+                    level,
+                    mapping.target_name);
+            }
+            if (!texture_id)
+            {
+                continue;
+            }
+
+            auto& texture = level.GetTextureFromId(texture_id);
+            CopyTextureIntoRaytracingAtlas(
+                atlas_pixels,
+                *layout,
+                slot,
+                texture);
+        }
+
+        const auto atlas_texture_id = CreateRaytracingAtlasTexture(
+            level,
+            GetRaytracingAtlasTextureName(
+                level,
+                scene_material_id,
+                mapping.target_name),
+            *layout,
+            atlas_pixels);
+        ReplaceTextureBindingByInnerName(
+            level,
+            scene_material,
+            mapping.target_name,
+            atlas_texture_id);
+    }
+    return true;
+}
+
+bool HasBoundRaytracingTextureAtlas(
+    LevelInterface& level,
+    EntityId scene_material_id,
+    bool transmissive)
+{
+    if (!scene_material_id)
+    {
+        return false;
+    }
+
+    const auto& scene_material = level.GetMaterialFromId(scene_material_id);
+    const auto target_name = transmissive
+        ? "transmissive_albedo_texture"
+        : "opaque_albedo_texture";
+    const EntityId texture_id = FindTextureIdByInnerName(
+        scene_material,
+        target_name);
+    if (!texture_id)
+    {
+        return false;
+    }
+    return IsRaytracingAtlasTextureName(level.GetNameFromId(texture_id));
+}
+
 bool IsTransmissiveRaytracingSourceMaterial(
     LevelInterface& level, EntityId material_id)
 {
@@ -960,35 +1475,6 @@ void AdoptRaytracingSceneTextures(
     auto& source = level.GetMaterialFromId(source_material_id);
     auto& target = level.GetMaterialFromId(target_material_id);
 
-    struct Mapping
-    {
-        const char* source_name;
-        const char* fallback_name;
-        const char* target_name;
-    };
-
-    const std::array<Mapping, 7> opaque_mappings = {{
-        {"albedo_texture", "Color", "opaque_albedo_texture"},
-        {"normal_texture", nullptr, "opaque_normal_texture"},
-        {"roughness_texture", nullptr, "opaque_roughness_texture"},
-        {"metallic_texture", nullptr, "opaque_metallic_texture"},
-        {"ao_texture", nullptr, "opaque_ao_texture"},
-        {"specular_factor_texture", nullptr, "opaque_specular_factor_texture"},
-        {"specular_color_texture", nullptr, "opaque_specular_color_texture"},
-    }};
-    const std::array<Mapping, 10> transmissive_mappings = {{
-        {"albedo_texture", "Color", "transmissive_albedo_texture"},
-        {"normal_texture", nullptr, "transmissive_normal_texture"},
-        {"roughness_texture", nullptr, "transmissive_roughness_texture"},
-        {"metallic_texture", nullptr, "transmissive_metallic_texture"},
-        {"ao_texture", nullptr, "transmissive_ao_texture"},
-        {"transmission_texture", nullptr, "transmissive_transmission_texture"},
-        {"ior_texture", nullptr, "transmissive_ior_texture"},
-        {"thickness_texture", nullptr, "transmissive_thickness_texture"},
-        {"attenuation_color_texture", nullptr, "transmissive_attenuation_color_texture"},
-        {"attenuation_distance_texture", nullptr, "transmissive_attenuation_distance_texture"},
-    }};
-
     const auto copy_mapping =
         [&](const char* source_name,
             const char* fallback_name,
@@ -1002,23 +1488,12 @@ void AdoptRaytracingSceneTextures(
             {
                 return;
             }
-            const EntityId existing_target_id =
-                FindTextureIdByInnerName(target, target_name);
-            if (existing_target_id != NullId)
+            if (!ShouldReplaceRaytracingSceneTextureBinding(
+                    level,
+                    target,
+                    target_name))
             {
-                const auto existing_target_texture_name =
-                    level.GetNameFromId(existing_target_id);
-                const auto& existing_target_texture =
-                    level.GetTextureFromId(existing_target_id);
-                const bool replace_generated_target =
-                    IsGeneratedGltfTextureName(existing_target_texture_name) ||
-                    !existing_target_texture.SerializeEnable() ||
-                    existing_target_texture_name.find(".__raytrace_default_") !=
-                        std::string::npos;
-                if (!replace_generated_target)
-                {
-                    return;
-                }
+                return;
             }
             ReplaceTextureBindingByInnerName(
                 level, target, target_name, source_id);
@@ -1026,7 +1501,7 @@ void AdoptRaytracingSceneTextures(
 
     if (transmissive)
     {
-        for (const auto& mapping : transmissive_mappings)
+        for (const auto& mapping : kTransmissiveRaytracingTextureMappings)
         {
             copy_mapping(
                 mapping.source_name,
@@ -1035,7 +1510,7 @@ void AdoptRaytracingSceneTextures(
         }
         return;
     }
-    for (const auto& mapping : opaque_mappings)
+    for (const auto& mapping : kOpaqueRaytracingTextureMappings)
     {
         copy_mapping(
             mapping.source_name,
@@ -1103,6 +1578,7 @@ struct RaytraceAggregateBuffers
 
 RaytraceAggregateBuffers BuildRaytraceAggregateBuffers(
     LevelInterface& level,
+    EntityId scene_material_id,
     bool transmissive,
     const std::string& base_name,
     bool build_software_bvh)
@@ -1114,6 +1590,20 @@ RaytraceAggregateBuffers BuildRaytraceAggregateBuffers(
     std::vector<std::uint32_t> aggregate_indices = {};
     const auto reference_color =
         ResolveRaytracingReferenceColor(level, transmissive);
+    const auto atlas_layout = HasBoundRaytracingTextureAtlas(
+        level,
+        scene_material_id,
+        transmissive)
+        ? (transmissive
+               ? BuildRaytracingTextureAtlasLayout(
+                     level,
+                     true,
+                     kTransmissiveRaytracingTextureMappings)
+               : BuildRaytracingTextureAtlasLayout(
+                     level,
+                     false,
+                     kOpaqueRaytracingTextureMappings))
+        : std::nullopt;
 
     for (const auto& [source_node_id, source_material_id] :
          GetRaytracingSourceMeshMaterials(level))
@@ -1163,6 +1653,10 @@ RaytraceAggregateBuffers BuildRaytraceAggregateBuffers(
         {
             continue;
         }
+        const auto remapped_textures = RemapRaytracingAtlasUvs(
+            textures,
+            atlas_layout,
+            source_material_id);
         const auto source_color = ResolveRaytracingSourceMaterialColor(
             level, source_material_id);
         const auto color_multiplier = ResolveRaytracingColorMultiplier(
@@ -1179,8 +1673,8 @@ RaytraceAggregateBuffers BuildRaytraceAggregateBuffers(
             normals.end());
         aggregate_textures.insert(
             aggregate_textures.end(),
-            textures.begin(),
-            textures.end());
+            remapped_textures.begin(),
+            remapped_textures.end());
         for (const auto index : indices)
         {
             aggregate_indices.push_back(base_index + index);
@@ -1188,7 +1682,7 @@ RaytraceAggregateBuffers BuildRaytraceAggregateBuffers(
         const auto mesh_triangles = BuildRaytraceTriangles(
             points,
             normals,
-            textures,
+            remapped_textures,
             indices,
             color_multiplier);
         aggregate_triangles.insert(
@@ -1281,8 +1775,16 @@ void FinalizeRaytracingSceneMaterials(
             continue;
         }
 
-        bool adopted_transmissive = false;
-        bool adopted_opaque = false;
+        bool adopted_transmissive = BuildAndBindRaytracingTextureAtlases(
+            level,
+            scene_material_id,
+            kTransmissiveRaytracingTextureMappings,
+            true);
+        bool adopted_opaque = BuildAndBindRaytracingTextureAtlases(
+            level,
+            scene_material_id,
+            kOpaqueRaytracingTextureMappings,
+            false);
         for (const auto& [source_node_id, source_material_id] :
              GetRaytracingSourceMeshMaterials(level))
         {
@@ -1318,11 +1820,13 @@ void FinalizeRaytracingSceneMaterials(
             std::format("{}.scene", scene_material.GetData().name());
         const auto transmissive_buffers = BuildRaytraceAggregateBuffers(
             level,
+            scene_material_id,
             true,
             buffer_base_name + "_transmissive",
             build_software_bvh);
         const auto opaque_buffers = BuildRaytraceAggregateBuffers(
             level,
+            scene_material_id,
             false,
             buffer_base_name + "_opaque",
             build_software_bvh);

--- a/tests/frame/CMakeLists.txt
+++ b/tests/frame/CMakeLists.txt
@@ -35,7 +35,9 @@ set_target_properties(FrameTest PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 include(GoogleTest)
-gtest_add_tests(TARGET FrameTest)
+gtest_add_tests(TARGET FrameTest TEST_LIST FRAME_TESTS)
+set_tests_properties(WindowFactoryTest.CreateWindowOpenGLTest
+  PROPERTIES LABELS requires-opengl)
 
 add_subdirectory(file)
 add_subdirectory(json)

--- a/tests/frame/json/CMakeLists.txt
+++ b/tests/frame/json/CMakeLists.txt
@@ -43,6 +43,15 @@ set_target_properties(FrameJsonTest PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 include(GoogleTest)
-gtest_discover_tests(FrameJsonTest)
+gtest_add_tests(TARGET FrameJsonTest TEST_LIST FRAME_JSON_TESTS)
+set(FRAME_JSON_OPENGL_TESTS
+  ParseMaterialTest.CreateParseMaterialTest
+  ParseProgramTest.CreateParseProgramTest
+  ParseProgramTest.CreateParseProgramUniformTest
+  ParseTextureTest.CreateInvalidTextureFromProtoTest
+  ParseTextureTest.CreateTextureFromProtoCheckSizeTest
+  ParseTextureTest.CreateTextureFromProtoWrongSizeTest)
+set_tests_properties(${FRAME_JSON_OPENGL_TESTS}
+  PROPERTIES LABELS requires-opengl)
 
 set_property(TARGET FrameJsonTest PROPERTY FOLDER "FrameTest")

--- a/tests/frame/opengl/CMakeLists.txt
+++ b/tests/frame/opengl/CMakeLists.txt
@@ -61,7 +61,9 @@ set_target_properties(FrameOpenGLTest PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 include(GoogleTest)
-gtest_add_tests(TARGET FrameOpenGLTest)
+gtest_add_tests(TARGET FrameOpenGLTest TEST_LIST FRAME_OPENGL_TESTS)
+set_tests_properties(${FRAME_OPENGL_TESTS}
+  PROPERTIES LABELS requires-opengl)
 
 add_subdirectory(file)
 
@@ -98,6 +100,8 @@ if(MSVC)
   target_compile_options(FrameOpenGLGUITest PRIVATE /utf-8)
 endif()
 
-gtest_add_tests(TARGET FrameOpenGLGUITest)
+gtest_add_tests(TARGET FrameOpenGLGUITest TEST_LIST FRAME_OPENGL_GUI_TESTS)
+set_tests_properties(${FRAME_OPENGL_GUI_TESTS}
+  PROPERTIES LABELS requires-opengl)
 
 set_property(TARGET FrameOpenGLGUITest PROPERTY FOLDER "FrameTest/OpenGL")

--- a/tests/frame/opengl/file/CMakeLists.txt
+++ b/tests/frame/opengl/file/CMakeLists.txt
@@ -31,7 +31,9 @@ set_target_properties(FrameOpenGLFileTest PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 include(GoogleTest)
-gtest_add_tests(TARGET FrameOpenGLFileTest)
+gtest_add_tests(TARGET FrameOpenGLFileTest TEST_LIST FRAME_OPENGL_FILE_TESTS)
+set_tests_properties(${FRAME_OPENGL_FILE_TESTS}
+  PROPERTIES LABELS requires-opengl)
 
 set_property(TARGET FrameOpenGLFileTest PROPERTY FOLDER "FrameTest/OpenGL")
 

--- a/tests/frame/opengl/raytracing_test.cpp
+++ b/tests/frame/opengl/raytracing_test.cpp
@@ -6,6 +6,8 @@
 #include <cstdint>
 #include <fstream>
 #include <stdexcept>
+#include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "frame/camera.h"
@@ -58,6 +60,35 @@ frame::proto::Level LoadLevelProtoWithoutSkinnedMesh()
             break;
         }
     }
+    return level_proto;
+}
+
+frame::proto::Level LoadRaytracingProtoWithAdditionalSceneMesh(
+    const std::string& node_name, const std::string& file_name)
+{
+    auto level_proto = frame::json::LoadLevelProto(
+        frame::file::FindFile("asset/json/raytracing.json"));
+    auto* textures = level_proto.mutable_textures();
+    for (int i = 0; i < textures->size();)
+    {
+        const auto& texture = textures->Get(i);
+        if (texture.name() == "albedo_texture" ||
+            texture.name() == "normal_texture" ||
+            texture.name() == "roughness_texture" ||
+            texture.name() == "metallic_texture" ||
+            texture.name() == "ao_texture")
+        {
+            textures->DeleteSubrange(i, 1);
+            continue;
+        }
+        ++i;
+    }
+    auto* scene_tree = level_proto.mutable_scene_tree();
+    auto* node_mesh = scene_tree->add_node_meshes();
+    node_mesh->set_name(node_name);
+    node_mesh->set_parent("mesh_holder");
+    node_mesh->set_file_name(file_name);
+    node_mesh->set_render_time_enum(frame::proto::NodeMesh::SCENE_RENDER_TIME);
     return level_proto;
 }
 
@@ -1116,6 +1147,66 @@ TEST_F(OpenGLRayTracingLevelTest, ImportsGltfOpaqueSpecularFromPlate)
     EXPECT_NEAR(specular_color[0], 0.0f, 0.02f);
     EXPECT_NEAR(specular_color[1], 0.0f, 0.02f);
     EXPECT_NEAR(specular_color[2], 0.0f, 0.02f);
+}
+
+TEST_F(OpenGLRayTracingLevelTest, BuildsOpaqueAtlasForMultipleOpaqueGltfMaterials)
+{
+    auto level = frame::json::ParseLevel(
+        {1280u, 720u},
+        LoadRaytracingProtoWithAdditionalSceneMesh(
+            "TexturedScene",
+            "scene.glb"));
+    ASSERT_NE(level, nullptr);
+
+    const auto scene_material_id = level->GetIdFromName("RayTraceMaterial");
+    ASSERT_NE(scene_material_id, frame::NullId);
+    const auto& scene_material = level->GetMaterialFromId(scene_material_id);
+    const auto scene_albedo_texture_id = FindTextureByInnerName(
+        scene_material,
+        "opaque_albedo_texture");
+    ASSERT_NE(scene_albedo_texture_id, frame::NullId);
+
+    std::unordered_set<frame::EntityId> opaque_albedo_texture_ids = {};
+    for (const auto& mesh_material :
+         level->GetMeshMaterialIds(frame::proto::NodeMesh::SCENE_RENDER_TIME))
+    {
+        const auto material_id = mesh_material.second;
+        if (material_id == frame::NullId ||
+            material_id == scene_material_id)
+        {
+            continue;
+        }
+
+        const auto& material = level->GetMaterialFromId(material_id);
+        const auto transmission_texture_id = FindTextureByInnerName(
+            material,
+            "transmission_texture");
+        if (transmission_texture_id != frame::NullId &&
+            ReadTextureFirstChannel(*level, transmission_texture_id) > 0.01f)
+        {
+            continue;
+        }
+
+        const auto albedo_texture_id = FindTextureByInnerName(
+            material,
+            "albedo_texture");
+        if (albedo_texture_id != frame::NullId)
+        {
+            opaque_albedo_texture_ids.insert(albedo_texture_id);
+        }
+    }
+
+    ASSERT_GT(opaque_albedo_texture_ids.size(), 1u);
+    for (const auto texture_id : opaque_albedo_texture_ids)
+    {
+        EXPECT_NE(scene_albedo_texture_id, texture_id);
+    }
+
+    const auto scene_albedo_texture_name =
+        level->GetNameFromId(scene_albedo_texture_id);
+    EXPECT_NE(
+        scene_albedo_texture_name.find(".__raytrace_atlas_"),
+        std::string::npos);
 }
 
 TEST_F(OpenGLRayTracingLevelTest, SkinnedMeshPreRenderPopulatesSourceInstanceSceneBuffers)

--- a/tests/frame/vulkan/raytracing_test.cpp
+++ b/tests/frame/vulkan/raytracing_test.cpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <limits>
 #include <string>
+#include <unordered_set>
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -77,6 +78,35 @@ frame::proto::Level LoadSkinnedMeshLevelProtoWithSkinnedMeshAnimationEnabled(boo
             node_mesh.clear_animation_clip_index();
         }
     }
+    return level_proto;
+}
+
+frame::proto::Level LoadRaytracingProtoWithAdditionalSceneMesh(
+    const std::string& node_name, const std::string& file_name)
+{
+    auto level_proto = frame::json::LoadLevelProto(
+        frame::file::FindFile("asset/json/raytracing.json"));
+    auto* textures = level_proto.mutable_textures();
+    for (int i = 0; i < textures->size();)
+    {
+        const auto& texture = textures->Get(i);
+        if (texture.name() == "albedo_texture" ||
+            texture.name() == "normal_texture" ||
+            texture.name() == "roughness_texture" ||
+            texture.name() == "metallic_texture" ||
+            texture.name() == "ao_texture")
+        {
+            textures->DeleteSubrange(i, 1);
+            continue;
+        }
+        ++i;
+    }
+    auto* scene_tree = level_proto.mutable_scene_tree();
+    auto* node_mesh = scene_tree->add_node_meshes();
+    node_mesh->set_name(node_name);
+    node_mesh->set_parent("mesh_holder");
+    node_mesh->set_file_name(file_name);
+    node_mesh->set_render_time_enum(frame::proto::NodeMesh::SCENE_RENDER_TIME);
     return level_proto;
 }
 
@@ -718,6 +748,70 @@ TEST_F(VulkanRayTracingDualParseTest, ImportsGltfOpaqueSpecularFromPlate)
     EXPECT_NEAR(specular_color[0], 0.0f, 0.02f);
     EXPECT_NEAR(specular_color[1], 0.0f, 0.02f);
     EXPECT_NEAR(specular_color[2], 0.0f, 0.02f);
+}
+
+TEST_F(VulkanRayTracingDualParseTest, BuildsOpaqueAtlasForMultipleOpaqueGltfMaterials)
+{
+    const auto level_proto = LoadRaytracingProtoWithAdditionalSceneMesh(
+        "TexturedScene",
+        "scene.glb");
+    const auto level_data = frame::json::ParseLevelData(
+        glm::uvec2(512, 288),
+        level_proto,
+        asset_root_);
+    auto built = frame::vulkan::BuildLevel(glm::uvec2(512, 288), level_data);
+    ASSERT_NE(built.level, nullptr);
+    auto& level = *built.level;
+
+    const auto scene_material_id = level.GetIdFromName("RayTraceMaterial");
+    ASSERT_NE(scene_material_id, frame::NullId);
+    const auto& scene_material = level.GetMaterialFromId(scene_material_id);
+    const auto scene_albedo_texture_id = FindTextureByInnerName(
+        scene_material,
+        "opaque_albedo_texture");
+    ASSERT_NE(scene_albedo_texture_id, frame::NullId);
+
+    std::unordered_set<frame::EntityId> opaque_albedo_texture_ids = {};
+    for (const auto& mesh_material :
+         level.GetMeshMaterialIds(frame::proto::NodeMesh::SCENE_RENDER_TIME))
+    {
+        const auto material_id = mesh_material.second;
+        if (material_id == frame::NullId ||
+            material_id == scene_material_id)
+        {
+            continue;
+        }
+
+        const auto& material = level.GetMaterialFromId(material_id);
+        const auto transmission_texture_id = FindTextureByInnerName(
+            material,
+            "transmission_texture");
+        if (transmission_texture_id != frame::NullId &&
+            ReadTextureFirstChannel(level, transmission_texture_id) > 0.01f)
+        {
+            continue;
+        }
+
+        const auto albedo_texture_id = FindTextureByInnerName(
+            material,
+            "albedo_texture");
+        if (albedo_texture_id != frame::NullId)
+        {
+            opaque_albedo_texture_ids.insert(albedo_texture_id);
+        }
+    }
+
+    ASSERT_GT(opaque_albedo_texture_ids.size(), 1u);
+    for (const auto texture_id : opaque_albedo_texture_ids)
+    {
+        EXPECT_NE(scene_albedo_texture_id, texture_id);
+    }
+
+    const auto scene_albedo_texture_name =
+        level.GetNameFromId(scene_albedo_texture_id);
+    EXPECT_NE(
+        scene_albedo_texture_name.find(".__raytrace_atlas_"),
+        std::string::npos);
 }
 
 TEST_F(


### PR DESCRIPTION
## Summary
- Preserve per-source opaque/transmissive material textures in raytracing by building shared texture atlases and remapping source UVs into the atlas tiles.
- Carry atlas UV bounds through OpenGL and Vulkan aggregate/skinning paths so static and GPU-updated geometry samples the correct material tile.
- Add a multi-material raytracing sample scene and OpenGL/Vulkan regressions for multiple opaque glTF materials.
- Mark OpenGL-dependent CTest cases, including JSON tests that construct OpenGL-backed objects, and exclude them from GitHub-hosted Windows CI while aligning Linux/Windows PR triggers.

## Tests
- `git diff --check`
- `cmake --preset windows`
- `ctest --test-dir build\windows -C Debug -N -L requires-opengl`
- `ctest --test-dir build\windows -C Debug -N -LE requires-opengl`
- `ctest --test-dir build\windows -C Debug --output-on-failure -LE requires-opengl` (82/82 passed)
- `FrameOpenGLTest.exe --gtest_filter="OpenGLRayTracingLevelTest.ImportsGltfGlassMaterialFromIco:OpenGLRayTracingLevelTest.ImportsGltfOpaqueSpecularFromPlate:OpenGLRayTracingLevelTest.BuildsOpaqueAtlasForMultipleOpaqueGltfMaterials"`
- `FrameVulkanTest.exe --gtest_filter="VulkanRayTracingDualParseTest.ImportsGltfGlassMaterialFromIco:VulkanRayTracingDualParseTest.ImportsGltfOpaqueSpecularFromPlate:VulkanRayTracingDualParseTest.BuildsOpaqueAtlasForMultipleOpaqueGltfMaterials"`

## Notes
- Windows CI intentionally excludes tests labeled `requires-opengl`; Linux keeps OpenGL coverage through `xvfb`/Mesa.
- The new `asset/json/raytracing_multi_material.json` scene was JSON-validated but not manually launched.