### PR TITLE
Fix raytrace asset basis and atlas updates

### DIFF
--- a/frame/json/serialize_scene_tree.cpp
+++ b/frame/json/serialize_scene_tree.cpp
@@ -215,6 +215,16 @@ proto::NodeMesh SerializeNodeMesh(
         proto_node_mesh.set_animation_clip_index(
             node_mesh.GetData().animation_clip_index());
     }
+    if (node_mesh.GetData().has_asset_front())
+    {
+        proto_node_mesh.mutable_asset_front()->CopyFrom(
+            node_mesh.GetData().asset_front());
+    }
+    if (node_mesh.GetData().has_asset_up())
+    {
+        proto_node_mesh.mutable_asset_up()->CopyFrom(
+            node_mesh.GetData().asset_up());
+    }
     return proto_node_mesh;
 }
 

--- a/frame/proto/scene.proto
+++ b/frame/proto/scene.proto
@@ -33,7 +33,7 @@ message NodeMatrix {
 }
 
 // Mesh.
-// Next 18
+// Next 20
 message NodeMesh {
 	// This is the name of the mesh.
 	string name = 1;
@@ -118,6 +118,11 @@ message NodeMesh {
 
 	// Clip index fallback (used when animation_clip_name is not found).
 	optional uint32 animation_clip_index = 17;
+
+	// Mesh asset basis in local asset coordinates. The loader maps this basis
+	// to Frame's +X front / +Y up convention before scene-parent transforms.
+	optional UniformVector3 asset_front = 18;
+	optional UniformVector3 asset_up = 19;
 }
 
 // Camera

--- a/frame/vulkan/device.cpp
+++ b/frame/vulkan/device.cpp
@@ -918,6 +918,11 @@ constexpr std::size_t kRaytraceTriangleVertexStrideBytes =
 constexpr std::uint32_t kGpuSkinningBoneCapacity = 128u;
 constexpr std::uint32_t kGpuSkinningWorkgroupSize = 64u;
 
+std::uint32_t GetAccelerationStructureMaxVertex(std::uint32_t vertex_count)
+{
+    return vertex_count > 0u ? vertex_count - 1u : 0u;
+}
+
 struct RaytraceVertex
 {
     float px;
@@ -962,6 +967,15 @@ std::array<float, 4> GetRaytracingAtlasUvBounds(
     return {u0, std::max(u0, u1), v0, std::max(v0, v1)};
 }
 
+float WrapRaytracingAtlasUv(float value)
+{
+    if (!std::isfinite(value))
+    {
+        return 0.0f;
+    }
+    return value - std::floor(value);
+}
+
 std::vector<std::uint8_t> RemapRaytracingAtlasTriangleUvs(
     const std::vector<std::uint8_t>& raw,
     const std::optional<RaytracingTextureAtlasLayout>& layout,
@@ -984,8 +998,8 @@ std::vector<std::uint8_t> RemapRaytracingAtlasTriangleUvs(
     const std::size_t vertex_count = remapped.size() / sizeof(RaytraceVertex);
     for (std::size_t i = 0; i < vertex_count; ++i)
     {
-        const float u = std::clamp(vertices[i].u, 0.0f, 1.0f);
-        const float v = std::clamp(vertices[i].v, 0.0f, 1.0f);
+        const float u = WrapRaytracingAtlasUv(vertices[i].u);
+        const float v = WrapRaytracingAtlasUv(vertices[i].v);
         vertices[i].u = bounds[0] + (bounds[1] - bounds[0]) * u;
         vertices[i].v = bounds[2] + (bounds[3] - bounds[2]) * v;
     }
@@ -3437,7 +3451,7 @@ bool Device::UpdateHardwareRaytracingDynamicGeometry(
             vk::Format::eR32G32B32Sfloat,
             vk::DeviceOrHostAddressConstKHR(vertex_address),
             kRaytraceTriangleVertexStrideBytes,
-            geometry.vertex_count,
+            GetAccelerationStructureMaxVertex(geometry.vertex_count),
             vk::IndexType::eUint32,
             vk::DeviceOrHostAddressConstKHR(index_address));
         pending.geometry_data.setTriangles(pending.triangles);
@@ -3480,6 +3494,12 @@ bool Device::UpdateHardwareRaytracingDynamicGeometry(
     if (pending_updates.empty())
     {
         return false;
+    }
+
+    for (auto& pending : pending_updates)
+    {
+        // build_info keeps a pointer to as_geometry; refresh it after vector moves.
+        pending.build_info.setGeometries(pending.as_geometry);
     }
 
     const auto submit_start = SteadyClock::now();
@@ -4678,7 +4698,8 @@ std::vector<EntityId> Device::UpdateGpuSkinnedMeshes()
                     vk::Format::eR32G32B32Sfloat,
                     vk::DeviceOrHostAddressConstKHR(vertex_address),
                     kRaytraceTriangleVertexStrideBytes,
-                    pending.hardware_geometry->vertex_count,
+                    GetAccelerationStructureMaxVertex(
+                        pending.hardware_geometry->vertex_count),
                     vk::IndexType::eUint32,
                     vk::DeviceOrHostAddressConstKHR(index_address));
             pending.geometry_data.setTriangles(pending.triangles);
@@ -4733,6 +4754,15 @@ std::vector<EntityId> Device::UpdateGpuSkinnedMeshes()
     if (pending_dispatches.empty())
     {
         return {};
+    }
+
+    for (auto& pending : pending_dispatches)
+    {
+        if (pending.hardware_geometry)
+        {
+            // build_info keeps a pointer to as_geometry; refresh it after vector moves.
+            pending.build_info.setGeometries(pending.as_geometry);
+        }
     }
 
     const auto submit_start = SteadyClock::now();
@@ -5042,7 +5072,7 @@ void Device::CreateHardwareRaytracingScene()
                 vk::Format::eR32G32B32Sfloat,
                 vk::DeviceOrHostAddressConstKHR(vertex_address),
                 kRaytraceTriangleVertexStrideBytes,
-                vertex_count,
+                GetAccelerationStructureMaxVertex(vertex_count),
                 vk::IndexType::eUint32,
                 vk::DeviceOrHostAddressConstKHR(index_address));
             vk::AccelerationStructureGeometryDataKHR geometry_data;
@@ -5184,7 +5214,7 @@ void Device::CreateHardwareRaytracingScene()
                 vk::Format::eR32G32B32Sfloat,
                 vk::DeviceOrHostAddressConstKHR(vertex_address),
                 kRaytraceTriangleVertexStrideBytes,
-                vertex_count,
+                GetAccelerationStructureMaxVertex(vertex_count),
                 vk::IndexType::eUint32,
                 vk::DeviceOrHostAddressConstKHR(index_address));
             vk::AccelerationStructureGeometryDataKHR geometry_data;

--- a/frame/vulkan/json/parse_scene_tree.cpp
+++ b/frame/vulkan/json/parse_scene_tree.cpp
@@ -1128,6 +1128,15 @@ std::array<float, 4> GetRaytracingAtlasUvBounds(
     return {u0, std::max(u0, u1), v0, std::max(v0, v1)};
 }
 
+float WrapRaytracingAtlasUv(float value)
+{
+    if (!std::isfinite(value))
+    {
+        return 0.0f;
+    }
+    return value - std::floor(value);
+}
+
 std::vector<float> RemapRaytracingAtlasUvs(
     const std::vector<float>& textures,
     const std::optional<RaytracingTextureAtlasLayout>& layout,
@@ -1143,8 +1152,8 @@ std::vector<float> RemapRaytracingAtlasUvs(
     std::vector<float> remapped = textures;
     for (std::size_t i = 0; i + 1u < remapped.size(); i += 2u)
     {
-        const float u = std::clamp(remapped[i], 0.0f, 1.0f);
-        const float v = std::clamp(remapped[i + 1u], 0.0f, 1.0f);
+        const float u = WrapRaytracingAtlasUv(remapped[i]);
+        const float v = WrapRaytracingAtlasUv(remapped[i + 1u]);
         remapped[i] = bounds[0] + (bounds[1] - bounds[0]) * u;
         remapped[i + 1u] = bounds[2] + (bounds[3] - bounds[2]) * v;
     }
@@ -1948,6 +1957,106 @@ glm::uvec2 ResolveTextureDisplaySize(LevelInterface& level)
         return {1u, 1u};
     }
     return level.GetTextureFromId(output_id).GetSize();
+}
+
+glm::vec3 NormalizeBasisVector(
+    glm::vec3 value,
+    glm::vec3 fallback,
+    const char* field_name,
+    const std::string& mesh_name)
+{
+    if (glm::length(value) <= 1.0e-6f)
+    {
+        if (glm::length(fallback) <= 1.0e-6f)
+        {
+            throw std::runtime_error(std::format(
+                "NodeMesh {} has invalid {} basis vector.",
+                mesh_name,
+                field_name));
+        }
+        value = fallback;
+    }
+    return glm::normalize(value);
+}
+
+glm::mat4 BuildAssetBasisCorrection(
+    const frame::proto::NodeMesh& proto_mesh)
+{
+    glm::vec3 asset_front = proto_mesh.has_asset_front()
+        ? frame::json::ParseUniform(proto_mesh.asset_front())
+        : glm::vec3(1.0f, 0.0f, 0.0f);
+    glm::vec3 asset_up = proto_mesh.has_asset_up()
+        ? frame::json::ParseUniform(proto_mesh.asset_up())
+        : glm::vec3(0.0f, 1.0f, 0.0f);
+
+    asset_front = NormalizeBasisVector(
+        asset_front,
+        glm::vec3(1.0f, 0.0f, 0.0f),
+        "asset_front",
+        proto_mesh.name());
+    asset_up = NormalizeBasisVector(
+        asset_up,
+        glm::vec3(0.0f, 1.0f, 0.0f),
+        "asset_up",
+        proto_mesh.name());
+
+    glm::vec3 asset_side = glm::cross(asset_front, asset_up);
+    if (glm::length(asset_side) <= 1.0e-6f)
+    {
+        throw std::runtime_error(std::format(
+            "NodeMesh {} has parallel asset_front and asset_up vectors.",
+            proto_mesh.name()));
+    }
+    asset_side = glm::normalize(asset_side);
+    const glm::vec3 corrected_asset_up =
+        glm::normalize(glm::cross(asset_side, asset_front));
+
+    const glm::mat3 asset_basis(
+        asset_front,
+        corrected_asset_up,
+        asset_side);
+    return glm::mat4(glm::inverse(asset_basis));
+}
+
+std::string AddAssetBasisNodeIfNeeded(
+    LevelInterface& level,
+    const frame::proto::NodeMesh& proto_mesh)
+{
+    if (!proto_mesh.has_asset_front() && !proto_mesh.has_asset_up())
+    {
+        return proto_mesh.parent();
+    }
+
+    const std::string basis_node_name =
+        std::format("{}.__asset_basis", proto_mesh.name());
+    auto basis_node = std::make_unique<frame::NodeMatrix>(
+        MakeResolver(level),
+        BuildAssetBasisCorrection(proto_mesh),
+        false);
+    basis_node->GetData().set_name(basis_node_name);
+    basis_node->SetParentName(proto_mesh.parent());
+    const auto basis_node_id = level.AddSceneNode(std::move(basis_node));
+    if (!basis_node_id)
+    {
+        throw std::runtime_error(std::format(
+            "Failed to add asset basis node for mesh {}.",
+            proto_mesh.name()));
+    }
+    return basis_node_name;
+}
+
+void CopyAssetBasisFields(
+    frame::proto::NodeMesh& destination,
+    const frame::proto::NodeMesh& source)
+{
+    if (source.has_asset_front())
+    {
+        destination.mutable_asset_front()->CopyFrom(source.asset_front());
+    }
+    if (source.has_asset_up())
+    {
+        destination.mutable_asset_up()->CopyFrom(source.asset_up());
+    }
 }
 
 struct MaterialTextureSource
@@ -2944,6 +3053,8 @@ bool ParseNodeMesh(
             scene_global_inverse = scene->mRootNode->mTransformation;
             scene_global_inverse.Inverse();
         }
+        const std::string mesh_parent =
+            AddAssetBasisNodeIfNeeded(level, proto_mesh);
         scene_animation_clips.reserve(scene->mNumAnimations);
         for (unsigned int animation_index = 0;
              animation_index < scene->mNumAnimations;
@@ -4140,7 +4251,7 @@ bool ParseNodeMesh(
                                               proto_mesh.name(),
                                               counter);
             node->SetName(node_name);
-            node->SetParentName(proto_mesh.parent());
+            node->SetParentName(mesh_parent);
             node->GetData().set_render_time_enum(proto_mesh.render_time_enum());
             node->GetData().set_acceleration_structure_enum(
                 proto_mesh.acceleration_structure_enum());
@@ -4160,6 +4271,7 @@ bool ParseNodeMesh(
                 node->GetData().set_animation_clip_index(
                     proto_mesh.animation_clip_index());
             }
+            CopyAssetBasisFields(node->GetData(), proto_mesh);
 
             auto scene_id = level.AddSceneNode(std::move(node));
             if (!material_id)


### PR DESCRIPTION
## Summary
- add optional `asset_front` / `asset_up` fields to `NodeMesh` and preserve them during scene serialization
- apply asset-basis correction in the Vulkan glTF scene loader so meshes with different local front/up conventions can face Frame's +X/+Y basis through JSON
- wrap raytracing atlas UVs instead of clamping tiled UVs, and fix dynamic/skinned BLAS update geometry pointers/max vertex values

## Verification
- `cmake --build build\windows --config Debug --target grpcmmo_client -- /m:1`
- `ctest --test-dir build\windows -C Debug -R grpcmmo_client_tests --output-on-failure`
- Vulkan/raytrace client screenshot run with skinned CesiumMan mesh and tiled ground texture