### PR TITLE
[codex] Add selectable raster rendering path

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,27 +71,28 @@ The samples are built into `build/<preset>/bin/`.
 Windows example:
 
 ```sh
-build/windows/bin/Debug/01_RayTracing.exe --device=vulkan
-build/windows/bin/Debug/01_RayTracing.exe --device=opengl
+build/windows/bin/Debug/01_Refraction.exe --device=vulkan
+build/windows/bin/Debug/01_Refraction.exe --device=opengl
 ```
 
 Linux example:
 
 ```sh
-./build/linux-debug/bin/01_RayTracing --device=vulkan
-./build/linux-debug/bin/01_RayTracing --device=opengl
+./build/linux-debug/bin/01_Refraction --device=vulkan
+./build/linux-debug/bin/01_Refraction --device=opengl
 ```
 
 Available examples:
 
 - `00_Cubemap`
-- `01_RayTracing`
+- `01_Refraction`
 - `02_Dragon`
 - `03_SkinnedMesh`
 
 Useful runtime flags:
 
 - `--device={vulkan|opengl}`: choose rendering backend
+- `--rendering={auto|rasterise|raytrace}`: choose generated render path
 - `--vk_validation={true|false}`: toggle Vulkan validation layers
 
 ## Run Tests

--- a/asset/shader/opengl/CMakeLists.txt
+++ b/asset/shader/opengl/CMakeLists.txt
@@ -32,6 +32,8 @@ add_custom_target(AssetShaderOpenGL
     monte_carlo_prefilter.vert
     physically_based_rendering.frag
     physically_based_rendering.vert
+    raster_gltf.frag
+    raster_gltf.vert
     raytrace.frag
     raytrace.vert
     raytrace_bvh_refit.comp

--- a/asset/shader/opengl/raster_gltf.frag
+++ b/asset/shader/opengl/raster_gltf.frag
@@ -1,0 +1,186 @@
+#version 330 core
+
+in vec3 vert_normal;
+in vec2 vert_texcoord;
+in vec3 vert_world_pos;
+
+out vec4 frag_color;
+
+uniform sampler2D albedo_texture;
+uniform samplerCube skybox_env;
+uniform sampler2D normal_texture;
+uniform sampler2D roughness_texture;
+uniform sampler2D metallic_texture;
+uniform sampler2D ao_texture;
+uniform sampler2D transmission_texture;
+uniform sampler2D ior_texture;
+uniform sampler2D thickness_texture;
+uniform sampler2D attenuation_color_texture;
+uniform sampler2D specular_factor_texture;
+uniform sampler2D specular_color_texture;
+uniform mat4 view;
+uniform vec3 light_dir;
+uniform int light_type;
+uniform vec3 light_color;
+uniform sampler2D shadow_map;
+uniform mat4 light_view_projection;
+uniform int shadow_enabled;
+uniform float shadow_bias;
+uniform float shadow_map_size;
+
+const float pi = 3.14159265359;
+
+vec3 apply_normal_map(vec3 normal)
+{
+    vec3 mapped = texture(normal_texture, vert_texcoord).xyz * 2.0 - 1.0;
+    vec3 up = abs(normal.y) < 0.999 ? vec3(0.0, 1.0, 0.0)
+                                    : vec3(1.0, 0.0, 0.0);
+    vec3 tangent = normalize(cross(up, normal));
+    vec3 bitangent = cross(normal, tangent);
+    return normalize(
+        tangent * mapped.x + bitangent * mapped.y + normal * mapped.z);
+}
+
+float distribution_ggx(vec3 normal, vec3 halfway, float roughness)
+{
+    float alpha = max(roughness * roughness, 0.001);
+    float alpha2 = alpha * alpha;
+    float ndoth = max(dot(normal, halfway), 0.0);
+    float ndoth2 = ndoth * ndoth;
+    float denom = ndoth2 * (alpha2 - 1.0) + 1.0;
+    return alpha2 / max(pi * denom * denom, 0.0001);
+}
+
+float geometry_schlick_ggx(float ndotv, float roughness)
+{
+    float r = roughness + 1.0;
+    float k = (r * r) / 8.0;
+    return ndotv / max(ndotv * (1.0 - k) + k, 0.0001);
+}
+
+float geometry_smith(vec3 normal, vec3 view, vec3 light, float roughness)
+{
+    float ndotv = max(dot(normal, view), 0.0);
+    float ndotl = max(dot(normal, light), 0.0);
+    return geometry_schlick_ggx(ndotv, roughness) *
+           geometry_schlick_ggx(ndotl, roughness);
+}
+
+vec3 fresnel_schlick(float cos_theta, vec3 f0)
+{
+    return f0 + (1.0 - f0) * pow(1.0 - clamp(cos_theta, 0.0, 1.0), 5.0);
+}
+
+vec3 fresnel_schlick_roughness(float cos_theta, vec3 f0, float roughness)
+{
+    vec3 rough_f0 = max(vec3(1.0 - roughness), f0);
+    return f0 + (rough_f0 - f0) *
+                    pow(1.0 - clamp(cos_theta, 0.0, 1.0), 5.0);
+}
+
+float sample_shadow(vec3 normal, vec3 light)
+{
+    if (shadow_enabled == 0)
+    {
+        return 1.0;
+    }
+
+    vec4 light_clip = light_view_projection * vec4(vert_world_pos, 1.0);
+    if (abs(light_clip.w) < 0.0001)
+    {
+        return 1.0;
+    }
+    vec3 light_ndc = light_clip.xyz / light_clip.w;
+    vec2 shadow_uv = light_ndc.xy * 0.5 + 0.5;
+    float current_depth = light_ndc.z * 0.5 + 0.5;
+    if (shadow_uv.x < 0.0 || shadow_uv.x > 1.0 || shadow_uv.y < 0.0 ||
+        shadow_uv.y > 1.0 || current_depth < 0.0 || current_depth > 1.0)
+    {
+        return 1.0;
+    }
+
+    float bias = max(shadow_bias * (1.0 - dot(normal, light)), 0.0008);
+    vec2 texel_size = vec2(1.0 / max(shadow_map_size, 1.0));
+    float visibility = 0.0;
+    for (int x = -1; x <= 1; ++x)
+    {
+        for (int y = -1; y <= 1; ++y)
+        {
+            float closest_depth =
+                texture(shadow_map, shadow_uv + vec2(x, y) * texel_size).r;
+            visibility += current_depth - bias <= closest_depth ? 1.0 : 0.25;
+        }
+    }
+    return visibility / 9.0;
+}
+
+void main()
+{
+    vec3 normal = apply_normal_map(normalize(vert_normal));
+    vec3 camera_pos = vec3(inverse(view)[3]);
+    vec3 view_dir = normalize(camera_pos - vert_world_pos);
+    vec3 reflected_dir = reflect(-view_dir, normal);
+
+    vec3 albedo = texture(albedo_texture, vert_texcoord).rgb;
+    float roughness =
+        clamp(texture(roughness_texture, vert_texcoord).r, 0.04, 1.0);
+    float metallic =
+        clamp(texture(metallic_texture, vert_texcoord).r, 0.0, 1.0);
+    float ao = clamp(texture(ao_texture, vert_texcoord).r, 0.0, 1.0);
+    float transmission =
+        clamp(texture(transmission_texture, vert_texcoord).r, 0.0, 1.0);
+    float ior = max(texture(ior_texture, vert_texcoord).r, 1.01);
+    float thickness =
+        clamp(texture(thickness_texture, vert_texcoord).r, 0.0, 1.0);
+    vec3 attenuation = texture(attenuation_color_texture, vert_texcoord).rgb;
+    float specular_factor =
+        clamp(texture(specular_factor_texture, vert_texcoord).a, 0.0, 1.0);
+    vec3 specular_tint =
+        clamp(texture(specular_color_texture, vert_texcoord).rgb, 0.0, 1.0);
+
+    vec3 light = length(light_dir) > 0.0
+        ? normalize(-light_dir)
+        : normalize(vec3(-0.4, -0.7, 0.6));
+    vec3 halfway = normalize(view_dir + light);
+    float ndotv = max(dot(normal, view_dir), 0.0);
+    float ndotl = max(dot(normal, light), 0.0);
+    float shadow = sample_shadow(normal, light);
+    vec3 env_reflection = texture(skybox_env, reflected_dir).rgb;
+    vec3 dielectric_f0 = vec3(0.04) * specular_factor * specular_tint;
+    vec3 f0 = mix(dielectric_f0, albedo, metallic);
+
+    float normal_distribution = distribution_ggx(normal, halfway, roughness);
+    float geometry = geometry_smith(normal, view_dir, light, roughness);
+    vec3 fresnel = fresnel_schlick(max(dot(halfway, view_dir), 0.0), f0);
+    vec3 specular_brdf =
+        normal_distribution * geometry * fresnel /
+        max(4.0 * ndotv * ndotl, 0.0001);
+    vec3 diffuse_weight = (vec3(1.0) - fresnel) * (1.0 - metallic);
+    vec3 direct =
+        (diffuse_weight * albedo / pi + specular_brdf) *
+        max(light_color, vec3(0.0)) *
+        ndotl *
+        shadow;
+
+    vec3 env_diffuse = texture(skybox_env, normal).rgb * albedo;
+    vec3 env_fresnel = fresnel_schlick_roughness(ndotv, f0, roughness);
+    vec3 env_diffuse_weight = (vec3(1.0) - env_fresnel) * (1.0 - metallic);
+    vec3 env_specular =
+        env_reflection * env_fresnel * mix(1.0, 0.18, roughness);
+    vec3 ambient = (env_diffuse_weight * env_diffuse * 0.35 + env_specular) * ao;
+    vec3 surface_color = direct + ambient;
+
+    vec3 refracted_dir = refract(-view_dir, normal, 1.0 / ior);
+    if (length(refracted_dir) < 0.001)
+    {
+        refracted_dir = reflected_dir;
+    }
+    vec3 env_refraction = texture(skybox_env, refracted_dir).rgb;
+    float transmission_fresnel = max(max(env_fresnel.r, env_fresnel.g), env_fresnel.b);
+    vec3 transmission_color =
+        mix(env_refraction * albedo * attenuation, env_reflection, transmission_fresnel);
+    transmission_color = mix(transmission_color, env_reflection, thickness);
+
+    vec3 color = mix(surface_color, transmission_color, transmission);
+    frag_color = vec4(color, 1.0);
+}

--- a/asset/shader/opengl/raster_gltf.vert
+++ b/asset/shader/opengl/raster_gltf.vert
@@ -1,0 +1,39 @@
+#version 330 core
+
+layout(location = 0) in vec3 in_position;
+layout(location = 1) in vec3 in_normal;
+layout(location = 2) in vec2 in_texcoord;
+layout(location = 3) in ivec4 in_bone_ids;
+layout(location = 4) in vec4 in_bone_weights;
+
+out vec3 vert_normal;
+out vec2 vert_texcoord;
+out vec3 vert_world_pos;
+
+uniform mat4 projection;
+uniform mat4 view;
+uniform mat4 model;
+uniform int skinning_enabled;
+uniform mat4 bone_matrices[128];
+
+void main()
+{
+    vec4 local_position = vec4(in_position, 1.0);
+    vec3 local_normal = in_normal;
+    if (skinning_enabled != 0)
+    {
+        mat4 skin =
+            in_bone_weights.x * bone_matrices[in_bone_ids.x] +
+            in_bone_weights.y * bone_matrices[in_bone_ids.y] +
+            in_bone_weights.z * bone_matrices[in_bone_ids.z] +
+            in_bone_weights.w * bone_matrices[in_bone_ids.w];
+        local_position = skin * local_position;
+        local_normal = mat3(skin) * local_normal;
+    }
+
+    vec4 world_pos = model * local_position;
+    vert_world_pos = world_pos.xyz;
+    vert_normal = normalize(transpose(inverse(mat3(model))) * local_normal);
+    vert_texcoord = in_texcoord;
+    gl_Position = projection * view * world_pos;
+}

--- a/asset/shader/vulkan/CMakeLists.txt
+++ b/asset/shader/vulkan/CMakeLists.txt
@@ -7,6 +7,9 @@ set(_frame_vulkan_shader_sources
   ray_marching.vert
   cubemap.frag
   cubemap.vert
+  raster_gltf.frag
+  raster_gltf.vert
+  raster_shadow.vert
   raytrace.vert
   raytrace.frag
   raytrace.comp

--- a/asset/shader/vulkan/raster_gltf.frag
+++ b/asset/shader/vulkan/raster_gltf.frag
@@ -1,0 +1,201 @@
+#version 450
+
+layout(location = 0) in vec2 frag_uv;
+layout(location = 1) in vec3 frag_normal;
+layout(location = 2) in vec3 frag_skybox_dir;
+layout(location = 3) in float frag_skybox;
+layout(location = 4) in vec3 frag_world_pos;
+layout(location = 0) out vec4 frag_color;
+
+layout(set = 0, binding = 0) uniform sampler2D albedo_texture;
+layout(set = 0, binding = 1) uniform samplerCube skybox;
+layout(set = 0, binding = 2) uniform samplerCube skybox_env;
+layout(set = 0, binding = 3) uniform sampler2D normal_texture;
+layout(set = 0, binding = 4) uniform sampler2D roughness_texture;
+layout(set = 0, binding = 5) uniform sampler2D metallic_texture;
+layout(set = 0, binding = 6) uniform sampler2D ao_texture;
+layout(set = 0, binding = 7) uniform sampler2D transmission_texture;
+layout(set = 0, binding = 8) uniform sampler2D ior_texture;
+layout(set = 0, binding = 9) uniform sampler2D thickness_texture;
+layout(set = 0, binding = 10) uniform sampler2D attenuation_color_texture;
+layout(set = 0, binding = 11) uniform sampler2D specular_factor_texture;
+layout(set = 0, binding = 12) uniform sampler2D specular_color_texture;
+layout(set = 0, binding = 13) uniform sampler2D shadow_map;
+layout(set = 0, binding = 14) uniform UniformBlock
+{
+    mat4 projection;
+    mat4 view;
+    mat4 projection_inv;
+    mat4 view_inv;
+    mat4 model;
+    mat4 model_inv;
+    mat4 env_map_model;
+    vec4 camera_position;
+    vec4 light_dir;
+    vec4 light_color;
+    vec4 time_s;
+    mat4 light_view_projection;
+    vec4 shadow_params;
+} ubo;
+
+layout(push_constant) uniform PushConstants
+{
+    mat4 projection;
+    mat4 view;
+    mat4 model;
+    float time_s;
+} pc;
+
+const float pi = 3.14159265359;
+
+vec3 apply_normal_map(vec3 normal)
+{
+    vec3 mapped = texture(normal_texture, frag_uv).xyz * 2.0 - 1.0;
+    vec3 up = abs(normal.y) < 0.999 ? vec3(0.0, 1.0, 0.0)
+                                    : vec3(1.0, 0.0, 0.0);
+    vec3 tangent = normalize(cross(up, normal));
+    vec3 bitangent = cross(normal, tangent);
+    return normalize(
+        tangent * mapped.x + bitangent * mapped.y + normal * mapped.z);
+}
+
+float distribution_ggx(vec3 normal, vec3 halfway, float roughness)
+{
+    float alpha = max(roughness * roughness, 0.001);
+    float alpha2 = alpha * alpha;
+    float ndoth = max(dot(normal, halfway), 0.0);
+    float ndoth2 = ndoth * ndoth;
+    float denom = ndoth2 * (alpha2 - 1.0) + 1.0;
+    return alpha2 / max(pi * denom * denom, 0.0001);
+}
+
+float geometry_schlick_ggx(float ndotv, float roughness)
+{
+    float r = roughness + 1.0;
+    float k = (r * r) / 8.0;
+    return ndotv / max(ndotv * (1.0 - k) + k, 0.0001);
+}
+
+float geometry_smith(vec3 normal, vec3 view, vec3 light, float roughness)
+{
+    float ndotv = max(dot(normal, view), 0.0);
+    float ndotl = max(dot(normal, light), 0.0);
+    return geometry_schlick_ggx(ndotv, roughness) *
+           geometry_schlick_ggx(ndotl, roughness);
+}
+
+vec3 fresnel_schlick(float cos_theta, vec3 f0)
+{
+    return f0 + (1.0 - f0) * pow(1.0 - clamp(cos_theta, 0.0, 1.0), 5.0);
+}
+
+vec3 fresnel_schlick_roughness(float cos_theta, vec3 f0, float roughness)
+{
+    vec3 rough_f0 = max(vec3(1.0 - roughness), f0);
+    return f0 + (rough_f0 - f0) *
+                    pow(1.0 - clamp(cos_theta, 0.0, 1.0), 5.0);
+}
+
+float sample_shadow(vec3 normal, vec3 light)
+{
+    if (ubo.shadow_params.x < 0.5)
+    {
+        return 1.0;
+    }
+
+    vec4 light_clip =
+        ubo.light_view_projection * vec4(frag_world_pos, 1.0);
+    vec3 light_ndc = light_clip.xyz / light_clip.w;
+    vec2 shadow_uv = light_ndc.xy * 0.5 + 0.5;
+    float current_depth = light_ndc.z;
+    if (shadow_uv.x < 0.0 || shadow_uv.x > 1.0 || shadow_uv.y < 0.0 ||
+        shadow_uv.y > 1.0 || current_depth < 0.0 || current_depth > 1.0)
+    {
+        return 1.0;
+    }
+
+    float bias = max(ubo.shadow_params.y * (1.0 - dot(normal, light)), 0.0008);
+    vec2 texel_size = vec2(1.0 / max(ubo.shadow_params.z, 1.0));
+    float visibility = 0.0;
+    for (int x = -1; x <= 1; ++x)
+    {
+        for (int y = -1; y <= 1; ++y)
+        {
+            float closest_depth =
+                texture(shadow_map, shadow_uv + vec2(x, y) * texel_size).r;
+            visibility += current_depth - bias <= closest_depth ? 1.0 : 0.25;
+        }
+    }
+    return visibility / 9.0;
+}
+
+void main()
+{
+    if (frag_skybox > 0.5)
+    {
+        frag_color = texture(skybox, frag_skybox_dir);
+        return;
+    }
+
+    vec3 normal = apply_normal_map(normalize(frag_normal));
+    vec3 view_dir = normalize(ubo.camera_position.xyz - frag_world_pos);
+    vec3 reflected_dir = reflect(-view_dir, normal);
+
+    vec3 albedo = texture(albedo_texture, frag_uv).rgb;
+    float roughness = clamp(texture(roughness_texture, frag_uv).r, 0.04, 1.0);
+    float metallic = clamp(texture(metallic_texture, frag_uv).r, 0.0, 1.0);
+    float ao = clamp(texture(ao_texture, frag_uv).r, 0.0, 1.0);
+    float transmission =
+        clamp(texture(transmission_texture, frag_uv).r, 0.0, 1.0);
+    float ior = max(texture(ior_texture, frag_uv).r, 1.01);
+    float thickness = clamp(texture(thickness_texture, frag_uv).r, 0.0, 1.0);
+    vec3 attenuation = texture(attenuation_color_texture, frag_uv).rgb;
+    float specular_factor =
+        clamp(texture(specular_factor_texture, frag_uv).a, 0.0, 1.0);
+    vec3 specular_tint =
+        clamp(texture(specular_color_texture, frag_uv).rgb, 0.0, 1.0);
+
+    vec3 light = length(ubo.light_dir.xyz) > 0.0
+        ? normalize(-ubo.light_dir.xyz)
+        : normalize(vec3(-0.4, -0.7, 0.6));
+    vec3 halfway = normalize(view_dir + light);
+    float ndotv = max(dot(normal, view_dir), 0.0);
+    float ndotl = max(dot(normal, light), 0.0);
+    float shadow = sample_shadow(normal, light);
+    vec3 env_reflection = texture(skybox_env, reflected_dir).rgb;
+    vec3 dielectric_f0 = vec3(0.04) * specular_factor * specular_tint;
+    vec3 f0 = mix(dielectric_f0, albedo, metallic);
+
+    float normal_distribution = distribution_ggx(normal, halfway, roughness);
+    float geometry = geometry_smith(normal, view_dir, light, roughness);
+    vec3 fresnel = fresnel_schlick(max(dot(halfway, view_dir), 0.0), f0);
+    vec3 specular_brdf =
+        normal_distribution * geometry * fresnel /
+        max(4.0 * ndotv * ndotl, 0.0001);
+    vec3 diffuse_weight = (vec3(1.0) - fresnel) * (1.0 - metallic);
+    vec3 direct =
+        (diffuse_weight * albedo / pi + specular_brdf) *
+        max(ubo.light_color.rgb, vec3(0.0)) * ndotl * shadow;
+
+    vec3 env_diffuse = texture(skybox_env, normal).rgb * albedo;
+    vec3 env_fresnel = fresnel_schlick_roughness(ndotv, f0, roughness);
+    vec3 env_diffuse_weight = (vec3(1.0) - env_fresnel) * (1.0 - metallic);
+    vec3 env_specular =
+        env_reflection * env_fresnel * mix(1.0, 0.18, roughness);
+    vec3 ambient = (env_diffuse_weight * env_diffuse * 0.35 + env_specular) * ao;
+    vec3 surface_color = direct + ambient;
+
+    vec3 refracted_dir = refract(-view_dir, normal, 1.0 / ior);
+    if (length(refracted_dir) < 0.001)
+    {
+        refracted_dir = reflected_dir;
+    }
+    vec3 env_refraction = texture(skybox_env, refracted_dir).rgb;
+    float transmission_fresnel = max(max(env_fresnel.r, env_fresnel.g), env_fresnel.b);
+    vec3 transmission_color =
+        mix(env_refraction * albedo * attenuation, env_reflection, transmission_fresnel);
+    transmission_color = mix(transmission_color, env_reflection, thickness);
+
+    vec3 color = mix(surface_color, transmission_color, transmission);
+    frag_color = vec4(color, 1.0);
+}

--- a/asset/shader/vulkan/raster_gltf.vert
+++ b/asset/shader/vulkan/raster_gltf.vert
@@ -1,0 +1,42 @@
+#version 450
+
+layout(location = 0) in vec3 in_position;
+layout(location = 1) in vec3 in_normal;
+layout(location = 2) in vec2 in_texcoord;
+
+layout(location = 0) out vec2 frag_uv;
+layout(location = 1) out vec3 frag_normal;
+layout(location = 2) out vec3 frag_skybox_dir;
+layout(location = 3) out float frag_skybox;
+layout(location = 4) out vec3 frag_world_pos;
+
+layout(push_constant) uniform PushConstants
+{
+    mat4 projection;
+    mat4 view;
+    mat4 model;
+    float time_s;
+} pc;
+
+void main()
+{
+    frag_uv = in_texcoord;
+    vec4 world_pos = pc.model * vec4(in_position, 1.0);
+    frag_world_pos = world_pos.xyz;
+    frag_normal = normalize(transpose(inverse(mat3(pc.model))) * in_normal);
+    frag_skybox_dir = in_position;
+    frag_skybox = pc.time_s < 0.0 ? 1.0 : 0.0;
+    if (frag_skybox > 0.5)
+    {
+        mat4 rotation_view = mat4(mat3(pc.view));
+        mat4 rotation_model = mat4(mat3(pc.model));
+        mat4 pvm = pc.projection * rotation_view * rotation_model;
+        vec4 clip_pos = pvm * vec4(in_position.x, -in_position.yz, 1.0);
+        gl_Position = vec4(clip_pos.xy, clip_pos.w, clip_pos.w);
+    }
+    else
+    {
+        gl_Position = pc.projection * pc.view * pc.model *
+            vec4(in_position, 1.0);
+    }
+}

--- a/asset/shader/vulkan/raster_shadow.vert
+++ b/asset/shader/vulkan/raster_shadow.vert
@@ -1,0 +1,14 @@
+#version 450
+
+layout(location = 0) in vec3 in_position;
+
+layout(push_constant) uniform PushConstants
+{
+    mat4 light_view_projection;
+    mat4 model;
+} pc;
+
+void main()
+{
+    gl_Position = pc.light_view_projection * pc.model * vec4(in_position, 1.0);
+}

--- a/asset/shader/vulkan/raytrace.comp
+++ b/asset/shader/vulkan/raytrace.comp
@@ -89,6 +89,8 @@ layout(set = 0, binding = 12) uniform UniformBlock
     vec4 light_dir;
     vec4 light_color;
     vec4 time_s;
+    mat4 light_view_projection;
+    vec4 shadow_params;
 } ubo;
 
 struct HitInfo

--- a/asset/shader/vulkan/raytrace.rgen
+++ b/asset/shader/vulkan/raytrace.rgen
@@ -72,6 +72,8 @@ layout(set = 0, binding = 12) uniform UniformBlock
     vec4 light_dir;
     vec4 light_color;
     vec4 time_s;
+    mat4 light_view_projection;
+    vec4 shadow_params;
 } ubo;
 
 struct HardwareRaytraceInstanceData

--- a/examples/00-cubemap/main.cpp
+++ b/examples/00-cubemap/main.cpp
@@ -22,13 +22,14 @@ int Run(int argc, char** argv)
 {
     absl::SetProgramUsageMessage(
         "00_Cubemap --device={vulkan|opengl} "
+        "[--rendering={auto|rasterise|raytrace}] "
         "[--auto_exit_seconds=<seconds>] (defaults to vulkan)");
     frame::common::Application app(argc, argv, kDefaultSize);
     app.Startup(frame::file::FindFile(kLevelPath));
     app.Run();
     return 0;
 }
-}
+} // namespace
 
 #if defined(_WIN32) || defined(_WIN64)
 int WINAPI WinMain(

--- a/examples/01-refraction/CMakeLists.txt
+++ b/examples/01-refraction/CMakeLists.txt
@@ -1,19 +1,19 @@
-# Ray Tracing (simple)
+# Refraction
 
-add_executable(01_RayTracing
+add_executable(01_Refraction
   WIN32
     main.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../asset/json/raytracing.json
 )
 
-target_include_directories(01_RayTracing
+target_include_directories(01_Refraction
   PUBLIC
-    examples/01-raytracing
+    examples/01-refraction
     ${CMAKE_CURRENT_SOURCE_DIR}/../..
     ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-target_link_libraries(01_RayTracing
+target_link_libraries(01_Refraction
   PUBLIC
     ${FRAME_LINK_GROUP_BEGIN}
     ${FRAME_CORE_LIBS}
@@ -22,4 +22,4 @@ target_link_libraries(01_RayTracing
     ${FRAME_LINK_GROUP_END}
 )
 
-set_property(TARGET 01_RayTracing PROPERTY FOLDER "FrameExamples")
+set_property(TARGET 01_Refraction PROPERTY FOLDER "FrameExamples")

--- a/examples/01-refraction/main.cpp
+++ b/examples/01-refraction/main.cpp
@@ -1,4 +1,4 @@
-// Ray tracing example using a simple icosahedron scene.
+// Refraction example using a simple icosahedron scene.
 // From: https://sourceforge.net/p/predef/wiki/OperatingSystems/
 #if defined(_WIN32) || defined(_WIN64)
 #define WINDOWS_LEAN_AND_MEAN
@@ -35,7 +35,8 @@ try
     constexpr glm::uvec2 kDefaultSize{1280u, 720u};
     constexpr const char* kLevelPath = "asset/json/raytracing.json";
     absl::SetProgramUsageMessage(
-        "01_RayTracing --device={vulkan|opengl} "
+        "01_Refraction --device={vulkan|opengl} "
+        "[--rendering={auto|rasterise|raytrace}] "
         "[--auto_exit_seconds=<seconds>] (defaults to vulkan)");
     frame::common::Application app(ac, av, kDefaultSize);
     app.Startup(frame::file::FindFile(kLevelPath));
@@ -45,7 +46,7 @@ try
 catch (const std::exception& e)
 {
     auto& logger = frame::Logger::GetInstance();
-    logger->error("Unhandled exception in 01_RayTracing: {}", e.what());
+    logger->error("Unhandled exception in 01_Refraction: {}", e.what());
     logger->flush();
 #if defined(_WIN32) || defined(_WIN64)
     MessageBoxA(nullptr, e.what(), "Error", MB_OK | MB_ICONERROR);

--- a/examples/02-dragon/main.cpp
+++ b/examples/02-dragon/main.cpp
@@ -36,6 +36,7 @@ try
     constexpr const char* kLevelPath = "asset/json/dragon.json";
     absl::SetProgramUsageMessage(
         "02_Dragon --device={vulkan|opengl} "
+        "[--rendering={auto|rasterise|raytrace}] "
         "[--auto_exit_seconds=<seconds>] (defaults to vulkan)");
     frame::common::Application app(ac, av, kDefaultSize);
     app.Startup(frame::file::FindFile(kLevelPath));

--- a/examples/03-skinned_mesh/main.cpp
+++ b/examples/03-skinned_mesh/main.cpp
@@ -23,6 +23,7 @@ int Run(int argc, char** argv)
 {
     absl::SetProgramUsageMessage(
         "03_SkinnedMesh --device={vulkan|opengl} "
+        "[--rendering={auto|rasterise|raytrace}] "
         "[--auto_exit_seconds=<seconds>] (defaults to vulkan)");
     frame::common::Application app(argc, argv, kDefaultSize);
     app.Startup(frame::file::FindFile(kLevelPath));

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Active samples.
 
 add_subdirectory(00-cubemap)
-add_subdirectory(01-raytracing)
+add_subdirectory(01-refraction)
 add_subdirectory(02-dragon)
 add_subdirectory(03-skinned_mesh)

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,17 +5,19 @@
 Loads `asset/json/cubemap.json` and keeps the skybox/cubemap path available in
 the reduced sample set.
 
-## 01 Raytracing
+## 01 Refraction
 
-![Screenshot of the ray tracing app.](https://github.com/anirul/Frame/raw/master/examples/raytracing.png)
+![Screenshot of the refraction app.](https://github.com/anirul/Frame/raw/master/examples/raytracing.png)
 
-The simple raytracing sample. It loads `asset/json/raytracing.json` and is one
-of the active examples kept during the renderer cleanup.
+The refraction sample. It loads `asset/json/raytracing.json` and is one of the
+active examples kept during the renderer cleanup. Pass
+`--rendering=rasterise` to render the same scene through the raster path.
 
 ## 02 Dragon
 
 The dragon sample. It loads `asset/json/dragon.json` and is the main
-reference for the acceleration-structure path across both backends.
+reference for the acceleration-structure path across both backends. Pass
+`--rendering=rasterise` to render the same scene through the raster path.
 
 ## 03 Skinned Mesh
 

--- a/frame/common/application.cpp
+++ b/frame/common/application.cpp
@@ -1,5 +1,7 @@
 #include "frame/common/application.h"
 
+#include <algorithm>
+#include <array>
 #include <chrono>
 #include <stdexcept>
 #include <string_view>
@@ -15,6 +17,13 @@
 #include "frame/window_factory_internal.h"
 
 ABSL_FLAG(std::string, device, "vulkan", "Rendering backend (vulkan|opengl).");
+ABSL_FLAG(
+    std::string,
+    rendering,
+    "auto",
+    "Rendering technique "
+    "(auto|raytrace|raytracing|rasterise|rasterising|rasterize|rasterizing|"
+    "raster).");
 #if defined(_DEBUG)
 ABSL_FLAG(bool, vk_validation, true, "Enable Vulkan validation layers.");
 #else
@@ -42,15 +51,18 @@ bool StartsWith(std::string_view value, std::string_view prefix)
 
 std::string NormalizeKnownFlag(std::string_view arg)
 {
-    constexpr std::array<std::string_view, 4> kKnownFlags = {
+    constexpr std::array<std::string_view, 5> kKnownFlags = {
         "device",
+        "rendering",
         "vk_validation",
         "auto_exit_seconds",
         "screenshot_on_exit"};
     for (const auto flag_name : kKnownFlags)
     {
-        const std::string short_prefix = std::string("-") + std::string(flag_name);
-        const std::string slash_prefix = std::string("/") + std::string(flag_name);
+        const std::string short_prefix =
+            std::string("-") + std::string(flag_name);
+        const std::string slash_prefix =
+            std::string("/") + std::string(flag_name);
         if (arg == short_prefix || arg == slash_prefix ||
             StartsWith(arg, short_prefix + "=") ||
             StartsWith(arg, slash_prefix + "="))
@@ -87,10 +99,7 @@ Application::Application(std::unique_ptr<frame::WindowInterface> window)
 }
 
 Application::Application(
-    int argc,
-    char** argv,
-    glm::uvec2 size,
-    DrawingTargetEnum drawing_target)
+    int argc, char** argv, glm::uvec2 size, DrawingTargetEnum drawing_target)
 {
     auto normalized_args = NormalizeCommandLineArgs(argc, argv);
     std::vector<char*> normalized_argv = {};
@@ -100,8 +109,7 @@ Application::Application(
         normalized_argv.push_back(arg.data());
     }
     absl::ParseCommandLine(
-        static_cast<int>(normalized_argv.size()),
-        normalized_argv.data());
+        static_cast<int>(normalized_argv.size()), normalized_argv.data());
     InitializeFromArgs(argc, argv, size, drawing_target);
 }
 
@@ -159,39 +167,36 @@ WindowReturnEnum Application::Run(std::function<bool()> lambda)
     auto& logger = frame::Logger::GetInstance();
     const auto start = std::chrono::steady_clock::now();
     bool auto_exit_logged = false;
-    return GetWindow().Run(
-        [lambda = std::move(lambda),
-         auto_exit_seconds,
-         start,
-         this,
-         &logger,
-         auto_exit_logged]() mutable {
-            const auto now = std::chrono::steady_clock::now();
-            const std::chrono::duration<double> elapsed = now - start;
-            const bool keep_running = elapsed.count() < auto_exit_seconds;
-            if (!keep_running && !auto_exit_logged)
+    return GetWindow().Run([lambda = std::move(lambda),
+                            auto_exit_seconds,
+                            start,
+                            this,
+                            &logger,
+                            auto_exit_logged]() mutable {
+        const auto now = std::chrono::steady_clock::now();
+        const std::chrono::duration<double> elapsed = now - start;
+        const bool keep_running = elapsed.count() < auto_exit_seconds;
+        if (!keep_running && !auto_exit_logged)
+        {
+            if (absl::GetFlag(FLAGS_screenshot_on_exit))
             {
-                if (absl::GetFlag(FLAGS_screenshot_on_exit))
+                try
                 {
-                    try
-                    {
-                        GetWindow().GetDevice().ScreenShot("ScreenShot.png");
-                    }
-                    catch (const std::exception& ex)
-                    {
-                        logger->warn(
-                            "Failed to save screenshot on exit: {}",
-                            ex.what());
-                    }
+                    GetWindow().GetDevice().ScreenShot("ScreenShot.png");
                 }
-                logger->info(
-                    "Auto exit triggered after {:.3f} seconds.",
-                    auto_exit_seconds);
-                logger->flush();
-                auto_exit_logged = true;
+                catch (const std::exception& ex)
+                {
+                    logger->warn(
+                        "Failed to save screenshot on exit: {}", ex.what());
+                }
             }
-            return keep_running && lambda();
-        });
+            logger->info(
+                "Auto exit triggered after {:.3f} seconds.", auto_exit_seconds);
+            logger->flush();
+            auto_exit_logged = true;
+        }
+        return keep_running && lambda();
+    });
 }
 
 RenderingAPIEnum Application::ParseDeviceFlag(const std::string& value) const
@@ -206,8 +211,7 @@ RenderingAPIEnum Application::ParseDeviceFlag(const std::string& value) const
         return RenderingAPIEnum::VULKAN;
     }
     frame::Logger::GetInstance()->warn(
-        "Unknown rendering device '{}', defaulting to Vulkan.",
-        value);
+        "Unknown rendering device '{}', defaulting to Vulkan.", value);
     return RenderingAPIEnum::VULKAN;
 }
 
@@ -250,15 +254,13 @@ void Application::InitializeFromArgs(
         catch (const std::exception& ex)
         {
             frame::Logger::GetInstance()->warn(
-                "Vulkan startup failed, falling back to OpenGL: {}",
-                ex.what());
+                "Vulkan startup failed, falling back to OpenGL: {}", ex.what());
         }
     }
 
     window_ = attempt(
-        requested == RenderingAPIEnum::VULKAN
-            ? RenderingAPIEnum::OPENGL
-            : requested);
+        requested == RenderingAPIEnum::VULKAN ? RenderingAPIEnum::OPENGL
+                                              : requested);
 }
 
 } // namespace frame::common

--- a/frame/common/application.h
+++ b/frame/common/application.h
@@ -11,6 +11,7 @@
 #include "frame/window_interface.h"
 
 ABSL_DECLARE_FLAG(bool, vk_validation);
+ABSL_DECLARE_FLAG(std::string, rendering);
 ABSL_DECLARE_FLAG(double, auto_exit_seconds);
 ABSL_DECLARE_FLAG(bool, screenshot_on_exit);
 

--- a/frame/common/draw.cpp
+++ b/frame/common/draw.cpp
@@ -1,13 +1,57 @@
 #include "frame/common/draw.h"
 
+#include <algorithm>
+#include <cctype>
+#include <optional>
 #include <stdexcept>
 
+#include "absl/flags/flag.h"
+
+#include "frame/common/application.h"
 #include "frame/file/file_system.h"
 #include "frame/json/parse_level.h"
 #include "frame/level_data_startup_internal.h"
 
 namespace frame::common
 {
+
+namespace
+{
+
+std::string ToLowerAscii(std::string value)
+{
+    std::transform(
+        value.begin(), value.end(), value.begin(), [](unsigned char c) {
+            return static_cast<char>(std::tolower(c));
+        });
+    return value;
+}
+
+std::optional<frame::json::RenderPreset> ParseRenderingOverride(
+    const std::string& value)
+{
+    const auto lowered = ToLowerAscii(value);
+    if (lowered == "auto")
+    {
+        return std::nullopt;
+    }
+    if (lowered == "raytrace" || lowered == "raytracing")
+    {
+        return frame::json::RenderPreset::Raytrace;
+    }
+    if (lowered == "rasterise" || lowered == "rasterising" ||
+        lowered == "rasterize" || lowered == "rasterizing" ||
+        lowered == "raster")
+    {
+        return frame::json::RenderPreset::Raster;
+    }
+    throw std::invalid_argument(
+        "Unknown rendering mode '" + value +
+        "'. Expected auto, raytrace, raytracing, rasterise, rasterising, "
+        "rasterize, rasterizing, or raster.");
+}
+
+} // namespace
 
 // CHECKME(anirul): Why not assign size to size_?
 void Draw::Startup(glm::uvec2 size)
@@ -16,11 +60,17 @@ void Draw::Startup(glm::uvec2 size)
     if (draw_type_based_ == DrawTypeEnum::PATH)
     {
         const auto asset_root = frame::file::FindDirectory("asset");
-        const auto level_data =
-            frame::json::ParseLevelData(size_, path_, asset_root);
+        auto proto_level = frame::json::LoadLevelProto(path_);
+        frame::json::LevelDataOptions options;
+        if (const auto override_preset =
+                ParseRenderingOverride(absl::GetFlag(FLAGS_rendering)))
+        {
+            options.render_preset = *override_preset;
+        }
+        const auto level_data = frame::json::ParseLevelData(
+            size_, proto_level, asset_root, path_, options);
         auto* level_data_startup =
-            dynamic_cast<frame::internal::LevelDataStartupInterface*>(
-                &device_);
+            dynamic_cast<frame::internal::LevelDataStartupInterface*>(&device_);
         if (!level_data_startup)
         {
             throw std::runtime_error(
@@ -51,5 +101,3 @@ void Draw::PreRender(
 }
 
 } // End namespace frame::common.
-
-

--- a/frame/json/level_data.cpp
+++ b/frame/json/level_data.cpp
@@ -17,6 +17,7 @@ namespace
 enum class SupportedScenePreset
 {
     Unknown,
+    Raster,
     Cubemap,
     Raytrace,
 };
@@ -24,18 +25,14 @@ enum class SupportedScenePreset
 std::string ToLowerAscii(std::string value)
 {
     std::transform(
-        value.begin(),
-        value.end(),
-        value.begin(),
-        [](unsigned char c) {
+        value.begin(), value.end(), value.begin(), [](unsigned char c) {
             return static_cast<char>(std::tolower(c));
         });
     return value;
 }
 
 proto::Uniform MakeUniformEnum(
-    const std::string& name,
-    proto::Uniform::UniformEnum uniform_enum)
+    const std::string& name, proto::Uniform::UniformEnum uniform_enum)
 {
     proto::Uniform uniform;
     uniform.set_name(name);
@@ -86,14 +83,14 @@ ProgramInfo MakeCubemapProgram(const std::string& output_texture_name)
         0,
         proto::ProgramBinding::COMBINED_IMAGE_SAMPLER,
         {proto::ProgramStage::FRAGMENT});
-    *program.add_uniforms() = MakeUniformEnum(
-        "projection", proto::Uniform::PROJECTION_MAT4);
-    *program.add_uniforms() = MakeUniformEnum(
-        "view", proto::Uniform::VIEW_MAT4);
-    *program.add_uniforms() = MakeUniformEnum(
-        "model", proto::Uniform::MODEL_MAT4);
-    *program.add_uniforms() = MakeUniformEnum(
-        "time_s", proto::Uniform::FLOAT_TIME_S);
+    *program.add_uniforms() =
+        MakeUniformEnum("projection", proto::Uniform::PROJECTION_MAT4);
+    *program.add_uniforms() =
+        MakeUniformEnum("view", proto::Uniform::VIEW_MAT4);
+    *program.add_uniforms() =
+        MakeUniformEnum("model", proto::Uniform::MODEL_MAT4);
+    *program.add_uniforms() =
+        MakeUniformEnum("time_s", proto::Uniform::FLOAT_TIME_S);
     return MakeProgramInfo(
         std::move(program),
         {.vertex_shader = "cubemap.vert", .fragment_shader = "cubemap.frag"},
@@ -102,29 +99,28 @@ ProgramInfo MakeCubemapProgram(const std::string& output_texture_name)
 
 void AddSharedRaytracingUniforms(proto::Program& program)
 {
-    *program.add_uniforms() = MakeUniformEnum(
-        "projection", proto::Uniform::PROJECTION_MAT4);
-    *program.add_uniforms() = MakeUniformEnum(
-        "view", proto::Uniform::VIEW_MAT4);
-    *program.add_uniforms() = MakeUniformEnum(
-        "projection_inv", proto::Uniform::PROJECTION_INV_MAT4);
-    *program.add_uniforms() = MakeUniformEnum(
-        "view_inv", proto::Uniform::VIEW_INV_MAT4);
-    *program.add_uniforms() = MakeUniformEnum(
-        "model", proto::Uniform::MODEL_MAT4);
-    *program.add_uniforms() = MakeUniformEnum(
-        "model_inv", proto::Uniform::MODEL_INV_MAT4);
+    *program.add_uniforms() =
+        MakeUniformEnum("projection", proto::Uniform::PROJECTION_MAT4);
+    *program.add_uniforms() =
+        MakeUniformEnum("view", proto::Uniform::VIEW_MAT4);
+    *program.add_uniforms() =
+        MakeUniformEnum("projection_inv", proto::Uniform::PROJECTION_INV_MAT4);
+    *program.add_uniforms() =
+        MakeUniformEnum("view_inv", proto::Uniform::VIEW_INV_MAT4);
+    *program.add_uniforms() =
+        MakeUniformEnum("model", proto::Uniform::MODEL_MAT4);
+    *program.add_uniforms() =
+        MakeUniformEnum("model_inv", proto::Uniform::MODEL_INV_MAT4);
     *program.add_uniforms() = MakeUniformEnum(
         "camera_position", proto::Uniform::CAMERA_POSITION_VEC3);
-    *program.add_uniforms() = MakeUniformEnum(
-        "light_dir", proto::Uniform::LIGHT_POSITION_VEC3);
-    *program.add_uniforms() = MakeUniformEnum(
-        "light_color", proto::Uniform::LIGHT_COLOR_VEC3);
+    *program.add_uniforms() =
+        MakeUniformEnum("light_dir", proto::Uniform::LIGHT_POSITION_VEC3);
+    *program.add_uniforms() =
+        MakeUniformEnum("light_color", proto::Uniform::LIGHT_COLOR_VEC3);
 }
 
 void AddSharedRaytracingInputs(
-    proto::Program& program,
-    const std::string& output_texture_name)
+    proto::Program& program, const std::string& output_texture_name)
 {
     program.add_output_texture_names(output_texture_name);
     program.add_input_texture_names("skybox");
@@ -144,7 +140,8 @@ void AddRaytraceSceneMaterialInputs(proto::Program& program)
     program.add_input_texture_names("transmissive_ior_texture");
     program.add_input_texture_names("transmissive_thickness_texture");
     program.add_input_texture_names("transmissive_attenuation_color_texture");
-    program.add_input_texture_names("transmissive_attenuation_distance_texture");
+    program.add_input_texture_names(
+        "transmissive_attenuation_distance_texture");
     program.add_input_texture_names("opaque_albedo_texture");
     program.add_input_texture_names("opaque_normal_texture");
     program.add_input_texture_names("opaque_roughness_texture");
@@ -308,6 +305,104 @@ ProgramInfo MakeRaytraceProgram(const std::string& output_texture_name)
          .closesthit_shader = "raytrace.rchit"});
 }
 
+ProgramInfo MakeRasterSceneProgram(const std::string& output_texture_name)
+{
+    proto::Program program;
+    program.set_name("RasterSceneProgram");
+    program.set_pipeline_name("raster_scene");
+    program.add_output_texture_names(output_texture_name);
+    program.mutable_input_scene_type()->set_value(proto::SceneType::SCENE);
+    *program.add_bindings() = MakeBinding(
+        "albedo_texture",
+        0,
+        proto::ProgramBinding::COMBINED_IMAGE_SAMPLER,
+        {proto::ProgramStage::FRAGMENT});
+    program.add_input_texture_names("skybox");
+    *program.add_bindings() = MakeBinding(
+        "skybox",
+        1,
+        proto::ProgramBinding::COMBINED_IMAGE_SAMPLER,
+        {proto::ProgramStage::FRAGMENT});
+    program.add_input_texture_names("skybox_env");
+    *program.add_bindings() = MakeBinding(
+        "skybox_env",
+        2,
+        proto::ProgramBinding::COMBINED_IMAGE_SAMPLER,
+        {proto::ProgramStage::FRAGMENT});
+    *program.add_bindings() = MakeBinding(
+        "normal_texture",
+        3,
+        proto::ProgramBinding::COMBINED_IMAGE_SAMPLER,
+        {proto::ProgramStage::FRAGMENT});
+    *program.add_bindings() = MakeBinding(
+        "roughness_texture",
+        4,
+        proto::ProgramBinding::COMBINED_IMAGE_SAMPLER,
+        {proto::ProgramStage::FRAGMENT});
+    *program.add_bindings() = MakeBinding(
+        "metallic_texture",
+        5,
+        proto::ProgramBinding::COMBINED_IMAGE_SAMPLER,
+        {proto::ProgramStage::FRAGMENT});
+    *program.add_bindings() = MakeBinding(
+        "ao_texture",
+        6,
+        proto::ProgramBinding::COMBINED_IMAGE_SAMPLER,
+        {proto::ProgramStage::FRAGMENT});
+    *program.add_bindings() = MakeBinding(
+        "transmission_texture",
+        7,
+        proto::ProgramBinding::COMBINED_IMAGE_SAMPLER,
+        {proto::ProgramStage::FRAGMENT});
+    *program.add_bindings() = MakeBinding(
+        "ior_texture",
+        8,
+        proto::ProgramBinding::COMBINED_IMAGE_SAMPLER,
+        {proto::ProgramStage::FRAGMENT});
+    *program.add_bindings() = MakeBinding(
+        "thickness_texture",
+        9,
+        proto::ProgramBinding::COMBINED_IMAGE_SAMPLER,
+        {proto::ProgramStage::FRAGMENT});
+    *program.add_bindings() = MakeBinding(
+        "attenuation_color_texture",
+        10,
+        proto::ProgramBinding::COMBINED_IMAGE_SAMPLER,
+        {proto::ProgramStage::FRAGMENT});
+    *program.add_bindings() = MakeBinding(
+        "specular_factor_texture",
+        11,
+        proto::ProgramBinding::COMBINED_IMAGE_SAMPLER,
+        {proto::ProgramStage::FRAGMENT});
+    *program.add_bindings() = MakeBinding(
+        "specular_color_texture",
+        12,
+        proto::ProgramBinding::COMBINED_IMAGE_SAMPLER,
+        {proto::ProgramStage::FRAGMENT});
+    *program.add_bindings() = MakeBinding(
+        "shadow_map",
+        13,
+        proto::ProgramBinding::COMBINED_IMAGE_SAMPLER,
+        {proto::ProgramStage::FRAGMENT});
+    *program.add_bindings() = MakeBinding(
+        "UniformBlock",
+        14,
+        proto::ProgramBinding::UNIFORM_BUFFER,
+        {proto::ProgramStage::FRAGMENT});
+    *program.add_uniforms() =
+        MakeUniformEnum("projection", proto::Uniform::PROJECTION_MAT4);
+    *program.add_uniforms() =
+        MakeUniformEnum("view", proto::Uniform::VIEW_MAT4);
+    *program.add_uniforms() =
+        MakeUniformEnum("model", proto::Uniform::MODEL_MAT4);
+    return MakeProgramInfo(
+        std::move(program),
+        {.vertex_shader = "raster_gltf.vert",
+         .fragment_shader = "raster_gltf.frag"},
+        {.vertex_shader = "raster_gltf.vert",
+         .fragment_shader = "raster_gltf.frag"});
+}
+
 ProgramInfo MakeRaytracingPreprocessProgram(
     const std::string& pipeline_name,
     ShaderFiles opengl_files,
@@ -319,17 +414,27 @@ ProgramInfo MakeRaytracingPreprocessProgram(
     program.mutable_input_scene_type()->set_value(proto::SceneType::SCENE);
     AddSharedRaytracingUniforms(program);
     return MakeProgramInfo(
-        std::move(program),
-        std::move(opengl_files),
-        std::move(vulkan_files));
+        std::move(program), std::move(opengl_files), std::move(vulkan_files));
 }
 
+bool HasSkyboxRenderPass(const proto::Level& proto_level);
+
 std::vector<ProgramInfo> BuildProgramsForPreset(
-    SupportedScenePreset preset,
-    const proto::Level& proto_level)
+    SupportedScenePreset preset, const proto::Level& proto_level)
 {
     switch (preset)
     {
+    case SupportedScenePreset::Raster: {
+        std::vector<ProgramInfo> programs = {};
+        if (HasSkyboxRenderPass(proto_level))
+        {
+            programs.push_back(
+                MakeCubemapProgram(proto_level.default_texture_name()));
+        }
+        programs.push_back(
+            MakeRasterSceneProgram(proto_level.default_texture_name()));
+        return programs;
+    }
     case SupportedScenePreset::Cubemap:
         return {MakeCubemapProgram(proto_level.default_texture_name())};
     case SupportedScenePreset::Raytrace:
@@ -338,23 +443,71 @@ std::vector<ProgramInfo> BuildProgramsForPreset(
             MakeRaytraceProgram(proto_level.default_texture_name()),
             MakeRaytracingPreprocessProgram(
                 "raytrace_preprocess",
-                {.vertex_shader = "raytrace.vert", .fragment_shader = "raytrace.frag"},
-                {.vertex_shader = "raytrace.vert", .fragment_shader = "raytrace.frag"})};
+                {.vertex_shader = "raytrace.vert",
+                 .fragment_shader = "raytrace.frag"},
+                {.vertex_shader = "raytrace.vert",
+                 .fragment_shader = "raytrace.frag"})};
     case SupportedScenePreset::Unknown:
     default:
         throw std::runtime_error("Unsupported internal render preset.");
     }
 }
 
+bool HasSkyboxRenderPass(const proto::Level& proto_level)
+{
+    for (const auto& node : proto_level.scene_tree().node_meshes())
+    {
+        if (node.render_time_enum() == proto::NodeMesh::SKYBOX_RENDER_TIME)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool HasRasterSceneMesh(const proto::Level& proto_level)
+{
+    for (const auto& node : proto_level.scene_tree().node_meshes())
+    {
+        if (node.render_time_enum() != proto::NodeMesh::SCENE_RENDER_TIME)
+        {
+            continue;
+        }
+        if (node.has_clean_buffer())
+        {
+            continue;
+        }
+        if (ToLowerAscii(node.name()) == "raytracingrendering")
+        {
+            continue;
+        }
+        return true;
+    }
+    return false;
+}
+
 std::vector<RenderPassProgramInfo> BuildRenderPassProgramsForPreset(
-    SupportedScenePreset preset)
+    SupportedScenePreset preset, const proto::Level& proto_level)
 {
     switch (preset)
     {
+    case SupportedScenePreset::Raster: {
+        std::vector<RenderPassProgramInfo> passes = {};
+        if (HasSkyboxRenderPass(proto_level))
+        {
+            passes.push_back(
+                {.render_time = proto::NodeMesh::SKYBOX_RENDER_TIME,
+                 .program_name = "CubemapProgram"});
+        }
+        passes.push_back(
+            {.render_time = proto::NodeMesh::SCENE_RENDER_TIME,
+             .program_name = "RasterSceneProgram"});
+        return passes;
+    }
     case SupportedScenePreset::Cubemap:
-        return {{
-            .render_time = proto::NodeMesh::SKYBOX_RENDER_TIME,
-            .program_name = "CubemapProgram"}};
+        return {
+            {.render_time = proto::NodeMesh::SKYBOX_RENDER_TIME,
+             .program_name = "CubemapProgram"}};
     case SupportedScenePreset::Raytrace:
         return {
             {.render_time = proto::NodeMesh::SKYBOX_RENDER_TIME,
@@ -370,8 +523,7 @@ std::vector<RenderPassProgramInfo> BuildRenderPassProgramsForPreset(
     }
 }
 
-bool HasMeshFile(
-    const proto::Level& proto_level, const std::string& file_name)
+bool HasMeshFile(const proto::Level& proto_level, const std::string& file_name)
 {
     const auto expected = ToLowerAscii(file_name);
     for (const auto& node : proto_level.scene_tree().node_meshes())
@@ -388,18 +540,61 @@ bool HasMeshFile(
     return false;
 }
 
+void RemoveRaytracingResolveNodes(proto::Level& proto_level)
+{
+    if (!proto_level.has_scene_tree())
+    {
+        return;
+    }
+    auto* node_meshes = proto_level.mutable_scene_tree()->mutable_node_meshes();
+    for (int i = node_meshes->size() - 1; i >= 0; --i)
+    {
+        if (ToLowerAscii(node_meshes->Get(i).name()) == "raytracingrendering")
+        {
+            node_meshes->DeleteSubrange(i, 1);
+        }
+    }
+}
+
+void DisableRaytracingAcceleration(proto::Level& proto_level)
+{
+    if (!proto_level.has_scene_tree())
+    {
+        return;
+    }
+    for (auto& node : *proto_level.mutable_scene_tree()->mutable_node_meshes())
+    {
+        node.set_acceleration_structure_enum(proto::NodeMesh::NO_ACCELERATION);
+    }
+}
+
 SupportedScenePreset InferScenePreset(
     const proto::Level& proto_level,
-    const std::filesystem::path& source_path)
+    const std::filesystem::path& source_path,
+    const LevelDataOptions& options)
 {
     (void)source_path;
+    switch (options.render_preset)
+    {
+    case RenderPreset::Raster:
+        return HasRasterSceneMesh(proto_level) ? SupportedScenePreset::Raster
+                                               : SupportedScenePreset::Cubemap;
+    case RenderPreset::Cubemap:
+        return SupportedScenePreset::Cubemap;
+    case RenderPreset::Raytrace:
+        return HasRasterSceneMesh(proto_level) ? SupportedScenePreset::Raytrace
+                                               : SupportedScenePreset::Cubemap;
+    case RenderPreset::Auto:
+    default:
+        break;
+    }
+
     bool has_non_skybox_mesh = false;
     bool has_skybox_cube = false;
     for (const auto& node : proto_level.scene_tree().node_meshes())
     {
         if (node.render_time_enum() == proto::NodeMesh::SKYBOX_RENDER_TIME &&
-            node.has_mesh_enum() &&
-            node.mesh_enum() == proto::NodeMesh::CUBE)
+            node.has_mesh_enum() && node.mesh_enum() == proto::NodeMesh::CUBE)
         {
             has_skybox_cube = true;
             continue;
@@ -426,14 +621,23 @@ LevelData BuildLevelData(
     glm::uvec2 /*size*/,
     const proto::Level& proto_level,
     const std::filesystem::path& asset_root,
-    const std::filesystem::path& source_path)
+    const std::filesystem::path& source_path,
+    const LevelDataOptions& options)
 {
+    proto::Level prepared_level = proto_level;
+    const auto preset = InferScenePreset(prepared_level, source_path, options);
+    if (preset == SupportedScenePreset::Raster)
+    {
+        RemoveRaytracingResolveNodes(prepared_level);
+        DisableRaytracingAcceleration(prepared_level);
+    }
+
     LevelData data;
-    data.proto = proto_level;
+    data.proto = prepared_level;
     data.asset_root = asset_root;
     data.source_path = source_path;
 
-    for (const auto& proto_texture : proto_level.textures())
+    for (const auto& proto_texture : prepared_level.textures())
     {
         TextureInfo texture_info;
         texture_info.name = proto_texture.name();
@@ -448,37 +652,56 @@ LevelData BuildLevelData(
         data.textures.push_back(std::move(texture_info));
     }
 
-    const auto preset = InferScenePreset(proto_level, source_path);
     if (preset == SupportedScenePreset::Unknown)
     {
-        if (!proto_level.scene_tree().node_meshes().empty())
+        if (!prepared_level.scene_tree().node_meshes().empty())
         {
-            throw std::runtime_error(std::format(
-                "Unable to infer internal render preset for level '{}' from '{}'.",
-                proto_level.name(),
-                source_path.string()));
+            throw std::runtime_error(
+                std::format(
+                    "Unable to infer internal render preset for level '{}' "
+                    "from '{}'.",
+                    prepared_level.name(),
+                    source_path.string()));
         }
         return data;
     }
-    data.programs = BuildProgramsForPreset(preset, proto_level);
-    data.render_pass_programs = BuildRenderPassProgramsForPreset(preset);
+    data.programs = BuildProgramsForPreset(preset, prepared_level);
+    data.render_pass_programs =
+        BuildRenderPassProgramsForPreset(preset, prepared_level);
 
-    for (const auto& node : proto_level.scene_tree().node_meshes())
+    for (const auto& node : prepared_level.scene_tree().node_meshes())
     {
         if (node.mesh_enum() == frame::proto::NodeMesh::QUAD)
         {
             StaticMeshInfo mesh_info;
             mesh_info.name = node.name();
             mesh_info.positions = {
-                -0.5f, -0.5f, 0.0f,
-                0.5f, -0.5f, 0.0f,
-                0.5f, 0.5f, 0.0f,
-                -0.5f, 0.5f, 0.0f};
-            mesh_info.uvs = {
-                0.0f, 0.0f,
-                1.0f, 0.0f,
-                1.0f, 1.0f,
-                0.0f, 1.0f};
+                -0.5f,
+                -0.5f,
+                0.0f,
+                0.5f,
+                -0.5f,
+                0.0f,
+                0.5f,
+                0.5f,
+                0.0f,
+                -0.5f,
+                0.5f,
+                0.0f};
+            mesh_info.uvs = {0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f};
+            mesh_info.normals = {
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f};
             mesh_info.indices = {0, 1, 2, 2, 3, 0};
             data.meshes.push_back(std::move(mesh_info));
         }
@@ -488,90 +711,313 @@ LevelData BuildLevelData(
             mesh_info.name = node.name();
             mesh_info.positions = {
                 // Front.
-                -0.5f, -0.5f, -0.5f,
-                0.5f, -0.5f, -0.5f,
-                0.5f, 0.5f, -0.5f,
-                0.5f, 0.5f, -0.5f,
-                -0.5f, 0.5f, -0.5f,
-                -0.5f, -0.5f, -0.5f,
+                -0.5f,
+                -0.5f,
+                -0.5f,
+                0.5f,
+                -0.5f,
+                -0.5f,
+                0.5f,
+                0.5f,
+                -0.5f,
+                0.5f,
+                0.5f,
+                -0.5f,
+                -0.5f,
+                0.5f,
+                -0.5f,
+                -0.5f,
+                -0.5f,
+                -0.5f,
                 // Back.
-                -0.5f, -0.5f, 0.5f,
-                0.5f, -0.5f, 0.5f,
-                0.5f, 0.5f, 0.5f,
-                0.5f, 0.5f, 0.5f,
-                -0.5f, 0.5f, 0.5f,
-                -0.5f, -0.5f, 0.5f,
+                -0.5f,
+                -0.5f,
+                0.5f,
+                0.5f,
+                -0.5f,
+                0.5f,
+                0.5f,
+                0.5f,
+                0.5f,
+                0.5f,
+                0.5f,
+                0.5f,
+                -0.5f,
+                0.5f,
+                0.5f,
+                -0.5f,
+                -0.5f,
+                0.5f,
                 // Left.
-                -0.5f, 0.5f, 0.5f,
-                -0.5f, 0.5f, -0.5f,
-                -0.5f, -0.5f, -0.5f,
-                -0.5f, -0.5f, -0.5f,
-                -0.5f, -0.5f, 0.5f,
-                -0.5f, 0.5f, 0.5f,
+                -0.5f,
+                0.5f,
+                0.5f,
+                -0.5f,
+                0.5f,
+                -0.5f,
+                -0.5f,
+                -0.5f,
+                -0.5f,
+                -0.5f,
+                -0.5f,
+                -0.5f,
+                -0.5f,
+                -0.5f,
+                0.5f,
+                -0.5f,
+                0.5f,
+                0.5f,
                 // Right.
-                0.5f, 0.5f, 0.5f,
-                0.5f, 0.5f, -0.5f,
-                0.5f, -0.5f, -0.5f,
-                0.5f, -0.5f, -0.5f,
-                0.5f, -0.5f, 0.5f,
-                0.5f, 0.5f, 0.5f,
+                0.5f,
+                0.5f,
+                0.5f,
+                0.5f,
+                0.5f,
+                -0.5f,
+                0.5f,
+                -0.5f,
+                -0.5f,
+                0.5f,
+                -0.5f,
+                -0.5f,
+                0.5f,
+                -0.5f,
+                0.5f,
+                0.5f,
+                0.5f,
+                0.5f,
                 // Bottom.
-                -0.5f, -0.5f, -0.5f,
-                0.5f, -0.5f, -0.5f,
-                0.5f, -0.5f, 0.5f,
-                0.5f, -0.5f, 0.5f,
-                -0.5f, -0.5f, 0.5f,
-                -0.5f, -0.5f, -0.5f,
+                -0.5f,
+                -0.5f,
+                -0.5f,
+                0.5f,
+                -0.5f,
+                -0.5f,
+                0.5f,
+                -0.5f,
+                0.5f,
+                0.5f,
+                -0.5f,
+                0.5f,
+                -0.5f,
+                -0.5f,
+                0.5f,
+                -0.5f,
+                -0.5f,
+                -0.5f,
                 // Top.
-                -0.5f, 0.5f, -0.5f,
-                0.5f, 0.5f, -0.5f,
-                0.5f, 0.5f, 0.5f,
-                0.5f, 0.5f, 0.5f,
-                -0.5f, 0.5f, 0.5f,
-                -0.5f, 0.5f, -0.5f};
+                -0.5f,
+                0.5f,
+                -0.5f,
+                0.5f,
+                0.5f,
+                -0.5f,
+                0.5f,
+                0.5f,
+                0.5f,
+                0.5f,
+                0.5f,
+                0.5f,
+                -0.5f,
+                0.5f,
+                0.5f,
+                -0.5f,
+                0.5f,
+                -0.5f};
             mesh_info.uvs = {
                 // Front.
-                0.0f, 0.0f,
-                1.0f, 0.0f,
-                1.0f, 1.0f,
-                1.0f, 1.0f,
-                0.0f, 1.0f,
-                0.0f, 0.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                1.0f,
+                1.0f,
+                1.0f,
+                1.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
                 // Back.
-                0.0f, 0.0f,
-                1.0f, 0.0f,
-                1.0f, 1.0f,
-                1.0f, 1.0f,
-                0.0f, 1.0f,
-                0.0f, 0.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                1.0f,
+                1.0f,
+                1.0f,
+                1.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
                 // Left.
-                1.0f, 0.0f,
-                1.0f, 1.0f,
-                0.0f, 1.0f,
-                0.0f, 1.0f,
-                0.0f, 0.0f,
-                1.0f, 0.0f,
+                1.0f,
+                0.0f,
+                1.0f,
+                1.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
                 // Right.
-                1.0f, 0.0f,
-                1.0f, 1.0f,
-                0.0f, 1.0f,
-                0.0f, 1.0f,
-                0.0f, 0.0f,
-                1.0f, 0.0f,
+                1.0f,
+                0.0f,
+                1.0f,
+                1.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
                 // Bottom.
-                0.0f, 1.0f,
-                1.0f, 1.0f,
-                1.0f, 0.0f,
-                1.0f, 0.0f,
-                0.0f, 0.0f,
-                0.0f, 1.0f,
+                0.0f,
+                1.0f,
+                1.0f,
+                1.0f,
+                1.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                0.0f,
+                0.0f,
+                1.0f,
                 // Top.
-                0.0f, 1.0f,
-                1.0f, 1.0f,
-                1.0f, 0.0f,
-                1.0f, 0.0f,
-                0.0f, 0.0f,
-                0.0f, 1.0f};
+                0.0f,
+                1.0f,
+                1.0f,
+                1.0f,
+                1.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                0.0f,
+                0.0f,
+                1.0f};
+            mesh_info.normals = {
+                // Front.
+                0.0f,
+                0.0f,
+                -1.0f,
+                0.0f,
+                0.0f,
+                -1.0f,
+                0.0f,
+                0.0f,
+                -1.0f,
+                0.0f,
+                0.0f,
+                -1.0f,
+                0.0f,
+                0.0f,
+                -1.0f,
+                0.0f,
+                0.0f,
+                -1.0f,
+                // Back.
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                // Left.
+                -1.0f,
+                0.0f,
+                0.0f,
+                -1.0f,
+                0.0f,
+                0.0f,
+                -1.0f,
+                0.0f,
+                0.0f,
+                -1.0f,
+                0.0f,
+                0.0f,
+                -1.0f,
+                0.0f,
+                0.0f,
+                -1.0f,
+                0.0f,
+                0.0f,
+                // Right.
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                // Bottom.
+                0.0f,
+                -1.0f,
+                0.0f,
+                0.0f,
+                -1.0f,
+                0.0f,
+                0.0f,
+                -1.0f,
+                0.0f,
+                0.0f,
+                -1.0f,
+                0.0f,
+                0.0f,
+                -1.0f,
+                0.0f,
+                0.0f,
+                -1.0f,
+                0.0f,
+                // Top.
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f,
+                0.0f,
+                1.0f,
+                0.0f};
             mesh_info.indices.resize(36);
             std::iota(mesh_info.indices.begin(), mesh_info.indices.end(), 0);
             data.meshes.push_back(std::move(mesh_info));

--- a/frame/json/level_data.h
+++ b/frame/json/level_data.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <filesystem>
 #include <cstdint>
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -11,6 +11,19 @@
 
 namespace frame::json
 {
+
+enum class RenderPreset
+{
+    Auto,
+    Raster,
+    Cubemap,
+    Raytrace,
+};
+
+struct LevelDataOptions
+{
+    RenderPreset render_preset = RenderPreset::Auto;
+};
 
 struct TextureInfo
 {
@@ -50,6 +63,7 @@ struct StaticMeshInfo
 {
     std::string name;
     std::vector<float> positions;
+    std::vector<float> normals;
     std::vector<float> uvs;
     std::vector<std::uint32_t> indices;
 };
@@ -69,6 +83,7 @@ LevelData BuildLevelData(
     glm::uvec2 size,
     const proto::Level& proto_level,
     const std::filesystem::path& asset_root,
-    const std::filesystem::path& source_path = {});
+    const std::filesystem::path& source_path = {},
+    const LevelDataOptions& options = {});
 
 } // namespace frame::json

--- a/frame/json/parse_level.h
+++ b/frame/json/parse_level.h
@@ -45,14 +45,35 @@ LevelData ParseLevelData(
     glm::uvec2 size,
     const proto::Level& proto,
     const std::filesystem::path& asset_root,
+    const LevelDataOptions& options);
+LevelData ParseLevelData(
+    glm::uvec2 size,
+    const proto::Level& proto,
+    const std::filesystem::path& asset_root,
     const std::filesystem::path& source_path);
+LevelData ParseLevelData(
+    glm::uvec2 size,
+    const proto::Level& proto,
+    const std::filesystem::path& asset_root,
+    const std::filesystem::path& source_path,
+    const LevelDataOptions& options);
 LevelData ParseLevelData(
     glm::uvec2 size,
     const std::string& content,
     const std::filesystem::path& asset_root);
 LevelData ParseLevelData(
     glm::uvec2 size,
+    const std::string& content,
+    const std::filesystem::path& asset_root,
+    const LevelDataOptions& options);
+LevelData ParseLevelData(
+    glm::uvec2 size,
     const std::filesystem::path& path,
     const std::filesystem::path& asset_root);
+LevelData ParseLevelData(
+    glm::uvec2 size,
+    const std::filesystem::path& path,
+    const std::filesystem::path& asset_root,
+    const LevelDataOptions& options);
 
 } // End namespace frame::json.

--- a/frame/json/parse_level_data.cpp
+++ b/frame/json/parse_level_data.cpp
@@ -32,6 +32,15 @@ LevelData ParseLevelData(
     glm::uvec2 size,
     const proto::Level& proto,
     const std::filesystem::path& asset_root,
+    const LevelDataOptions& options)
+{
+    return BuildLevelData(size, proto, asset_root, {}, options);
+}
+
+LevelData ParseLevelData(
+    glm::uvec2 size,
+    const proto::Level& proto,
+    const std::filesystem::path& asset_root,
     const std::filesystem::path& source_path)
 {
     return BuildLevelData(size, proto, asset_root, source_path);
@@ -39,11 +48,29 @@ LevelData ParseLevelData(
 
 LevelData ParseLevelData(
     glm::uvec2 size,
+    const proto::Level& proto,
+    const std::filesystem::path& asset_root,
+    const std::filesystem::path& source_path,
+    const LevelDataOptions& options)
+{
+    return BuildLevelData(size, proto, asset_root, source_path, options);
+}
+
+LevelData ParseLevelData(
+    glm::uvec2 size,
     const std::string& content,
     const std::filesystem::path& asset_root)
 {
-    return ParseLevelData(
-        size, LoadLevelProto(content), asset_root);
+    return ParseLevelData(size, LoadLevelProto(content), asset_root);
+}
+
+LevelData ParseLevelData(
+    glm::uvec2 size,
+    const std::string& content,
+    const std::filesystem::path& asset_root,
+    const LevelDataOptions& options)
+{
+    return ParseLevelData(size, LoadLevelProto(content), asset_root, options);
 }
 
 LevelData ParseLevelData(
@@ -52,6 +79,16 @@ LevelData ParseLevelData(
     const std::filesystem::path& asset_root)
 {
     return ParseLevelData(size, LoadLevelProto(path), asset_root, path);
+}
+
+LevelData ParseLevelData(
+    glm::uvec2 size,
+    const std::filesystem::path& path,
+    const std::filesystem::path& asset_root,
+    const LevelDataOptions& options)
+{
+    return ParseLevelData(
+        size, LoadLevelProto(path), asset_root, path, options);
 }
 
 } // namespace frame::json

--- a/frame/opengl/renderer.cpp
+++ b/frame/opengl/renderer.cpp
@@ -12,6 +12,8 @@
 #include <format>
 #include <glad/glad.h>
 #include <limits>
+#include <glm/ext/matrix_clip_space.hpp>
+#include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include <numeric>
 #include <stdexcept>
@@ -38,10 +40,66 @@ namespace frame::opengl
 namespace
 {
 
+constexpr int kShadowMapSize = 2048;
+constexpr int kShadowTextureUnit = 15;
+constexpr float kShadowBias = 0.003f;
+
 bool IsRaytracingProgram(const ProgramInterface& program)
 {
     const auto key = frame::json::ResolveProgramKey(program.GetData());
     return frame::json::IsRaytracingProgramKey(key);
+}
+
+std::unique_ptr<Program> CreateRasterShadowProgram()
+{
+    static constexpr const char* kVertexSource = R"(#version 330 core
+
+layout(location = 0) in vec3 in_position;
+layout(location = 3) in ivec4 in_bone_ids;
+layout(location = 4) in vec4 in_bone_weights;
+
+uniform mat4 light_view_projection;
+uniform mat4 model;
+uniform int skinning_enabled;
+uniform mat4 bone_matrices[128];
+
+void main()
+{
+    vec4 local_position = vec4(in_position, 1.0);
+    if (skinning_enabled != 0)
+    {
+        mat4 skin =
+            in_bone_weights.x * bone_matrices[in_bone_ids.x] +
+            in_bone_weights.y * bone_matrices[in_bone_ids.y] +
+            in_bone_weights.z * bone_matrices[in_bone_ids.z] +
+            in_bone_weights.w * bone_matrices[in_bone_ids.w];
+        local_position = skin * local_position;
+    }
+    gl_Position = light_view_projection * model * local_position;
+}
+)";
+    static constexpr const char* kFragmentSource = R"(#version 330 core
+
+void main()
+{
+}
+)";
+
+    auto program = std::make_unique<Program>("RasterShadowProgram");
+    Shader vertex_shader(ShaderEnum::VERTEX_SHADER);
+    if (!vertex_shader.LoadFromSource(kVertexSource))
+    {
+        throw std::runtime_error(vertex_shader.GetErrorMessage());
+    }
+    Shader fragment_shader(ShaderEnum::FRAGMENT_SHADER);
+    if (!fragment_shader.LoadFromSource(kFragmentSource))
+    {
+        throw std::runtime_error(fragment_shader.GetErrorMessage());
+    }
+    program->AddShader(vertex_shader);
+    program->AddShader(fragment_shader);
+    program->LinkShader();
+    return program;
 }
 
 bool IsRaytracingSourceMaterial(
@@ -63,6 +121,23 @@ bool IsRaytracingSourceMaterial(
         return false;
     }
     return material.GetPreprocessProgramId(&level) != frame::NullId;
+}
+
+bool IsRaytracingMaterial(
+    frame::LevelInterface& level, frame::EntityId material_id)
+{
+    if (material_id == frame::NullId)
+    {
+        return false;
+    }
+    auto& material = level.GetMaterialFromId(material_id);
+    const auto program_id = material.GetProgramId(&level);
+    if (program_id == frame::NullId)
+    {
+        return false;
+    }
+    const auto& program = level.GetProgramFromId(program_id);
+    return IsRaytracingProgram(program);
 }
 
 bool IsRaytracingResolveMaterial(
@@ -1414,6 +1489,230 @@ Renderer::Renderer(LevelInterface& level, glm::uvec4 viewport)
     gpu_skinning_empty_buffer_->Copy(std::vector<float>{0.0f});
 }
 
+Renderer::~Renderer()
+{
+    if (shadow_depth_texture_ != 0)
+    {
+        glDeleteTextures(1, &shadow_depth_texture_);
+        shadow_depth_texture_ = 0;
+    }
+    if (shadow_frame_buffer_ != 0)
+    {
+        glDeleteFramebuffers(1, &shadow_frame_buffer_);
+        shadow_frame_buffer_ = 0;
+    }
+}
+
+void Renderer::EnsureShadowResources()
+{
+    if (!shadow_program_)
+    {
+        shadow_program_ = CreateRasterShadowProgram();
+    }
+    if (shadow_frame_buffer_ != 0 && shadow_depth_texture_ != 0)
+    {
+        return;
+    }
+
+    glGenFramebuffers(1, &shadow_frame_buffer_);
+    glGenTextures(1, &shadow_depth_texture_);
+    glBindTexture(GL_TEXTURE_2D, shadow_depth_texture_);
+    glTexImage2D(
+        GL_TEXTURE_2D,
+        0,
+        GL_DEPTH_COMPONENT32F,
+        kShadowMapSize,
+        kShadowMapSize,
+        0,
+        GL_DEPTH_COMPONENT,
+        GL_FLOAT,
+        nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+    const std::array<float, 4> border_color = {1.0f, 1.0f, 1.0f, 1.0f};
+    glTexParameterfv(
+        GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, border_color.data());
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, shadow_frame_buffer_);
+    glFramebufferTexture2D(
+        GL_FRAMEBUFFER,
+        GL_DEPTH_ATTACHMENT,
+        GL_TEXTURE_2D,
+        shadow_depth_texture_,
+        0);
+    glDrawBuffer(GL_NONE);
+    glReadBuffer(GL_NONE);
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+    {
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        throw std::runtime_error("OpenGL raster shadow framebuffer incomplete.");
+    }
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+bool Renderer::UpdateShadowState()
+{
+    shadow_enabled_ = false;
+    shadow_light_view_projection_ = glm::mat4(1.0f);
+
+    const auto light_id = FindPreferredRaytraceLightId(level_);
+    if (light_id == NullId)
+    {
+        return false;
+    }
+    auto& light = level_.GetLightFromId(light_id);
+    if (light.GetShadowType() == ShadowTypeEnum::NO_SHADOW ||
+        light.GetType() != LightTypeEnum::DIRECTIONAL_LIGHT ||
+        glm::length(light.GetVector()) <= 0.0f)
+    {
+        return false;
+    }
+
+    const glm::vec3 direction = glm::normalize(light.GetVector());
+    const glm::vec3 center(0.0f, 0.0f, 0.0f);
+    const glm::vec3 up =
+        std::abs(glm::dot(direction, glm::vec3(0.0f, 1.0f, 0.0f))) > 0.95f
+        ? glm::vec3(1.0f, 0.0f, 0.0f)
+        : glm::vec3(0.0f, 1.0f, 0.0f);
+    const glm::vec3 position = center - direction * 8.0f;
+    const glm::mat4 light_view = glm::lookAtRH(position, center, up);
+    const glm::mat4 light_projection =
+        glm::orthoRH_NO(-6.0f, 6.0f, -6.0f, 6.0f, 0.1f, 20.0f);
+    shadow_light_view_projection_ = light_projection * light_view;
+    shadow_enabled_ = true;
+    return true;
+}
+
+void Renderer::RenderShadowMap()
+{
+    const auto scene_pairs =
+        level_.GetMeshMaterialIds(proto::NodeMesh::SCENE_RENDER_TIME);
+    bool has_shadow_caster = false;
+    for (const auto& p : scene_pairs)
+    {
+        if (IsRaytracingMaterial(level_, p.second))
+        {
+            continue;
+        }
+        auto& node = level_.GetSceneNodeFromId(p.first);
+        if (!node.GetLocalMesh())
+        {
+            continue;
+        }
+        auto& mesh = level_.GetMeshFromId(node.GetLocalMesh());
+        if (mesh.GetData().render_primitive_enum() ==
+                proto::NodeMesh::TRIANGLE_PRIMITIVE &&
+            mesh.GetIndexSize())
+        {
+            has_shadow_caster = true;
+            break;
+        }
+    }
+    if (!has_shadow_caster)
+    {
+        shadow_enabled_ = false;
+        return;
+    }
+
+    if (!UpdateShadowState())
+    {
+        return;
+    }
+
+    EnsureShadowResources();
+
+    std::array<GLint, 4> previous_viewport = {};
+    glGetIntegerv(GL_VIEWPORT, previous_viewport.data());
+    GLboolean previous_color_mask[4] = {};
+    glGetBooleanv(GL_COLOR_WRITEMASK, previous_color_mask);
+
+    glViewport(0, 0, kShadowMapSize, kShadowMapSize);
+    glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+    glBindFramebuffer(GL_FRAMEBUFFER, shadow_frame_buffer_);
+    glClear(GL_DEPTH_BUFFER_BIT);
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_POLYGON_OFFSET_FILL);
+    glPolygonOffset(1.25f, 1.75f);
+
+    shadow_program_->Use();
+    shadow_program_->AddUniform(
+        std::make_unique<Uniform>(
+            "light_view_projection", shadow_light_view_projection_));
+    for (const auto& p : scene_pairs)
+    {
+        if (IsRaytracingMaterial(level_, p.second))
+        {
+            continue;
+        }
+        auto& node = level_.GetSceneNodeFromId(p.first);
+        auto* node_mesh = dynamic_cast<NodeMesh*>(&node);
+        if (!node_mesh || !node.GetLocalMesh())
+        {
+            continue;
+        }
+        auto& mesh = level_.GetMeshFromId(node.GetLocalMesh());
+        if (mesh.GetData().render_primitive_enum() !=
+                proto::NodeMesh::TRIANGLE_PRIMITIVE ||
+            !mesh.GetIndexSize())
+        {
+            continue;
+        }
+
+        auto& gl_mesh = dynamic_cast<Mesh&>(mesh);
+        auto* gl_skinned_mesh = dynamic_cast<SkinnedMesh*>(&gl_mesh);
+        int skinning_enabled = 0;
+        if (gl_skinned_mesh && gl_skinned_mesh->HasActiveSkinning())
+        {
+            auto bone_matrices = gl_skinned_mesh->EvaluateSkinning(
+                gl_skinned_mesh->GetSkinningTime(delta_time_));
+            constexpr std::size_t kMaxBones = 128;
+            if (bone_matrices.size() > kMaxBones)
+            {
+                bone_matrices.resize(kMaxBones);
+            }
+            if (!bone_matrices.empty())
+            {
+                shadow_program_->UploadMatrix4ArrayUniform(
+                    "bone_matrices", bone_matrices);
+                skinning_enabled = 1;
+            }
+        }
+        shadow_program_->AddUniform(
+            std::make_unique<Uniform>("skinning_enabled", skinning_enabled));
+        shadow_program_->AddUniform(
+            std::make_unique<Uniform>("model", node.GetLocalModel(delta_time_)));
+
+        glBindVertexArray(gl_mesh.GetId());
+        auto& index_buffer = level_.GetBufferFromId(mesh.GetIndexBufferId());
+        auto& gl_index_buffer = dynamic_cast<Buffer&>(index_buffer);
+        gl_index_buffer.Bind();
+        glDrawElements(
+            GL_TRIANGLES,
+            static_cast<GLsizei>(mesh.GetIndexSize()) / sizeof(std::uint32_t),
+            GL_UNSIGNED_INT,
+            nullptr);
+        gl_index_buffer.UnBind();
+        glBindVertexArray(0);
+    }
+    shadow_program_->UnUse();
+
+    glDisable(GL_POLYGON_OFFSET_FILL);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glColorMask(
+        previous_color_mask[0],
+        previous_color_mask[1],
+        previous_color_mask[2],
+        previous_color_mask[3]);
+    glViewport(
+        previous_viewport[0],
+        previous_viewport[1],
+        previous_viewport[2],
+        previous_viewport[3]);
+}
+
 void Renderer::EnsureGpuSkinningProgram()
 {
     if (gpu_skinning_program_attempted_)
@@ -2143,6 +2442,20 @@ void Renderer::RenderMesh(
         std::unique_ptr<UniformInterface> env_map_uniform =
             std::make_unique<Uniform>("env_map_model", env_map_model_);
         uniform_collection_wrapper.AddUniform(std::move(env_map_uniform));
+        uniform_collection_wrapper.AddUniform(
+            std::make_unique<Uniform>(
+                "light_view_projection", shadow_light_view_projection_));
+        uniform_collection_wrapper.AddUniform(
+            std::make_unique<Uniform>(
+                "shadow_enabled",
+                shadow_enabled_ && shadow_depth_texture_ != 0 ? 1 : 0));
+        uniform_collection_wrapper.AddUniform(
+            std::make_unique<Uniform>("shadow_bias", kShadowBias));
+        uniform_collection_wrapper.AddUniform(
+            std::make_unique<Uniform>(
+                "shadow_map_size", static_cast<float>(kShadowMapSize)));
+        uniform_collection_wrapper.AddUniform(
+            std::make_unique<Uniform>("shadow_map", kShadowTextureUnit));
     }
     // Go through the callback.
     callback_(uniform_collection_wrapper, mesh, material);
@@ -2182,6 +2495,15 @@ void Renderer::RenderMesh(
     if (gl_skinned_mesh)
     {
         UpdateRaytraceBuffersIfNeeded(*gl_skinned_mesh);
+    }
+    const bool bind_shadow_map =
+        render_time_ == proto::NodeMesh::SCENE_RENDER_TIME &&
+        shadow_depth_texture_ != 0 &&
+        program.HasUniform("shadow_map");
+    if (bind_shadow_map)
+    {
+        glActiveTexture(GL_TEXTURE0 + kShadowTextureUnit);
+        glBindTexture(GL_TEXTURE_2D, shadow_depth_texture_);
     }
     program.Use(uniform_collection_wrapper, &level_);
     int skinning_enabled = 0;
@@ -2354,9 +2676,14 @@ void Renderer::RenderMesh(
             gl_texture.UnBind();
         }
     }
+    if (bind_shadow_map)
+    {
+        glActiveTexture(GL_TEXTURE0 + kShadowTextureUnit);
+        glBindTexture(GL_TEXTURE_2D, 0);
+    }
     material.DisableAll();
 
-    if (mesh.IsClearBuffer())
+    if (mesh.IsClearBuffer() && render_time_ != proto::NodeMesh::SCENE_RENDER_TIME)
     {
         glClear(GL_DEPTH_BUFFER_BIT);
     }
@@ -2566,6 +2893,11 @@ void Renderer::RenderSkybox(const CameraInterface& camera)
 void Renderer::RenderScene(const CameraInterface& camera)
 {
     render_time_ = proto::NodeMesh::SCENE_RENDER_TIME;
+    RenderShadowMap();
+    {
+        ScopedBind scoped_frame(*frame_buffer_);
+        glClear(GL_DEPTH_BUFFER_BIT);
+    }
     for (const auto& p : level_.GetMeshMaterialIds(
              proto::NodeMesh::SCENE_RENDER_TIME))
     {

--- a/frame/opengl/renderer.h
+++ b/frame/opengl/renderer.h
@@ -36,6 +36,7 @@ class Renderer : public RendererInterface
      * @param viewport: The viewport.
      */
     Renderer(LevelInterface& level, glm::uvec4 viewport);
+    ~Renderer() override;
 
   public:
     /**
@@ -136,6 +137,9 @@ class Renderer : public RendererInterface
     void EnsureGpuSkinningProgram();
     void EnsureGpuRaytraceTriangleCopyProgram();
     void EnsureGpuRaytraceBvhRefitProgram();
+    void EnsureShadowResources();
+    bool UpdateShadowState();
+    void RenderShadowMap();
 
   private:
     LevelInterface& level_;
@@ -163,8 +167,13 @@ class Renderer : public RendererInterface
     std::unique_ptr<Program> gpu_skinning_program_ = nullptr;
     std::unique_ptr<Program> gpu_raytrace_triangle_copy_program_ = nullptr;
     std::unique_ptr<Program> gpu_raytrace_bvh_refit_program_ = nullptr;
+    std::unique_ptr<Program> shadow_program_ = nullptr;
     std::unique_ptr<Buffer> gpu_skinning_bone_matrix_buffer_ = nullptr;
     std::unique_ptr<Buffer> gpu_skinning_empty_buffer_ = nullptr;
+    unsigned int shadow_frame_buffer_ = 0;
+    unsigned int shadow_depth_texture_ = 0;
+    glm::mat4 shadow_light_view_projection_ = glm::mat4(1.0f);
+    bool shadow_enabled_ = false;
     std::size_t last_source_instance_layout_hash_ = 0;
     bool has_source_instance_layout_hash_ = false;
     std::unordered_map<std::uint64_t, std::size_t>
@@ -176,5 +185,4 @@ class Renderer : public RendererInterface
 };
 
 } // End namespace frame::opengl.
-
 

--- a/frame/opengl/sdl_opengl_none.cpp
+++ b/frame/opengl/sdl_opengl_none.cpp
@@ -65,6 +65,13 @@ SDLOpenGLNone::SDLOpenGLNone(glm::uvec2 size) : size_(size)
 
 SDLOpenGLNone::~SDLOpenGLNone()
 {
+    if (gl_context_ && sdl_window_)
+    {
+        SDL_GL_MakeCurrent(sdl_window_, gl_context_);
+    }
+    device_.reset();
+    input_interface_.reset();
+
     if (gl_context_)
     {
         SDL_GL_DestroyContext(gl_context_);

--- a/frame/opengl/sdl_opengl_window.cpp
+++ b/frame/opengl/sdl_opengl_window.cpp
@@ -107,13 +107,23 @@ SDLOpenGLWindow::SDLOpenGLWindow(glm::uvec2 size) : size_(size)
 
 SDLOpenGLWindow::~SDLOpenGLWindow()
 {
-    // Destroy the context we own; don't touch device_ here.
+    if (gl_context_ && sdl_window_)
+    {
+        SDL_GL_MakeCurrent(sdl_window_, gl_context_);
+    }
+    device_.reset();
+    input_interface_.reset();
+
     if (gl_context_)
     {
         SDL_GL_DestroyContext(gl_context_);
         gl_context_ = nullptr;
     }
-    SDL_DestroyWindow(sdl_window_);
+    if (sdl_window_)
+    {
+        SDL_DestroyWindow(sdl_window_);
+        sdl_window_ = nullptr;
+    }
     SDL_Quit();
 }
 

--- a/frame/vulkan/device.cpp
+++ b/frame/vulkan/device.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
 #include <functional>
 #include <limits>
 #include <numeric>
@@ -14,10 +15,9 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <filesystem>
 
-#include <stdexcept>
 #include "absl/flags/flag.h"
+#include <stdexcept>
 
 #include "frame/bvh.h"
 #include "frame/camera.h"
@@ -30,8 +30,8 @@
 #include "frame/vulkan/buffer.h"
 #include "frame/vulkan/buffer_resources.h"
 #include "frame/vulkan/build_level.h"
-#include "frame/vulkan/command_resources.h"
 #include "frame/vulkan/command_queue.h"
+#include "frame/vulkan/command_resources.h"
 #include "frame/vulkan/frame_profiler.h"
 #include "frame/vulkan/gpu_memory_manager.h"
 #include "frame/vulkan/mesh_resources.h"
@@ -42,13 +42,13 @@
 #include "frame/vulkan/scene_state.h"
 #include "frame/vulkan/scoped_timer.h"
 #include "frame/vulkan/shader_compiler.h"
+#include "frame/vulkan/skinned_mesh.h"
 #include "frame/vulkan/swapchain_resources.h"
 #include "frame/vulkan/sync_resources.h"
 #include "frame/vulkan/texture.h"
 #include "frame/vulkan/texture_resources.h"
-#include "frame/vulkan/skinned_mesh.h"
-#include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/matrix_inverse.hpp>
+#include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
 namespace frame::vulkan
@@ -74,7 +74,8 @@ using SteadyClock = std::chrono::steady_clock;
 
 double ElapsedMilliseconds(const SteadyClock::time_point& start)
 {
-    return std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(
+    return std::chrono::duration_cast<
+               std::chrono::duration<double, std::milli>>(
                SteadyClock::now() - start)
         .count();
 }
@@ -128,8 +129,7 @@ std::uint32_t BytesPerPixelForScreenshotFormat(vk::Format format)
     }
 }
 
-void FlipRowsInPlace(
-    std::vector<std::uint8_t>& pixels, std::size_t row_stride)
+void FlipRowsInPlace(std::vector<std::uint8_t>& pixels, std::size_t row_stride)
 {
     if (row_stride == 0)
     {
@@ -176,11 +176,7 @@ std::vector<std::uint8_t> ReadScreenshotPixels(
 
     command_queue.SubmitOneTime([&](vk::CommandBuffer command_buffer) {
         const vk::ImageSubresourceRange subresource_range(
-            vk::ImageAspectFlagBits::eColor,
-            0,
-            1,
-            0,
-            1);
+            vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1);
         const vk::ImageMemoryBarrier to_transfer(
             vk::AccessFlagBits::eShaderRead,
             vk::AccessFlagBits::eTransferRead,
@@ -288,7 +284,12 @@ void LogAnimatedRaytraceTimingStatsIfReady()
         static_cast<double>(stats.uploaded_triangle_bytes) /
         (1024.0 * 1024.0 * frame_count);
     logger->info(
-        "Animated Vulkan RT timing avg over {} frames: total={:.2f}ms, triangle_eval={:.2f}ms, triangle_copy={:.2f}ms, aggregate_range_update={:.2f}ms (prepare={:.2f}ms, upload={:.2f}ms), dynamic_geometry_total={:.2f}ms (prepare={:.2f}ms, submit={:.2f}ms, transforms={:.2f}ms), transform_total={:.2f}ms (wait_fences={:.2f}ms, upload={:.2f}ms, tlas_rebuild={:.2f}ms), upload={:.2f} MiB/frame.",
+        "Animated Vulkan RT timing avg over {} frames: total={:.2f}ms, "
+        "triangle_eval={:.2f}ms, triangle_copy={:.2f}ms, "
+        "aggregate_range_update={:.2f}ms (prepare={:.2f}ms, upload={:.2f}ms), "
+        "dynamic_geometry_total={:.2f}ms (prepare={:.2f}ms, submit={:.2f}ms, "
+        "transforms={:.2f}ms), transform_total={:.2f}ms (wait_fences={:.2f}ms, "
+        "upload={:.2f}ms, tlas_rebuild={:.2f}ms), upload={:.2f} MiB/frame.",
         stats.frame_count,
         stats.update_raytrace_buffers_ms / frame_count,
         stats.triangle_eval_ms / frame_count,
@@ -308,8 +309,7 @@ void LogAnimatedRaytraceTimingStatsIfReady()
     stats.Reset();
 }
 
-template <typename T>
-T AlignUp(T value, T alignment)
+template <typename T> T AlignUp(T value, T alignment)
 {
     if (alignment == 0)
     {
@@ -350,8 +350,7 @@ std::unordered_set<std::string> GetSupportedDeviceExtensions(
     for (const auto& extension :
          physical_device.enumerateDeviceExtensionProperties())
     {
-        supported.emplace(
-            static_cast<const char*>(extension.extensionName));
+        supported.emplace(static_cast<const char*>(extension.extensionName));
     }
     return supported;
 }
@@ -384,8 +383,7 @@ float ReadTextureFirstChannel(const frame::TextureInterface& texture)
     case frame::proto::PixelElementSize::BYTE:
     default: {
         const auto data = texture.GetTextureByte();
-        return data.empty() ? 0.0f
-                            : static_cast<float>(data.front()) / 255.0f;
+        return data.empty() ? 0.0f : static_cast<float>(data.front()) / 255.0f;
     }
     }
 }
@@ -442,8 +440,9 @@ std::array<float, 4> ReadTextureColor(const frame::TextureInterface& texture)
         const float green = read_channel(green_index);
         const float blue = read_channel(blue_index);
         const float alpha =
-            alpha_index >= 0 ? read_channel(static_cast<std::size_t>(alpha_index))
-                             : 1.0f;
+            alpha_index >= 0
+                ? read_channel(static_cast<std::size_t>(alpha_index))
+                : 1.0f;
         return std::array<float, 4>{red, green, blue, alpha};
     };
 
@@ -475,7 +474,7 @@ bool IsTransmissiveMaterial(
             continue;
         }
         return ReadTextureFirstChannel(level.GetTextureFromId(texture_id)) >
-            0.01f;
+               0.01f;
     }
     return false;
 }
@@ -536,8 +535,7 @@ GetRaytracingSourceMeshMaterials(frame::LevelInterface& level)
 }
 
 std::array<float, 4> ResolveRaytracingSourceMaterialColor(
-    frame::LevelInterface& level,
-    frame::EntityId material_id)
+    frame::LevelInterface& level, frame::EntityId material_id)
 {
     constexpr std::array<float, 4> kWhite = {1.0f, 1.0f, 1.0f, 1.0f};
     if (!material_id)
@@ -546,7 +544,8 @@ std::array<float, 4> ResolveRaytracingSourceMaterialColor(
     }
 
     const auto& material = level.GetMaterialFromId(material_id);
-    auto color_texture_id = FindTextureIdByInnerName(material, "albedo_texture");
+    auto color_texture_id =
+        FindTextureIdByInnerName(material, "albedo_texture");
     if (!color_texture_id)
     {
         color_texture_id = FindTextureIdByInnerName(material, "Color");
@@ -559,8 +558,7 @@ std::array<float, 4> ResolveRaytracingSourceMaterialColor(
 }
 
 std::array<float, 4> ResolveRaytracingReferenceColor(
-    frame::LevelInterface& level,
-    bool transmissive)
+    frame::LevelInterface& level, bool transmissive)
 {
     constexpr std::array<float, 4> kWhite = {1.0f, 1.0f, 1.0f, 1.0f};
     for (const auto& [source_node_id, source_material_id] :
@@ -621,8 +619,12 @@ constexpr std::array<RaytracingTextureMapping, 10>
         {"transmission_texture", nullptr, "transmissive_transmission_texture"},
         {"ior_texture", nullptr, "transmissive_ior_texture"},
         {"thickness_texture", nullptr, "transmissive_thickness_texture"},
-        {"attenuation_color_texture", nullptr, "transmissive_attenuation_color_texture"},
-        {"attenuation_distance_texture", nullptr, "transmissive_attenuation_distance_texture"},
+        {"attenuation_color_texture",
+         nullptr,
+         "transmissive_attenuation_color_texture"},
+        {"attenuation_distance_texture",
+         nullptr,
+         "transmissive_attenuation_distance_texture"},
     }};
 
 struct RaytracingTextureAtlasLayout
@@ -679,8 +681,7 @@ std::optional<RaytracingTextureAtlasLayout> BuildRaytracingTextureAtlasLayout(
     for (std::size_t i = 0; i < layout.material_ids.size(); ++i)
     {
         layout.slot_by_material_id.emplace(
-            layout.material_ids[i],
-            static_cast<std::uint32_t>(i));
+            layout.material_ids[i], static_cast<std::uint32_t>(i));
     }
 
     for (const auto material_id : layout.material_ids)
@@ -688,25 +689,23 @@ std::optional<RaytracingTextureAtlasLayout> BuildRaytracingTextureAtlasLayout(
         const auto& material = level.GetMaterialFromId(material_id);
         for (const auto& mapping : mappings)
         {
-            const auto texture_id = ResolveRaytracingMappedTextureId(
-                material,
-                mapping);
+            const auto texture_id =
+                ResolveRaytracingMappedTextureId(material, mapping);
             if (!texture_id)
             {
                 continue;
             }
             const auto size = level.GetTextureFromId(texture_id).GetSize();
-            layout.tile_width = std::max(layout.tile_width, std::max(1u, size.x));
-            layout.tile_height = std::max(
-                layout.tile_height,
-                std::max(1u, size.y));
+            layout.tile_width =
+                std::max(layout.tile_width, std::max(1u, size.x));
+            layout.tile_height =
+                std::max(layout.tile_height, std::max(1u, size.y));
         }
     }
 
     const auto material_count = static_cast<double>(layout.material_ids.size());
     layout.columns = std::max(
-        1u,
-        static_cast<std::uint32_t>(std::ceil(std::sqrt(material_count))));
+        1u, static_cast<std::uint32_t>(std::ceil(std::sqrt(material_count))));
     layout.rows = std::max(
         1u,
         static_cast<std::uint32_t>(
@@ -718,8 +717,7 @@ std::optional<RaytracingTextureAtlasLayout> BuildRaytracingTextureAtlasLayout(
 }
 
 bool HasBoundRaytracingTextureAtlas(
-    frame::LevelInterface& level,
-    bool transmissive)
+    frame::LevelInterface& level, bool transmissive)
 {
     const auto scene_material_id = level.GetIdFromName("RayTraceMaterial");
     if (scene_material_id == frame::NullId)
@@ -727,20 +725,19 @@ bool HasBoundRaytracingTextureAtlas(
         return false;
     }
     const auto& scene_material = level.GetMaterialFromId(scene_material_id);
-    const auto* target_name = transmissive
-        ? "transmissive_albedo_texture"
-        : "opaque_albedo_texture";
-    const auto texture_id = FindTextureIdByInnerName(scene_material, target_name);
+    const auto* target_name =
+        transmissive ? "transmissive_albedo_texture" : "opaque_albedo_texture";
+    const auto texture_id =
+        FindTextureIdByInnerName(scene_material, target_name);
     if (texture_id == frame::NullId)
     {
         return false;
     }
     return level.GetNameFromId(texture_id).find(".__raytrace_atlas_") !=
-        std::string::npos;
+           std::string::npos;
 }
 
-template <typename T>
-void HashCombine(std::size_t& seed, const T& value)
+template <typename T> void HashCombine(std::size_t& seed, const T& value)
 {
     seed ^= std::hash<T>{}(value) + 0x9e3779b9u + (seed << 6u) + (seed >> 2u);
 }
@@ -769,8 +766,7 @@ void HashMatrix(std::size_t& seed, const glm::mat4& matrix)
     }
 }
 
-void HashByteSamples(
-    std::size_t& seed, const std::vector<std::uint8_t>& bytes)
+void HashByteSamples(std::size_t& seed, const std::vector<std::uint8_t>& bytes)
 {
     HashCombine(seed, bytes.size());
     if (bytes.empty())
@@ -805,7 +801,8 @@ std::size_t BuildRaytracingSourceStateHash(
     HashCombine(state_hash, include_node_matrices);
     const auto source_mesh_materials = GetRaytracingSourceMeshMaterials(level);
     HashCombine(state_hash, source_mesh_materials.size());
-    for (const auto& [source_node_id, source_material_id] : source_mesh_materials)
+    for (const auto& [source_node_id, source_material_id] :
+         source_mesh_materials)
     {
         HashCombine(state_hash, static_cast<std::uint64_t>(source_node_id));
         HashCombine(state_hash, static_cast<std::uint64_t>(source_material_id));
@@ -822,8 +819,7 @@ std::size_t BuildRaytracingSourceStateHash(
             HashMatrix(state_hash, node->GetLocalModel(time_seconds));
         }
         HashCombine(
-            state_hash,
-            IsTransmissiveMaterial(level, source_material_id));
+            state_hash, IsTransmissiveMaterial(level, source_material_id));
         HashColor(
             state_hash,
             ResolveRaytracingSourceMaterialColor(level, source_material_id));
@@ -837,16 +833,14 @@ std::size_t BuildRaytracingSourceStateHash(
 
         const auto triangle_buffer_id =
             level.GetMeshFromId(mesh_id).GetTriangleBufferId();
-        HashCombine(
-            state_hash,
-            static_cast<std::uint64_t>(triangle_buffer_id));
+        HashCombine(state_hash, static_cast<std::uint64_t>(triangle_buffer_id));
         if (!triangle_buffer_id)
         {
             continue;
         }
 
-        auto* triangle_buffer = dynamic_cast<Buffer*>(
-            &level.GetBufferFromId(triangle_buffer_id));
+        auto* triangle_buffer =
+            dynamic_cast<Buffer*>(&level.GetBufferFromId(triangle_buffer_id));
         if (!triangle_buffer)
         {
             continue;
@@ -872,8 +866,7 @@ bool HasRaytracingSourceMeshes(frame::LevelInterface& level)
 }
 
 std::optional<glm::mat4> GetSharedRaytraceSceneTransform(
-    frame::LevelInterface& level,
-    double time_seconds)
+    frame::LevelInterface& level, double time_seconds)
 {
     const auto source_mesh_materials = GetRaytracingSourceMeshMaterials(level);
     if (source_mesh_materials.empty())
@@ -882,7 +875,8 @@ std::optional<glm::mat4> GetSharedRaytraceSceneTransform(
     }
 
     std::optional<glm::mat4> shared_model = std::nullopt;
-    for (const auto& [source_node_id, source_material_id] : source_mesh_materials)
+    for (const auto& [source_node_id, source_material_id] :
+         source_mesh_materials)
     {
         (void)source_material_id;
         auto* node =
@@ -906,8 +900,7 @@ std::optional<glm::mat4> GetSharedRaytraceSceneTransform(
 }
 
 bool CanUseSharedTransformHardwareRaytraceScene(
-    frame::LevelInterface& level,
-    double time_seconds)
+    frame::LevelInterface& level, double time_seconds)
 {
     return !RaytraceSceneRequiresWorldSpaceBuffers(level) &&
            GetSharedRaytraceSceneTransform(level, time_seconds).has_value();
@@ -941,8 +934,7 @@ struct RaytraceVertex
 };
 
 std::array<float, 4> GetRaytracingAtlasUvBounds(
-    const RaytracingTextureAtlasLayout& layout,
-    frame::EntityId material_id)
+    const RaytracingTextureAtlasLayout& layout, frame::EntityId material_id)
 {
     const auto it = layout.slot_by_material_id.find(material_id);
     if (it == layout.slot_by_material_id.end())
@@ -990,7 +982,8 @@ std::vector<std::uint8_t> RemapRaytracingAtlasTriangleUvs(
     if (raw.size() % sizeof(RaytraceVertex) != 0u)
     {
         throw std::runtime_error(
-            "Vulkan raytrace triangle buffer size is not aligned to the expected vertex stride.");
+            "Vulkan raytrace triangle buffer size is not aligned to the "
+            "expected vertex stride.");
     }
 
     const auto bounds = GetRaytracingAtlasUvBounds(*layout, material_id);
@@ -1058,10 +1051,7 @@ std::vector<std::uint8_t> BuildGpuSkinningSourceVertexBytes(
         if (uv_offset + 1u < textures.size())
         {
             dst.uv = glm::vec4(
-                textures[uv_offset + 0u],
-                textures[uv_offset + 1u],
-                0.0f,
-                0.0f);
+                textures[uv_offset + 0u], textures[uv_offset + 1u], 0.0f, 0.0f);
         }
         if (bone_offset + 3u < bone_indices.size())
         {
@@ -1106,8 +1096,7 @@ std::vector<std::uint8_t> BuildFlatBytes(const std::vector<T>& values)
 }
 
 std::vector<std::uint8_t> ApplyTriangleColorMultiplier(
-    const std::vector<std::uint8_t>& raw,
-    const std::array<float, 4>& color)
+    const std::vector<std::uint8_t>& raw, const std::array<float, 4>& color)
 {
     if (raw.empty())
     {
@@ -1116,7 +1105,8 @@ std::vector<std::uint8_t> ApplyTriangleColorMultiplier(
     if (raw.size() % sizeof(RaytraceVertex) != 0)
     {
         throw std::runtime_error(
-            "Animated Vulkan raytrace triangle buffer size is not aligned to the expected vertex stride.");
+            "Animated Vulkan raytrace triangle buffer size is not aligned to "
+            "the expected vertex stride.");
     }
 
     std::vector<std::uint8_t> tinted = raw;
@@ -1133,8 +1123,7 @@ std::vector<std::uint8_t> ApplyTriangleColorMultiplier(
 }
 
 std::vector<std::uint8_t> TransformTriangleBytes(
-    const std::vector<std::uint8_t>& raw,
-    const glm::mat4& model)
+    const std::vector<std::uint8_t>& raw, const glm::mat4& model)
 {
     if (raw.empty() || model == glm::mat4(1.0f))
     {
@@ -1143,12 +1132,14 @@ std::vector<std::uint8_t> TransformTriangleBytes(
     if (raw.size() % sizeof(RaytraceVertex) != 0)
     {
         throw std::runtime_error(
-            "Animated Vulkan raytrace triangle buffer size is not aligned to the expected vertex stride.");
+            "Animated Vulkan raytrace triangle buffer size is not aligned to "
+            "the expected vertex stride.");
     }
 
     std::vector<std::uint8_t> transformed = raw;
     auto* vertices = reinterpret_cast<RaytraceVertex*>(transformed.data());
-    const std::size_t vertex_count = transformed.size() / sizeof(RaytraceVertex);
+    const std::size_t vertex_count =
+        transformed.size() / sizeof(RaytraceVertex);
 
     glm::mat3 normal_matrix = glm::mat3(1.0f);
     const float det = glm::determinant(glm::mat3(model));
@@ -1160,12 +1151,14 @@ std::vector<std::uint8_t> TransformTriangleBytes(
     for (std::size_t i = 0; i < vertex_count; ++i)
     {
         const glm::vec3 position = glm::vec3(
-            model * glm::vec4(vertices[i].px, vertices[i].py, vertices[i].pz, 1.0f));
+            model *
+            glm::vec4(vertices[i].px, vertices[i].py, vertices[i].pz, 1.0f));
         vertices[i].px = position.x;
         vertices[i].py = position.y;
         vertices[i].pz = position.z;
 
-        glm::vec3 normal = normal_matrix *
+        glm::vec3 normal =
+            normal_matrix *
             glm::vec3(vertices[i].nx, vertices[i].ny, vertices[i].nz);
         if (glm::length(normal) > 1.0e-6f)
         {
@@ -1204,7 +1197,8 @@ glm::mat4 InverseOrIdentity(const glm::mat4& matrix)
     return glm::inverse(matrix);
 }
 
-vk::TransformMatrixKHR MakeAccelerationStructureTransform(const glm::mat4& matrix)
+vk::TransformMatrixKHR MakeAccelerationStructureTransform(
+    const glm::mat4& matrix)
 {
     vk::TransformMatrixKHR transform = {};
     for (int row = 0; row < 3; ++row)
@@ -1217,7 +1211,8 @@ vk::TransformMatrixKHR MakeAccelerationStructureTransform(const glm::mat4& matri
     return transform;
 }
 
-std::optional<RaytracingSourceGeometryData> BuildRaytracingSourceGeometryDataForSource(
+std::optional<RaytracingSourceGeometryData>
+BuildRaytracingSourceGeometryDataForSource(
     frame::LevelInterface& level,
     frame::EntityId source_node_id,
     frame::EntityId source_material_id,
@@ -1225,11 +1220,9 @@ std::optional<RaytracingSourceGeometryData> BuildRaytracingSourceGeometryDataFor
     bool apply_node_transform,
     std::uint32_t triangle_offset)
 {
-    const auto transmissive =
-        IsTransmissiveMaterial(level, source_material_id);
-    const auto reference_color = ResolveRaytracingReferenceColor(
-        level,
-        transmissive);
+    const auto transmissive = IsTransmissiveMaterial(level, source_material_id);
+    const auto reference_color =
+        ResolveRaytracingReferenceColor(level, transmissive);
 
     auto* node = dynamic_cast<frame::NodeMesh*>(
         &level.GetSceneNodeFromId(source_node_id));
@@ -1257,33 +1250,24 @@ std::optional<RaytracingSourceGeometryData> BuildRaytracingSourceGeometryDataFor
         return std::nullopt;
     }
 
-    const auto source_color = ResolveRaytracingSourceMaterialColor(
-        level,
-        source_material_id);
-    const auto color_multiplier = ResolveRaytracingColorMultiplier(
-        source_color,
-        reference_color);
-    const auto atlas_layout = HasBoundRaytracingTextureAtlas(level, transmissive)
-        ? (transmissive
-               ? BuildRaytracingTextureAtlasLayout(
-                     level,
-                     true,
-                     kTransmissiveRaytracingTextureMappings)
-               : BuildRaytracingTextureAtlasLayout(
-                     level,
-                     false,
-                     kOpaqueRaytracingTextureMappings))
-        : std::nullopt;
+    const auto source_color =
+        ResolveRaytracingSourceMaterialColor(level, source_material_id);
+    const auto color_multiplier =
+        ResolveRaytracingColorMultiplier(source_color, reference_color);
+    const auto atlas_layout =
+        HasBoundRaytracingTextureAtlas(level, transmissive)
+            ? (transmissive
+                   ? BuildRaytracingTextureAtlasLayout(
+                         level, true, kTransmissiveRaytracingTextureMappings)
+                   : BuildRaytracingTextureAtlasLayout(
+                         level, false, kOpaqueRaytracingTextureMappings))
+            : std::nullopt;
     const auto remapped = RemapRaytracingAtlasTriangleUvs(
-        triangle_buffer->GetRawData(),
-        atlas_layout,
-        source_material_id);
+        triangle_buffer->GetRawData(), atlas_layout, source_material_id);
     const auto transformed =
-        apply_node_transform
-            ? TransformTriangleBytes(
-                  remapped,
-                  node->GetLocalModel(time_seconds))
-            : remapped;
+        apply_node_transform ? TransformTriangleBytes(
+                                   remapped, node->GetLocalModel(time_seconds))
+                             : remapped;
 
     RaytracingSourceGeometryData geometry = {};
     geometry.source_node_id = source_node_id;
@@ -1291,11 +1275,12 @@ std::optional<RaytracingSourceGeometryData> BuildRaytracingSourceGeometryDataFor
     geometry.source_material_id = source_material_id;
     geometry.material_id = transmissive ? 0u : 1u;
     geometry.triangle_offset = triangle_offset;
-    geometry.atlas_uv_bounds = transmissive && atlas_layout
-        ? GetRaytracingAtlasUvBounds(*atlas_layout, source_material_id)
+    geometry.atlas_uv_bounds =
+        transmissive && atlas_layout
+            ? GetRaytracingAtlasUvBounds(*atlas_layout, source_material_id)
         : (!transmissive && atlas_layout)
-        ? GetRaytracingAtlasUvBounds(*atlas_layout, source_material_id)
-        : std::array<float, 4>{0.0f, 1.0f, 0.0f, 1.0f};
+            ? GetRaytracingAtlasUvBounds(*atlas_layout, source_material_id)
+            : std::array<float, 4>{0.0f, 1.0f, 0.0f, 1.0f};
     geometry.triangle_bytes =
         ApplyTriangleColorMultiplier(transformed, color_multiplier);
     return geometry;
@@ -1314,9 +1299,9 @@ std::vector<RaytracingSourceGeometryData> BuildRaytracingSourceGeometryData(
     {
         const bool transmissive =
             IsTransmissiveMaterial(level, source_material_id);
-        const std::uint32_t triangle_offset = transmissive
-            ? next_transmissive_triangle_offset
-            : next_opaque_triangle_offset;
+        const std::uint32_t triangle_offset =
+            transmissive ? next_transmissive_triangle_offset
+                         : next_opaque_triangle_offset;
         auto geometry = BuildRaytracingSourceGeometryDataForSource(
             level,
             source_node_id,
@@ -1381,7 +1366,8 @@ BuildPreparedUpdatedRaytracingSourceGeometries(
     };
 
     std::vector<RaytracingSourceGeometryData> prepared_source_geometries = {};
-    prepared_source_geometries.reserve(updated_source_triangle_buffer_ids.size());
+    prepared_source_geometries.reserve(
+        updated_source_triangle_buffer_ids.size());
     std::uint32_t next_transmissive_triangle_offset = 0;
     std::uint32_t next_opaque_triangle_offset = 0;
     for (const auto& [source_node_id, source_material_id] :
@@ -1389,9 +1375,9 @@ BuildPreparedUpdatedRaytracingSourceGeometries(
     {
         const bool transmissive =
             IsTransmissiveMaterial(level, source_material_id);
-        const std::uint32_t triangle_offset = transmissive
-            ? next_transmissive_triangle_offset
-            : next_opaque_triangle_offset;
+        const std::uint32_t triangle_offset =
+            transmissive ? next_transmissive_triangle_offset
+                         : next_opaque_triangle_offset;
 
         auto* node = dynamic_cast<frame::NodeMesh*>(
             &level.GetSceneNodeFromId(source_node_id));
@@ -1433,7 +1419,8 @@ BuildPreparedUpdatedRaytracingSourceGeometries(
                 triangle_offset);
             if (source_geometry)
             {
-                prepared_source_geometries.push_back(std::move(*source_geometry));
+                prepared_source_geometries.push_back(
+                    std::move(*source_geometry));
             }
         }
 
@@ -1561,13 +1548,13 @@ bool AreTexturesCompatibleForReuse(
 }
 
 std::size_t TransferTextureGpuResources(
-    frame::LevelInterface& old_level,
-    frame::LevelInterface& new_level)
+    frame::LevelInterface& old_level, frame::LevelInterface& new_level)
 {
     std::size_t transfer_count = 0;
     for (const auto new_texture_id : new_level.GetTextures())
     {
-        const std::string texture_name = new_level.GetNameFromId(new_texture_id);
+        const std::string texture_name =
+            new_level.GetNameFromId(new_texture_id);
         const auto old_texture_id = old_level.GetIdFromName(texture_name);
         if (old_texture_id == frame::NullId)
         {
@@ -1643,17 +1630,14 @@ std::vector<std::uint8_t> BuildAggregateTriangleBytes(
     std::vector<std::uint8_t> aggregate_triangle_bytes = {};
     const auto reference_color =
         ResolveRaytracingReferenceColor(level, transmissive);
-    const auto atlas_layout = HasBoundRaytracingTextureAtlas(level, transmissive)
-        ? (transmissive
-               ? BuildRaytracingTextureAtlasLayout(
-                     level,
-                     true,
-                     kTransmissiveRaytracingTextureMappings)
-               : BuildRaytracingTextureAtlasLayout(
-                     level,
-                     false,
-                     kOpaqueRaytracingTextureMappings))
-        : std::nullopt;
+    const auto atlas_layout =
+        HasBoundRaytracingTextureAtlas(level, transmissive)
+            ? (transmissive
+                   ? BuildRaytracingTextureAtlasLayout(
+                         level, true, kTransmissiveRaytracingTextureMappings)
+                   : BuildRaytracingTextureAtlasLayout(
+                         level, false, kOpaqueRaytracingTextureMappings))
+            : std::nullopt;
     for (const auto& [source_node_id, source_material_id] :
          GetRaytracingSourceMeshMaterials(level))
     {
@@ -1662,9 +1646,8 @@ std::vector<std::uint8_t> BuildAggregateTriangleBytes(
             continue;
         }
 
-        auto* node =
-            dynamic_cast<frame::NodeMesh*>(
-                &level.GetSceneNodeFromId(source_node_id));
+        auto* node = dynamic_cast<frame::NodeMesh*>(
+            &level.GetSceneNodeFromId(source_node_id));
         if (!node)
         {
             continue;
@@ -1691,25 +1674,19 @@ std::vector<std::uint8_t> BuildAggregateTriangleBytes(
 
         const auto source_color =
             ResolveRaytracingSourceMaterialColor(level, source_material_id);
-        const auto color_multiplier = ResolveRaytracingColorMultiplier(
-            source_color,
-            reference_color);
+        const auto color_multiplier =
+            ResolveRaytracingColorMultiplier(source_color, reference_color);
         const auto remapped = RemapRaytracingAtlasTriangleUvs(
-            triangle_buffer->GetRawData(),
-            atlas_layout,
-            source_material_id);
+            triangle_buffer->GetRawData(), atlas_layout, source_material_id);
         const auto transformed =
             apply_node_transform
                 ? TransformTriangleBytes(
-                      remapped,
-                      node->GetLocalModel(time_seconds))
+                      remapped, node->GetLocalModel(time_seconds))
                 : remapped;
         const auto tinted =
             ApplyTriangleColorMultiplier(transformed, color_multiplier);
         aggregate_triangle_bytes.insert(
-            aggregate_triangle_bytes.end(),
-            tinted.begin(),
-            tinted.end());
+            aggregate_triangle_bytes.end(), tinted.begin(), tinted.end());
     }
     return aggregate_triangle_bytes;
 }
@@ -1724,7 +1701,8 @@ std::vector<std::uint8_t> BuildAggregateBvhBytes(
     if (triangle_bytes.size() % kRaytraceTriangleVertexStrideBytes != 0)
     {
         throw std::runtime_error(
-            "Animated raytrace triangle buffer size is not aligned to the expected vertex stride.");
+            "Animated raytrace triangle buffer size is not aligned to the "
+            "expected vertex stride.");
     }
 
     const auto* triangle_floats =
@@ -1733,7 +1711,8 @@ std::vector<std::uint8_t> BuildAggregateBvhBytes(
         triangle_bytes.size() / kRaytraceTriangleVertexStrideBytes;
     std::vector<float> points = {};
     points.reserve(vertex_count * 3);
-    for (std::size_t vertex_index = 0; vertex_index < vertex_count; ++vertex_index)
+    for (std::size_t vertex_index = 0; vertex_index < vertex_count;
+         ++vertex_index)
     {
         const std::size_t base = vertex_index * kRaytraceFloatsPerVertex;
         points.push_back(triangle_floats[base + 0]);
@@ -1745,8 +1724,7 @@ std::vector<std::uint8_t> BuildAggregateBvhBytes(
     std::iota(indices.begin(), indices.end(), 0u);
     const auto bvh_nodes = frame::BuildBVH(points, indices);
 
-    std::vector<std::uint8_t> bytes(
-        bvh_nodes.size() * sizeof(frame::BVHNode));
+    std::vector<std::uint8_t> bytes(bvh_nodes.size() * sizeof(frame::BVHNode));
     if (!bytes.empty())
     {
         std::memcpy(bytes.data(), bvh_nodes.data(), bytes.size());
@@ -1756,12 +1734,8 @@ std::vector<std::uint8_t> BuildAggregateBvhBytes(
 
 } // namespace
 
-Device::Device(
-    void* vk_instance,
-    glm::uvec2 size,
-    vk::SurfaceKHR& surface)
-    : vk_instance_(static_cast<VkInstance>(vk_instance)),
-      size_(size),
+Device::Device(void* vk_instance, glm::uvec2 size, vk::SurfaceKHR& surface)
+    : vk_instance_(static_cast<VkInstance>(vk_instance)), size_(size),
       vk_surface_(surface),
       texture_resources_(std::make_unique<TextureResources>(*this)),
       pipeline_resources_(std::make_unique<PipelineResources>(*this)),
@@ -1846,8 +1820,7 @@ Device::Device(
     if (!present_queue_index)
     {
         if (vk_physical_device_.getSurfaceSupportKHR(
-                graphics_queue_index.value(),
-                vk_surface_))
+                graphics_queue_index.value(), vk_surface_))
         {
             present_queue_index = graphics_queue_index;
         }
@@ -1861,7 +1834,8 @@ Device::Device(
     graphics_queue_family_index_ = graphics_queue_index.value();
     present_queue_family_index_ = present_queue_index.value();
 
-    std::vector<std::uint32_t> unique_queue_indices = {graphics_queue_family_index_};
+    std::vector<std::uint32_t> unique_queue_indices = {
+        graphics_queue_family_index_};
     if (present_queue_family_index_ != graphics_queue_family_index_)
     {
         unique_queue_indices.push_back(present_queue_family_index_);
@@ -1872,10 +1846,7 @@ Device::Device(
     for (auto index : unique_queue_indices)
     {
         queue_create_infos.emplace_back(
-            vk::DeviceQueueCreateFlags{},
-            index,
-            1,
-            &queue_family_priority_);
+            vk::DeviceQueueCreateFlags{}, index, 1, &queue_family_priority_);
     }
 
     const auto supported_extensions =
@@ -1912,10 +1883,10 @@ Device::Device(
             VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
         device_extensions.push_back(
             VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
-        device_extensions.push_back(
-            VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+        device_extensions.push_back(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
         device_extensions.push_back(VK_KHR_SPIRV_1_4_EXTENSION_NAME);
-        device_extensions.push_back(VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME);
+        device_extensions.push_back(
+            VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME);
         device_extensions.push_back(
             VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME);
     }
@@ -1931,7 +1902,8 @@ Device::Device(
     {
         logger_->warn(
             "shaderStorageImageExtendedFormats not supported; "
-            "raytracing compute output uses rgba16f storage images and may fail.");
+            "raytracing compute output uses rgba16f storage images and may "
+            "fail.");
     }
 
     vk::DeviceCreateInfo device_create_info(
@@ -1955,23 +1927,29 @@ Device::Device(
         device_create_info.setPNext(&buffer_device_address_features_);
     }
 
-    vk_unique_device_ = vk_physical_device_.createDeviceUnique(device_create_info);
+    vk_unique_device_ =
+        vk_physical_device_.createDeviceUnique(device_create_info);
     VULKAN_HPP_DEFAULT_DISPATCHER.init(*vk_unique_device_);
-    graphics_queue_ = vk_unique_device_->getQueue(graphics_queue_family_index_, 0);
-    present_queue_ = vk_unique_device_->getQueue(present_queue_family_index_, 0);
+    graphics_queue_ =
+        vk_unique_device_->getQueue(graphics_queue_family_index_, 0);
+    present_queue_ =
+        vk_unique_device_->getQueue(present_queue_family_index_, 0);
 
     logger_->info(
-        "Vulkan logical device created (graphics queue family {}, present queue family {}).",
+        "Vulkan logical device created (graphics queue family {}, present "
+        "queue family {}).",
         graphics_queue_family_index_,
         present_queue_family_index_);
     if (hardware_raytracing_supported_)
     {
-        logger_->info("Vulkan hardware raytracing pipeline extensions enabled.");
+        logger_->info(
+            "Vulkan hardware raytracing pipeline extensions enabled.");
     }
     else
     {
         logger_->info(
-            "Vulkan hardware raytracing pipeline unavailable; using software compute traversal.");
+            "Vulkan hardware raytracing pipeline unavailable; using software "
+            "compute traversal.");
     }
 }
 
@@ -2019,50 +1997,48 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
     {
         ScopedTimer timer(logger_, "Select program");
         auto pick_program = [&]() -> std::optional<frame::json::ProgramInfo> {
-            auto find_program_by_name =
-                [&](const std::string& program_name)
+            auto find_program_by_name = [&](const std::string& program_name)
                 -> std::optional<frame::json::ProgramInfo> {
-                    if (program_name.empty())
-                    {
-                        return std::nullopt;
-                    }
-                    for (const auto& program : level_data.programs)
-                    {
-                        if (program.name == program_name)
-                        {
-                            return program;
-                        }
-                    }
+                if (program_name.empty())
+                {
                     return std::nullopt;
-                };
+                }
+                for (const auto& program : level_data.programs)
+                {
+                    if (program.name == program_name)
+                    {
+                        return program;
+                    }
+                }
+                return std::nullopt;
+            };
             auto find_program_info_by_name =
                 [&](const std::string& program_name)
                 -> const frame::json::ProgramInfo* {
-                    if (program_name.empty())
-                    {
-                        return nullptr;
-                    }
-                    for (const auto& program_info : level_data.programs)
-                    {
-                        if (program_info.name == program_name)
-                        {
-                            return &program_info;
-                        }
-                    }
+                if (program_name.empty())
+                {
                     return nullptr;
-                };
-            auto is_raytracing_program =
-                [&](const std::string& program_name) {
-                    const auto* program_info =
-                        find_program_info_by_name(program_name);
-                    if (!program_info)
+                }
+                for (const auto& program_info : level_data.programs)
+                {
+                    if (program_info.name == program_name)
                     {
-                        return false;
+                        return &program_info;
                     }
-                    const auto key =
-                        frame::json::ResolveProgramKey(program_info->proto);
-                    return frame::json::IsRaytracingProgramKey(key);
-                };
+                }
+                return nullptr;
+            };
+            auto is_raytracing_program = [&](const std::string& program_name) {
+                const auto* program_info =
+                    find_program_info_by_name(program_name);
+                if (!program_info)
+                {
+                    return false;
+                }
+                const auto key =
+                    frame::json::ResolveProgramKey(program_info->proto);
+                return frame::json::IsRaytracingProgramKey(key);
+            };
             auto pass_has_renderable_mesh =
                 [&](frame::proto::NodeMesh::RenderTimeEnum pass) {
                     if (!level_data.proto.has_scene_tree())
@@ -2111,8 +2087,7 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
                 {
                     continue;
                 }
-                for (const auto& pass_program :
-                     level_data.render_pass_programs)
+                for (const auto& pass_program : level_data.render_pass_programs)
                 {
                     if (pass_program.render_time != pass)
                     {
@@ -2222,8 +2197,7 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
     auto previous_level = std::move(level_);
     std::size_t transferred_texture_count = 0;
     const bool prefer_hardware_raytracing_build =
-        active_program_info_ &&
-        active_program_info_->use_compute &&
+        active_program_info_ && active_program_info_->use_compute &&
         hardware_raytracing_supported_ &&
         !active_program_info_->raygen_shader.empty() &&
         !active_program_info_->miss_shader.empty() &&
@@ -2279,7 +2253,8 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
                                 continue;
                             }
                             mesh_bound_material_ids.insert(material_id);
-                            if (candidate_material_seen.insert(material_id).second)
+                            if (candidate_material_seen.insert(material_id)
+                                    .second)
                             {
                                 candidate_material_ids.push_back(material_id);
                             }
@@ -2306,7 +2281,8 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
                 const auto count_matching_bindings =
                     [&](const frame::MaterialInterface& material) {
                         int matches = 0;
-                        for (const auto& binding : active_program_info_->bindings)
+                        for (const auto& binding :
+                             active_program_info_->bindings)
                         {
                             if (binding.name.empty())
                             {
@@ -2314,8 +2290,10 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
                             }
                             switch (binding.binding_type)
                             {
-                            case frame::proto::ProgramBinding::COMBINED_IMAGE_SAMPLER: {
-                                for (const auto texture_id : material.GetTextureIds())
+                            case frame::proto::ProgramBinding::
+                                COMBINED_IMAGE_SAMPLER: {
+                                for (const auto texture_id :
+                                     material.GetTextureIds())
                                 {
                                     if (material.GetInnerName(texture_id) ==
                                         binding.name)
@@ -2327,10 +2305,11 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
                                 break;
                             }
                             case frame::proto::ProgramBinding::STORAGE_BUFFER: {
-                                for (const auto& buffer_name : material.GetBufferNames())
+                                for (const auto& buffer_name :
+                                     material.GetBufferNames())
                                 {
-                                    if (material.GetInnerBufferName(buffer_name) ==
-                                        binding.name)
+                                    if (material.GetInnerBufferName(
+                                            buffer_name) == binding.name)
                                     {
                                         ++matches;
                                         break;
@@ -2356,9 +2335,8 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
                         count_matching_bindings(material);
                     const int score =
                         matching_bindings * 10000 +
-                        (mesh_bound_material_ids.contains(material_id)
-                             ? 1000
-                             : 0) +
+                        (mesh_bound_material_ids.contains(material_id) ? 1000
+                                                                       : 0) +
                         static_cast<int>(material.GetTextureIds().size()) +
                         static_cast<int>(material.GetBufferNames().size());
                     if (score > selected_material_score)
@@ -2375,11 +2353,12 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
                     active_program_info_->material_id = selected_material_id;
                     for (auto texture_id : material.GetTextureIds())
                     {
-                        const auto inner_name = material.GetInnerName(texture_id);
+                        const auto inner_name =
+                            material.GetInnerName(texture_id);
                         if (!inner_name.empty())
                         {
-                            active_program_info_->texture_ids_by_inner[inner_name] =
-                                texture_id;
+                            active_program_info_
+                                ->texture_ids_by_inner[inner_name] = texture_id;
                         }
                     }
                     for (const auto& buffer_name : material.GetBufferNames())
@@ -2390,18 +2369,37 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
                         {
                             continue;
                         }
-                        const auto buffer_id = level_->GetIdFromName(buffer_name);
+                        const auto buffer_id =
+                            level_->GetIdFromName(buffer_name);
                         if (buffer_id != NullId)
                         {
-                            active_program_info_->buffer_ids_by_inner[inner_name] =
-                                buffer_id;
+                            active_program_info_
+                                ->buffer_ids_by_inner[inner_name] = buffer_id;
                         }
                     }
                     logger_->info(
-                        "Selected Vulkan material '{}' for program '{}' (score {}).",
+                        "Selected Vulkan material '{}' for program '{}' (score "
+                        "{}).",
                         level_->GetNameFromId(selected_material_id),
                         active_program_info_->program_name,
                         selected_material_score);
+                }
+                for (const auto& binding : active_program_info_->bindings)
+                {
+                    if (binding.binding_type != frame::proto::ProgramBinding::
+                                                    COMBINED_IMAGE_SAMPLER ||
+                        binding.name.empty() ||
+                        active_program_info_->texture_ids_by_inner.contains(
+                            binding.name))
+                    {
+                        continue;
+                    }
+                    const auto texture_id = level_->GetIdFromName(binding.name);
+                    if (texture_id != NullId)
+                    {
+                        active_program_info_
+                            ->texture_ids_by_inner[binding.name] = texture_id;
+                    }
                 }
             }
             catch (const std::exception& ex)
@@ -2436,13 +2434,13 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
             else if (hardware_raytracing_supported_)
             {
                 logger_->info(
-                    "Vulkan hardware raytracing is available but program {} has no ray tracing stage mapping.",
+                    "Vulkan hardware raytracing is available but program {} "
+                    "has no ray tracing stage mapping.",
                     active_program_info_->program_name);
             }
         }
         if (active_program_info_ && active_program_info_->use_compute &&
-            active_program_info_->compute_shader.empty() &&
-            current_level_data_)
+            active_program_info_->compute_shader.empty() && current_level_data_)
         {
             logger_->warn(
                 "Compute program {} has no mapped compute pipeline source.",
@@ -2462,15 +2460,9 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
             graphics_queue_,
             *command_resources_->GetPool());
         buffer_resources_ = std::make_unique<BufferResourceManager>(
-            *vk_unique_device_,
-            *gpu_memory_manager_,
-            *command_queue_,
-            logger_);
+            *vk_unique_device_, *gpu_memory_manager_, *command_queue_, logger_);
         mesh_resources_ = std::make_unique<MeshResources>(
-            *vk_unique_device_,
-            *gpu_memory_manager_,
-            *command_queue_,
-            logger_);
+            *vk_unique_device_, *gpu_memory_manager_, *command_queue_, logger_);
     }
     if (!swapchain_resources_)
     {
@@ -2489,12 +2481,15 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
 
     DestroyRaytracingPipeline();
     DestroyComputePipeline();
+    DestroyShadowMapPipeline();
     DestroyGraphicsPipeline();
     DestroyDescriptorResources();
+    DestroyShadowMapResources();
     DestroyHardwareRaytracingScene();
     DestroyGpuSkinningResources();
-    // TextureResources keeps raw pointers to textures owned by the previous level.
-    // Clear the resource map after resource transfer and before dropping old level.
+    // TextureResources keeps raw pointers to textures owned by the previous
+    // level. Clear the resource map after resource transfer and before dropping
+    // old level.
     DestroyTextureResources();
     if (mesh_resources_)
     {
@@ -2529,13 +2524,21 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
             CreateSwapchainPreviewImage();
         }
         {
+            ScopedTimer timer(logger_, "CreateShadowMapResources");
+            CreateShadowMapResources();
+        }
+        {
             ScopedTimer timer(logger_, "CreateDescriptorResources");
             CreateDescriptorResources();
         }
         if (mesh_resources_)
         {
             ScopedTimer timer(logger_, "MeshResources Build");
-            mesh_resources_->Build(level_data);
+            mesh_resources_->Build(
+                *level_,
+                level_data,
+                active_program_info_ && active_program_info_->scene_type ==
+                                            frame::proto::SceneType::SCENE);
         }
         {
             ScopedTimer timer(logger_, "CreateGpuSkinningResources");
@@ -2544,6 +2547,10 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
         {
             ScopedTimer timer(logger_, "CreateGraphicsPipeline");
             CreateGraphicsPipeline();
+        }
+        {
+            ScopedTimer timer(logger_, "CreateShadowMapPipeline");
+            CreateShadowMapPipeline();
         }
         if (use_raytracing_pipeline_)
         {
@@ -2560,7 +2567,9 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
     catch (const std::exception& ex)
     {
         logger_->error("Failed to prepare Vulkan GPU resources: {}", ex.what());
+        DestroyShadowMapPipeline();
         DestroyDescriptorResources();
+        DestroyShadowMapResources();
         DestroyHardwareRaytracingScene();
         DestroyGpuSkinningResources();
         DestroyTextureResources();
@@ -2578,11 +2587,12 @@ void Device::StartupFromLevelData(const frame::json::LevelData& level_data)
         sync_resources_ = std::make_unique<SyncResources>(
             *vk_unique_device_,
             kMaxFramesInFlight,
-            swapchain_resources_ ? swapchain_resources_->GetImages().size() : 0);
+            swapchain_resources_ ? swapchain_resources_->GetImages().size()
+                                 : 0);
     }
-    else if (swapchain_resources_ &&
-             sync_resources_->GetSwapchainImageCount() !=
-                 swapchain_resources_->GetImages().size())
+    else if (
+        swapchain_resources_ && sync_resources_->GetSwapchainImageCount() !=
+                                    swapchain_resources_->GetImages().size())
     {
         sync_resources_->Destroy();
         sync_resources_->SetSwapchainImageCount(
@@ -2674,6 +2684,7 @@ void Device::Cleanup()
 
     DestroyRaytracingPipeline();
     DestroyComputePipeline();
+    DestroyShadowMapPipeline();
     DestroyGraphicsPipeline();
     DestroySwapchainPreviewImage();
     if (swapchain_resources_)
@@ -2681,6 +2692,7 @@ void Device::Cleanup()
         swapchain_resources_->Destroy();
     }
     DestroyDescriptorResources();
+    DestroyShadowMapResources();
     DestroyHardwareRaytracingScene();
     DestroyGpuSkinningResources();
     DestroyTextureResources();
@@ -2730,8 +2742,7 @@ glm::uvec2 Device::GetSize() const
 
 void Device::UpdateRaytraceBuffers()
 {
-    if (!level_ ||
-        !buffer_resources_ ||
+    if (!level_ || !buffer_resources_ ||
         (!use_compute_raytracing_ && !use_raytracing_pipeline_))
     {
         return;
@@ -2768,7 +2779,8 @@ void Device::UpdateRaytraceBuffers()
         use_hardware_raytracing_ && hardware_raytracing_uses_source_instances_;
     bool animated_triangle_updated = false;
     const auto gpu_update_start = SteadyClock::now();
-    const auto gpu_updated_source_triangle_buffer_ids = UpdateGpuSkinnedMeshes();
+    const auto gpu_updated_source_triangle_buffer_ids =
+        UpdateGpuSkinnedMeshes();
     animated_rt_stats.dynamic_geometry_total_ms +=
         ElapsedMilliseconds(gpu_update_start);
     if (!gpu_updated_source_triangle_buffer_ids.empty())
@@ -2779,12 +2791,13 @@ void Device::UpdateRaytraceBuffers()
     gpu_managed_triangle_buffer_ids.reserve(gpu_skinning_resources_.size());
     for (const auto& resource : gpu_skinning_resources_)
     {
-        gpu_managed_triangle_buffer_ids.insert(resource.source_triangle_buffer_id);
+        gpu_managed_triangle_buffer_ids.insert(
+            resource.source_triangle_buffer_id);
     }
     for (const auto node_id : level_->GetSceneNodes())
     {
-        auto* node_mesh =
-            dynamic_cast<frame::NodeMesh*>(&level_->GetSceneNodeFromId(node_id));
+        auto* node_mesh = dynamic_cast<frame::NodeMesh*>(
+            &level_->GetSceneNodeFromId(node_id));
         if (!node_mesh)
         {
             continue;
@@ -2813,7 +2826,8 @@ void Device::UpdateRaytraceBuffers()
             skinned_mesh->HasActiveRaytraceTriangleCallback())
         {
             const auto triangle_eval_start = SteadyClock::now();
-            auto triangles = skinned_mesh->EvaluateRaytraceTriangles(skinning_time);
+            auto triangles =
+                skinned_mesh->EvaluateRaytraceTriangles(skinning_time);
             animated_rt_stats.triangle_eval_ms +=
                 ElapsedMilliseconds(triangle_eval_start);
             if (!triangles.empty())
@@ -2839,7 +2853,8 @@ void Device::UpdateRaytraceBuffers()
                         if (changed)
                         {
                             logger_->info(
-                                "Detected Vulkan skinned animation updates for mesh '{}'.",
+                                "Detected Vulkan skinned animation updates for "
+                                "mesh '{}'.",
                                 level_->GetNameFromId(mesh_id));
                             logged_motion = true;
                         }
@@ -2895,18 +2910,18 @@ void Device::UpdateRaytraceBuffers()
     if (HasRaytracingSourceMeshes(*level_))
     {
         bool used_incremental_source_updates = false;
-        if (use_hardware_raytracing_ && hardware_raytracing_uses_source_instances_ &&
+        if (use_hardware_raytracing_ &&
+            hardware_raytracing_uses_source_instances_ &&
             !gpu_updated_source_triangle_buffer_ids.empty())
         {
             used_incremental_source_updates = true;
             updated_aggregate_scene = true;
             last_raytrace_scene_state_hash_ = BuildRaytracingSourceStateHash(
-                *level_,
-                static_cast<double>(elapsed_time_seconds_),
-                false);
+                *level_, static_cast<double>(elapsed_time_seconds_), false);
             has_raytrace_scene_state_hash_ = true;
         }
-        if (use_hardware_raytracing_ && hardware_raytracing_uses_source_instances_ &&
+        if (use_hardware_raytracing_ &&
+            hardware_raytracing_uses_source_instances_ &&
             !updated_source_triangle_buffer_ids.empty())
         {
             const auto prepared_source_geometries =
@@ -2932,10 +2947,11 @@ void Device::UpdateRaytraceBuffers()
             {
                 used_incremental_source_updates = true;
                 updated_aggregate_scene = true;
-                last_raytrace_scene_state_hash_ = BuildRaytracingSourceStateHash(
-                    *level_,
-                    static_cast<double>(elapsed_time_seconds_),
-                    false);
+                last_raytrace_scene_state_hash_ =
+                    BuildRaytracingSourceStateHash(
+                        *level_,
+                        static_cast<double>(elapsed_time_seconds_),
+                        false);
                 has_raytrace_scene_state_hash_ = true;
             }
         }
@@ -2964,12 +2980,12 @@ void Device::UpdateRaytraceBuffers()
     if (updated_buffer_count > 0 || updated_aggregate_scene ||
         updated_hardware_transforms)
     {
-        // Re-arm transfer->compute visibility barrier after dynamic SSBO writes.
+        // Re-arm transfer->compute visibility barrier after dynamic SSBO
+        // writes.
         storage_buffers_ready_ = false;
     }
     RecordVulkanProfileCounter(
-        "raytrace.updated_cpu_storage_buffers",
-        updated_buffer_count);
+        "raytrace.updated_cpu_storage_buffers", updated_buffer_count);
     if (updated_aggregate_scene)
     {
         RecordVulkanProfileCounter("raytrace.updated_aggregate_scenes");
@@ -3018,11 +3034,10 @@ bool Device::UpdateAggregateRaytracingSceneBuffers(bool build_software_bvh)
     }
     const bool use_world_space_triangles =
         build_software_bvh || RaytraceSceneRequiresWorldSpaceBuffers(*level_);
-    const std::size_t scene_state_hash =
-        BuildRaytracingSourceStateHash(
-            *level_,
-            static_cast<double>(elapsed_time_seconds_),
-            use_world_space_triangles);
+    const std::size_t scene_state_hash = BuildRaytracingSourceStateHash(
+        *level_,
+        static_cast<double>(elapsed_time_seconds_),
+        use_world_space_triangles);
     if (has_raytrace_scene_state_hash_ &&
         last_raytrace_scene_state_hash_ == scene_state_hash)
     {
@@ -3031,7 +3046,8 @@ bool Device::UpdateAggregateRaytracingSceneBuffers(bool build_software_bvh)
 
     auto update_buffer = [&](const char* inner_name,
                              const std::vector<std::uint8_t>& bytes) {
-        const auto it = active_program_info_->buffer_ids_by_inner.find(inner_name);
+        const auto it =
+            active_program_info_->buffer_ids_by_inner.find(inner_name);
         if (it == active_program_info_->buffer_ids_by_inner.end())
         {
             return false;
@@ -3054,8 +3070,7 @@ bool Device::UpdateAggregateRaytracingSceneBuffers(bool build_software_bvh)
             return true;
         }
         if (!buffer_resources_->UpdateStorageBuffer(
-                level_->GetNameFromId(it->second),
-                buffer->GetRawData()))
+                level_->GetNameFromId(it->second), buffer->GetRawData()))
         {
             logger_->warn(
                 "Failed to update animated Vulkan raytracing buffer '{}'.",
@@ -3064,22 +3079,20 @@ bool Device::UpdateAggregateRaytracingSceneBuffers(bool build_software_bvh)
         return true;
     };
 
-    const auto transmissive_triangles =
-        BuildAggregateTriangleBytes(
-            *level_,
-            true,
-            static_cast<double>(elapsed_time_seconds_),
-            use_world_space_triangles);
-    const auto opaque_triangles =
-        BuildAggregateTriangleBytes(
-            *level_,
-            false,
-            static_cast<double>(elapsed_time_seconds_),
-            use_world_space_triangles);
+    const auto transmissive_triangles = BuildAggregateTriangleBytes(
+        *level_,
+        true,
+        static_cast<double>(elapsed_time_seconds_),
+        use_world_space_triangles);
+    const auto opaque_triangles = BuildAggregateTriangleBytes(
+        *level_,
+        false,
+        static_cast<double>(elapsed_time_seconds_),
+        use_world_space_triangles);
 
     bool updated = false;
-    updated |= update_buffer(
-        "TriangleBufferTransmissive", transmissive_triangles);
+    updated |=
+        update_buffer("TriangleBufferTransmissive", transmissive_triangles);
     updated |= update_buffer("TriangleBufferOpaque", opaque_triangles);
 
     if (build_software_bvh)
@@ -3088,8 +3101,7 @@ bool Device::UpdateAggregateRaytracingSceneBuffers(bool build_software_bvh)
             "BvhBufferTransmissive",
             BuildAggregateBvhBytes(transmissive_triangles));
         updated |= update_buffer(
-            "BvhBufferOpaque",
-            BuildAggregateBvhBytes(opaque_triangles));
+            "BvhBufferOpaque", BuildAggregateBvhBytes(opaque_triangles));
     }
 
     last_raytrace_scene_state_hash_ = scene_state_hash;
@@ -3104,8 +3116,8 @@ bool Device::UpdateHardwareRaytracingInstanceStorageBuffer()
         return false;
     }
 
-    const auto it =
-        active_program_info_->buffer_ids_by_inner.find("RaytraceInstanceBuffer");
+    const auto it = active_program_info_->buffer_ids_by_inner.find(
+        "RaytraceInstanceBuffer");
     if (it == active_program_info_->buffer_ids_by_inner.end())
     {
         return false;
@@ -3171,7 +3183,8 @@ bool Device::UpdateHardwareRaytracingInstanceStorageBuffer()
         else if (!previous_bytes.empty())
         {
             logger_->warn(
-                "Vulkan raytrace instance buffer '{}' changed size from {} to {}; GPU upload requires a resource rebuild.",
+                "Vulkan raytrace instance buffer '{}' changed size from {} to "
+                "{}; GPU upload requires a resource rebuild.",
                 buffer_name,
                 previous_bytes.size(),
                 bytes.size());
@@ -3185,8 +3198,7 @@ bool Device::UpdateHardwareRaytracingAggregateSceneBuffers(
     const std::vector<EntityId>& updated_source_triangle_buffer_ids)
 {
     return UpdateHardwareRaytracingAggregateSceneBuffers(
-        updated_source_triangle_buffer_ids,
-        {});
+        updated_source_triangle_buffer_ids, {});
 }
 
 bool Device::UpdateHardwareRaytracingAggregateSceneBuffers(
@@ -3233,13 +3245,14 @@ bool Device::UpdateHardwareRaytracingAggregateSceneBuffers(
         if (!source_geometry)
         {
             const auto prepare_start = SteadyClock::now();
-            rebuilt_source_geometry = BuildRaytracingSourceGeometryDataForSource(
-                *level_,
-                geometry.source_node_id,
-                geometry.source_material_id,
-                static_cast<double>(elapsed_time_seconds_),
-                false,
-                geometry.triangle_offset);
+            rebuilt_source_geometry =
+                BuildRaytracingSourceGeometryDataForSource(
+                    *level_,
+                    geometry.source_node_id,
+                    geometry.source_material_id,
+                    static_cast<double>(elapsed_time_seconds_),
+                    false,
+                    geometry.triangle_offset);
             animated_rt_stats.aggregate_prepare_ms +=
                 ElapsedMilliseconds(prepare_start);
             if (rebuilt_source_geometry)
@@ -3254,11 +3267,11 @@ bool Device::UpdateHardwareRaytracingAggregateSceneBuffers(
             return false;
         }
 
-        const char* inner_name =
-            geometry.material_id == 0u
-                ? "TriangleBufferTransmissive"
-                : "TriangleBufferOpaque";
-        const auto it = active_program_info_->buffer_ids_by_inner.find(inner_name);
+        const char* inner_name = geometry.material_id == 0u
+                                     ? "TriangleBufferTransmissive"
+                                     : "TriangleBufferOpaque";
+        const auto it =
+            active_program_info_->buffer_ids_by_inner.find(inner_name);
         if (it == active_program_info_->buffer_ids_by_inner.end())
         {
             return false;
@@ -3271,8 +3284,8 @@ bool Device::UpdateHardwareRaytracingAggregateSceneBuffers(
             return false;
         }
 
-        const std::size_t byte_offset = static_cast<std::size_t>(
-            geometry.triangle_offset) *
+        const std::size_t byte_offset =
+            static_cast<std::size_t>(geometry.triangle_offset) *
             (kRaytraceTriangleVertexStrideBytes * 3u);
         if (byte_offset > aggregate_buffer->GetRawData().size() ||
             source_geometry->triangle_bytes.size() >
@@ -3282,8 +3295,7 @@ bool Device::UpdateHardwareRaytracingAggregateSceneBuffers(
         }
 
         if (!aggregate_buffer->CopyRange(
-                byte_offset,
-                source_geometry->triangle_bytes))
+                byte_offset, source_geometry->triangle_bytes))
         {
             continue;
         }
@@ -3295,7 +3307,8 @@ bool Device::UpdateHardwareRaytracingAggregateSceneBuffers(
                 byte_offset))
         {
             logger_->warn(
-                "Failed to update Vulkan raytrace aggregate buffer '{}' range [{}..{}).",
+                "Failed to update Vulkan raytrace aggregate buffer '{}' range "
+                "[{}..{}).",
                 inner_name,
                 byte_offset,
                 byte_offset + source_geometry->triangle_bytes.size());
@@ -3311,25 +3324,25 @@ bool Device::UpdateHardwareRaytracingAggregateSceneBuffers(
 bool Device::UpdateHardwareRaytracingDynamicGeometry()
 {
     std::vector<EntityId> updated_source_triangle_buffer_ids = {};
-    updated_source_triangle_buffer_ids.reserve(hardware_raytracing_geometries_.size());
+    updated_source_triangle_buffer_ids.reserve(
+        hardware_raytracing_geometries_.size());
     for (const auto& geometry : hardware_raytracing_geometries_)
     {
         if (geometry.source_buffer_id != NullId)
         {
-            updated_source_triangle_buffer_ids.push_back(geometry.source_buffer_id);
+            updated_source_triangle_buffer_ids.push_back(
+                geometry.source_buffer_id);
         }
     }
     return UpdateHardwareRaytracingDynamicGeometry(
-        updated_source_triangle_buffer_ids,
-        {});
+        updated_source_triangle_buffer_ids, {});
 }
 
 bool Device::UpdateHardwareRaytracingDynamicGeometry(
     const std::vector<EntityId>& updated_source_triangle_buffer_ids)
 {
     return UpdateHardwareRaytracingDynamicGeometry(
-        updated_source_triangle_buffer_ids,
-        {});
+        updated_source_triangle_buffer_ids, {});
 }
 
 bool Device::UpdateHardwareRaytracingDynamicGeometry(
@@ -3407,13 +3420,14 @@ bool Device::UpdateHardwareRaytracingDynamicGeometry(
         if (!source_geometry)
         {
             const auto prepare_start = SteadyClock::now();
-            rebuilt_source_geometry = BuildRaytracingSourceGeometryDataForSource(
-                *level_,
-                geometry.source_node_id,
-                geometry.source_material_id,
-                static_cast<double>(elapsed_time_seconds_),
-                false,
-                geometry.triangle_offset);
+            rebuilt_source_geometry =
+                BuildRaytracingSourceGeometryDataForSource(
+                    *level_,
+                    geometry.source_node_id,
+                    geometry.source_material_id,
+                    static_cast<double>(elapsed_time_seconds_),
+                    false,
+                    geometry.triangle_offset);
             animated_rt_stats.dynamic_geometry_prepare_ms +=
                 ElapsedMilliseconds(prepare_start);
             if (rebuilt_source_geometry)
@@ -3426,7 +3440,8 @@ bool Device::UpdateHardwareRaytracingDynamicGeometry(
             return false;
         }
 
-        if (!geometry.blas || !geometry.vertex_buffer || !geometry.index_buffer ||
+        if (!geometry.blas || !geometry.vertex_buffer ||
+            !geometry.index_buffer ||
             geometry.source_node_id != source_geometry->source_node_id ||
             geometry.source_buffer_id != source_geometry->triangle_buffer_id ||
             geometry.material_id != source_geometry->material_id ||
@@ -3453,7 +3468,8 @@ bool Device::UpdateHardwareRaytracingDynamicGeometry(
 
         PendingBlasUpdate pending = {};
         pending.geometry = &geometry;
-        pending.upload_size = static_cast<vk::DeviceSize>(triangle_bytes.size());
+        pending.upload_size =
+            static_cast<vk::DeviceSize>(triangle_bytes.size());
 
         pending.staging_buffer = gpu_memory_manager_->CreateBuffer(
             pending.upload_size,
@@ -3462,9 +3478,7 @@ bool Device::UpdateHardwareRaytracingDynamicGeometry(
                 vk::MemoryPropertyFlagBits::eHostCoherent,
             pending.staging_memory);
         void* mapped = vk_unique_device_->mapMemory(
-            *pending.staging_memory,
-            0,
-            pending.upload_size);
+            *pending.staging_memory, 0, pending.upload_size);
         std::memcpy(mapped, triangle_bytes.data(), triangle_bytes.size());
         vk_unique_device_->unmapMemory(*pending.staging_memory);
 
@@ -3501,18 +3515,13 @@ bool Device::UpdateHardwareRaytracingDynamicGeometry(
                 pending.build_info,
                 geometry.triangle_count);
         const auto scratch_address = build_scratch_address(
-            std::max(
-                size_info.buildScratchSize,
-                size_info.updateScratchSize),
+            std::max(size_info.buildScratchSize, size_info.updateScratchSize),
             pending.scratch_buffer,
             pending.scratch_memory);
         pending.build_info.setScratchData(
             vk::DeviceOrHostAddressKHR(scratch_address));
         pending.range_info = vk::AccelerationStructureBuildRangeInfoKHR(
-            geometry.triangle_count,
-            0,
-            0,
-            0);
+            geometry.triangle_count, 0, 0, 0);
         pending_updates.push_back(std::move(pending));
     }
 
@@ -3524,52 +3533,50 @@ bool Device::UpdateHardwareRaytracingDynamicGeometry(
 
     for (auto& pending : pending_updates)
     {
-        // build_info keeps a pointer to as_geometry; refresh it after vector moves.
+        // build_info keeps a pointer to as_geometry; refresh it after vector
+        // moves.
         pending.build_info.setGeometries(pending.as_geometry);
     }
 
     const auto submit_start = SteadyClock::now();
     {
         VulkanProfileScope submit_scope("raytrace.blas_update_submit_wait");
-        command_queue_->SubmitOneTime(
-            [&](vk::CommandBuffer command_buffer)
+        command_queue_->SubmitOneTime([&](vk::CommandBuffer command_buffer) {
+            std::vector<vk::BufferMemoryBarrier> copy_barriers = {};
+            copy_barriers.reserve(pending_updates.size());
+            for (const auto& pending : pending_updates)
             {
-                std::vector<vk::BufferMemoryBarrier> copy_barriers = {};
-                copy_barriers.reserve(pending_updates.size());
-                for (const auto& pending : pending_updates)
-                {
-                    command_buffer.copyBuffer(
-                        *pending.staging_buffer,
-                        *pending.geometry->vertex_buffer,
-                        vk::BufferCopy(0, 0, pending.upload_size));
-                    copy_barriers.emplace_back(
-                        vk::AccessFlagBits::eTransferWrite,
-                        vk::AccessFlagBits::eAccelerationStructureReadKHR,
-                        VK_QUEUE_FAMILY_IGNORED,
-                        VK_QUEUE_FAMILY_IGNORED,
-                        *pending.geometry->vertex_buffer,
-                        0,
-                        pending.upload_size);
-                }
-                if (!copy_barriers.empty())
-                {
-                    command_buffer.pipelineBarrier(
-                        vk::PipelineStageFlagBits::eTransfer,
-                        vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR,
-                        {},
-                        nullptr,
-                        copy_barriers,
-                        nullptr);
-                }
-                for (const auto& pending : pending_updates)
-                {
-                    const vk::AccelerationStructureBuildRangeInfoKHR*
-                        range_infos[] = {&pending.range_info};
-                    command_buffer.buildAccelerationStructuresKHR(
-                        pending.build_info,
-                        range_infos);
-                }
-            });
+                command_buffer.copyBuffer(
+                    *pending.staging_buffer,
+                    *pending.geometry->vertex_buffer,
+                    vk::BufferCopy(0, 0, pending.upload_size));
+                copy_barriers.emplace_back(
+                    vk::AccessFlagBits::eTransferWrite,
+                    vk::AccessFlagBits::eAccelerationStructureReadKHR,
+                    VK_QUEUE_FAMILY_IGNORED,
+                    VK_QUEUE_FAMILY_IGNORED,
+                    *pending.geometry->vertex_buffer,
+                    0,
+                    pending.upload_size);
+            }
+            if (!copy_barriers.empty())
+            {
+                command_buffer.pipelineBarrier(
+                    vk::PipelineStageFlagBits::eTransfer,
+                    vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR,
+                    {},
+                    nullptr,
+                    copy_barriers,
+                    nullptr);
+            }
+            for (const auto& pending : pending_updates)
+            {
+                const vk::AccelerationStructureBuildRangeInfoKHR*
+                    range_infos[] = {&pending.range_info};
+                command_buffer.buildAccelerationStructuresKHR(
+                    pending.build_info, range_infos);
+            }
+        });
     }
     animated_rt_stats.dynamic_geometry_submit_ms +=
         ElapsedMilliseconds(submit_start);
@@ -3594,7 +3601,8 @@ bool Device::UpdateHardwareRaytracingTransforms(bool force_tlas_update)
 {
     if (!use_hardware_raytracing_ || !vk_unique_device_ || !level_ ||
         hardware_raytracing_geometries_.empty() || !hardware_raytracing_tlas_ ||
-        !hardware_raytracing_instance_buffer_ || !hardware_raytracing_instance_memory_)
+        !hardware_raytracing_instance_buffer_ ||
+        !hardware_raytracing_instance_memory_)
     {
         return false;
     }
@@ -3620,8 +3628,9 @@ bool Device::UpdateHardwareRaytracingTransforms(bool force_tlas_update)
                 &level_->GetSceneNodeFromId(geometry.source_node_id));
             if (node)
             {
-                instance.transform = MakeAccelerationStructureTransform(
-                    node->GetLocalModel(static_cast<double>(elapsed_time_seconds_)));
+                instance.transform =
+                    MakeAccelerationStructureTransform(node->GetLocalModel(
+                        static_cast<double>(elapsed_time_seconds_)));
             }
             else
             {
@@ -3660,7 +3669,8 @@ bool Device::UpdateHardwareRaytracingTransforms(bool force_tlas_update)
             return storage_buffer_changed;
         }
         RebuildHardwareRaytracingTlas();
-        animated_rt_stats.transform_total_ms += ElapsedMilliseconds(total_start);
+        animated_rt_stats.transform_total_ms +=
+            ElapsedMilliseconds(total_start);
         return true;
     }
 
@@ -3685,7 +3695,8 @@ bool Device::UpdateHardwareRaytracingTransforms(bool force_tlas_update)
             if (wait_result != VK_SUCCESS)
             {
                 logger_->error(
-                    "vkWaitForFences failed before updating hardware raytracing transforms: {}",
+                    "vkWaitForFences failed before updating hardware "
+                    "raytracing transforms: {}",
                     vk::to_string(static_cast<vk::Result>(wait_result)));
                 if (wait_result == VK_ERROR_DEVICE_LOST)
                 {
@@ -3718,8 +3729,8 @@ bool Device::UpdateHardwareRaytracingTransforms(bool force_tlas_update)
 
 void Device::RebuildHardwareRaytracingTlas()
 {
-    if (!use_hardware_raytracing_ || !vk_unique_device_ || !gpu_memory_manager_ ||
-        !command_queue_ || !hardware_raytracing_tlas_ ||
+    if (!use_hardware_raytracing_ || !vk_unique_device_ ||
+        !gpu_memory_manager_ || !command_queue_ || !hardware_raytracing_tlas_ ||
         !hardware_raytracing_instance_buffer_)
     {
         return;
@@ -3754,8 +3765,7 @@ void Device::RebuildHardwareRaytracingTlas()
     const auto instance_address = vk_unique_device_->getBufferAddress(
         vk::BufferDeviceAddressInfo(*hardware_raytracing_instance_buffer_));
     vk::AccelerationStructureGeometryInstancesDataKHR instances_data(
-        VK_FALSE,
-        vk::DeviceOrHostAddressConstKHR(instance_address));
+        VK_FALSE, vk::DeviceOrHostAddressConstKHR(instance_address));
     vk::AccelerationStructureGeometryDataKHR tlas_geometry_data;
     tlas_geometry_data.setInstances(instances_data);
     vk::AccelerationStructureGeometryKHR tlas_geometry(
@@ -3770,10 +3780,11 @@ void Device::RebuildHardwareRaytracingTlas()
         {},
         tlas_geometry);
     tlas_build_info.setSrcAccelerationStructure(*hardware_raytracing_tlas_);
-    const auto tlas_size = vk_unique_device_->getAccelerationStructureBuildSizesKHR(
-        vk::AccelerationStructureBuildTypeKHR::eDevice,
-        tlas_build_info,
-        instance_count);
+    const auto tlas_size =
+        vk_unique_device_->getAccelerationStructureBuildSizesKHR(
+            vk::AccelerationStructureBuildTypeKHR::eDevice,
+            tlas_build_info,
+            instance_count);
     vk::UniqueBuffer tlas_scratch_buffer;
     vk::UniqueDeviceMemory tlas_scratch_memory;
     const auto tlas_scratch_address = build_scratch_address(
@@ -3784,22 +3795,16 @@ void Device::RebuildHardwareRaytracingTlas()
     tlas_build_info.setScratchData(
         vk::DeviceOrHostAddressKHR(tlas_scratch_address));
     vk::AccelerationStructureBuildRangeInfoKHR tlas_range_info(
-        instance_count,
-        0,
-        0,
-        0);
+        instance_count, 0, 0, 0);
     const vk::AccelerationStructureBuildRangeInfoKHR* tlas_ranges[] = {
         &tlas_range_info};
     const auto rebuild_start = SteadyClock::now();
     {
         VulkanProfileScope submit_scope("raytrace.tlas_update_submit_wait");
-        command_queue_->SubmitOneTime(
-            [&](vk::CommandBuffer command_buffer)
-            {
-                command_buffer.buildAccelerationStructuresKHR(
-                    tlas_build_info,
-                    tlas_ranges);
-            });
+        command_queue_->SubmitOneTime([&](vk::CommandBuffer command_buffer) {
+            command_buffer.buildAccelerationStructuresKHR(
+                tlas_build_info, tlas_ranges);
+        });
     }
     GetAnimatedRaytraceTimingStats().tlas_rebuild_ms +=
         ElapsedMilliseconds(rebuild_start);
@@ -3834,7 +3839,8 @@ void Device::UpdateHardwareRaytracingDescriptor()
         nullptr);
 }
 
-std::optional<vk::DescriptorImageInfo> Device::GetComputeOutputDescriptorInfo() const
+std::optional<vk::DescriptorImageInfo> Device::GetComputeOutputDescriptorInfo()
+    const
 {
     if (!output_image_resources_)
     {
@@ -3843,7 +3849,8 @@ std::optional<vk::DescriptorImageInfo> Device::GetComputeOutputDescriptorInfo() 
     return output_image_resources_->GetComputeOutputDescriptorInfo();
 }
 
-std::optional<vk::DescriptorImageInfo> Device::GetSwapchainPreviewDescriptorInfo() const
+std::optional<vk::DescriptorImageInfo> Device::
+    GetSwapchainPreviewDescriptorInfo() const
 {
     if (!output_image_resources_)
     {
@@ -3867,8 +3874,7 @@ void Device::LogRuntimeConfiguration() const
     const bool has_compute_shader =
         has_active_program && !active_program_info_->compute_shader.empty();
     const bool has_raytracing_stage_mapping =
-        has_active_program &&
-        !active_program_info_->raygen_shader.empty() &&
+        has_active_program && !active_program_info_->raygen_shader.empty() &&
         !active_program_info_->miss_shader.empty() &&
         !active_program_info_->closesthit_shader.empty();
     const bool raytracing_pipeline_ready =
@@ -3901,15 +3907,22 @@ void Device::LogRuntimeConfiguration() const
     }
 
     std::string material_name = "<none>";
-    if (level_ && has_active_program && active_program_info_->material_id != NullId)
+    if (level_ && has_active_program &&
+        active_program_info_->material_id != NullId)
     {
-        material_name = level_->GetNameFromId(active_program_info_->material_id);
+        material_name =
+            level_->GetNameFromId(active_program_info_->material_id);
     }
 
     logger_->info(
-        "Vulkan runtime summary: validation={}, program='{}', material='{}', path={}, hw_rt_supported={}, hw_rt_requested={}, hw_rt_scene_ready={}, rt_pipeline_ready={}, compute_pipeline_ready={}, compute_shader_mapped={}, rt_stage_mapping={}.",
+        "Vulkan runtime summary: validation={}, program='{}', material='{}', "
+        "path={}, hw_rt_supported={}, hw_rt_requested={}, "
+        "hw_rt_scene_ready={}, rt_pipeline_ready={}, "
+        "compute_pipeline_ready={}, compute_shader_mapped={}, "
+        "rt_stage_mapping={}.",
         BoolToString(validation_enabled),
-        has_active_program ? active_program_info_->program_name.c_str() : "<none>",
+        has_active_program ? active_program_info_->program_name.c_str()
+                           : "<none>",
         material_name,
         active_path,
         BoolToString(hardware_raytracing_supported_),
@@ -3920,7 +3933,6 @@ void Device::LogRuntimeConfiguration() const
         BoolToString(has_compute_shader),
         BoolToString(has_raytracing_stage_mapping));
 }
-
 
 void Device::Shutdown()
 {
@@ -3935,8 +3947,8 @@ void Device::ScreenShot(const std::string& file) const
         throw std::runtime_error(
             "Cannot take a Vulkan screenshot after device loss.");
     }
-    if (!vk_unique_device_ || !swapchain_resources_ || !output_image_resources_ ||
-        !gpu_memory_manager_ || !command_queue_)
+    if (!vk_unique_device_ || !swapchain_resources_ ||
+        !output_image_resources_ || !gpu_memory_manager_ || !command_queue_)
     {
         throw std::runtime_error(
             "Vulkan screenshot resources are not initialized.");
@@ -3980,13 +3992,15 @@ void Device::ScreenShot(const std::string& file) const
 std::unique_ptr<frame::BufferInterface> Device::CreatePointBuffer(
     std::vector<float>&& /*vector*/)
 {
-    throw std::runtime_error("Vulkan point buffer support not implemented yet.");
+    throw std::runtime_error(
+        "Vulkan point buffer support not implemented yet.");
 }
 
 std::unique_ptr<frame::BufferInterface> Device::CreateIndexBuffer(
     std::vector<std::uint32_t>&& /*vector*/)
 {
-    throw std::runtime_error("Vulkan index buffer support not implemented yet.");
+    throw std::runtime_error(
+        "Vulkan index buffer support not implemented yet.");
 }
 
 std::unique_ptr<frame::MeshInterface> Device::CreateMesh(
@@ -4012,7 +4026,9 @@ void Device::RecreateSwapchain()
 
     DestroyRaytracingPipeline();
     DestroyComputePipeline();
+    DestroyShadowMapPipeline();
     DestroyDescriptorResources();
+    DestroyShadowMapResources();
     DestroyHardwareRaytracingScene();
     DestroyGraphicsPipeline();
     DestroySwapchainPreviewImage();
@@ -4034,6 +4050,7 @@ void Device::RecreateSwapchain()
         renderer_->Reset();
     }
     CreateSwapchainPreviewImage();
+    CreateShadowMapResources();
 
     if (use_hardware_raytracing_)
     {
@@ -4041,6 +4058,7 @@ void Device::RecreateSwapchain()
     }
     CreateDescriptorResources();
     CreateGraphicsPipeline();
+    CreateShadowMapPipeline();
     if (use_raytracing_pipeline_)
     {
         CreateRaytracingPipeline();
@@ -4058,19 +4076,15 @@ SceneState Device::BuildFrameSceneState(vk::Extent2D extent) const
     const bool has_raytrace_source_meshes =
         level_ && HasRaytracingSourceMeshes(*level_);
     const bool use_shared_transform_hardware_scene =
-        has_raytrace_source_meshes &&
-        use_hardware_raytracing_ &&
+        has_raytrace_source_meshes && use_hardware_raytracing_ &&
         CanUseSharedTransformHardwareRaytraceScene(
-            *level_,
-            static_cast<double>(elapsed_time_seconds_));
+            *level_, static_cast<double>(elapsed_time_seconds_));
     const bool use_world_space_raytrace_scene =
         has_raytrace_source_meshes &&
         (use_compute_raytracing_ || use_raytracing_pipeline_) &&
         !use_shared_transform_hardware_scene;
     std::string preferred_scene_root;
-    if (!use_world_space_raytrace_scene &&
-        level_ &&
-        active_program_info_ &&
+    if (!use_world_space_raytrace_scene && level_ && active_program_info_ &&
         active_program_info_->program_id != NullId)
     {
         preferred_scene_root =
@@ -4141,6 +4155,295 @@ void Device::DestroyRaytracingPipeline()
     }
 }
 
+void Device::CreateShadowMapResources()
+{
+    DestroyShadowMapResources();
+
+    if (!vk_unique_device_ || !gpu_memory_manager_ || !swapchain_resources_ ||
+        !active_program_info_ ||
+        active_program_info_->scene_type != frame::proto::SceneType::SCENE ||
+        use_compute_raytracing_ || use_raytracing_pipeline_)
+    {
+        return;
+    }
+
+    const vk::Format depth_format = swapchain_resources_->GetDepthFormat();
+    if (depth_format == vk::Format::eUndefined)
+    {
+        return;
+    }
+
+    vk::AttachmentDescription depth_attachment(
+        vk::AttachmentDescriptionFlags{},
+        depth_format,
+        vk::SampleCountFlagBits::e1,
+        vk::AttachmentLoadOp::eClear,
+        vk::AttachmentStoreOp::eStore,
+        vk::AttachmentLoadOp::eDontCare,
+        vk::AttachmentStoreOp::eDontCare,
+        vk::ImageLayout::eUndefined,
+        vk::ImageLayout::eShaderReadOnlyOptimal);
+    vk::AttachmentReference depth_ref(
+        0, vk::ImageLayout::eDepthStencilAttachmentOptimal);
+    vk::SubpassDescription subpass(
+        vk::SubpassDescriptionFlags{},
+        vk::PipelineBindPoint::eGraphics,
+        0,
+        nullptr,
+        0,
+        nullptr,
+        nullptr,
+        &depth_ref);
+    std::array<vk::SubpassDependency, 2> dependencies = {
+        vk::SubpassDependency(
+            VK_SUBPASS_EXTERNAL,
+            0,
+            vk::PipelineStageFlagBits::eFragmentShader,
+            vk::PipelineStageFlagBits::eEarlyFragmentTests,
+            vk::AccessFlagBits::eShaderRead,
+            vk::AccessFlagBits::eDepthStencilAttachmentWrite,
+            vk::DependencyFlagBits::eByRegion),
+        vk::SubpassDependency(
+            0,
+            VK_SUBPASS_EXTERNAL,
+            vk::PipelineStageFlagBits::eLateFragmentTests,
+            vk::PipelineStageFlagBits::eFragmentShader,
+            vk::AccessFlagBits::eDepthStencilAttachmentWrite,
+            vk::AccessFlagBits::eShaderRead,
+            vk::DependencyFlagBits::eByRegion)};
+    vk::RenderPassCreateInfo render_pass_info(
+        vk::RenderPassCreateFlags{},
+        1,
+        &depth_attachment,
+        1,
+        &subpass,
+        static_cast<std::uint32_t>(dependencies.size()),
+        dependencies.data());
+    shadow_map_render_pass_ =
+        vk_unique_device_->createRenderPassUnique(render_pass_info);
+
+    vk::ImageCreateInfo image_info(
+        vk::ImageCreateFlags{},
+        vk::ImageType::e2D,
+        depth_format,
+        vk::Extent3D(kShadowMapSize, kShadowMapSize, 1),
+        1,
+        1,
+        vk::SampleCountFlagBits::e1,
+        vk::ImageTiling::eOptimal,
+        vk::ImageUsageFlagBits::eDepthStencilAttachment |
+            vk::ImageUsageFlagBits::eSampled);
+    shadow_map_image_ = vk_unique_device_->createImageUnique(image_info);
+    const auto memory_requirements =
+        vk_unique_device_->getImageMemoryRequirements(*shadow_map_image_);
+    vk::MemoryAllocateInfo alloc_info(
+        memory_requirements.size,
+        gpu_memory_manager_->FindMemoryType(
+            memory_requirements.memoryTypeBits,
+            vk::MemoryPropertyFlagBits::eDeviceLocal));
+    shadow_map_memory_ = vk_unique_device_->allocateMemoryUnique(alloc_info);
+    vk_unique_device_->bindImageMemory(
+        *shadow_map_image_, *shadow_map_memory_, 0);
+
+    vk::ImageViewCreateInfo view_info(
+        vk::ImageViewCreateFlags{},
+        *shadow_map_image_,
+        vk::ImageViewType::e2D,
+        depth_format,
+        {},
+        {vk::ImageAspectFlagBits::eDepth, 0, 1, 0, 1});
+    shadow_map_view_ = vk_unique_device_->createImageViewUnique(view_info);
+
+    vk::SamplerCreateInfo sampler_info(
+        vk::SamplerCreateFlags{},
+        vk::Filter::eLinear,
+        vk::Filter::eLinear,
+        vk::SamplerMipmapMode::eNearest,
+        vk::SamplerAddressMode::eClampToBorder,
+        vk::SamplerAddressMode::eClampToBorder,
+        vk::SamplerAddressMode::eClampToBorder,
+        0.0f,
+        VK_FALSE,
+        1.0f,
+        VK_FALSE,
+        vk::CompareOp::eAlways,
+        0.0f,
+        0.0f,
+        vk::BorderColor::eFloatOpaqueWhite,
+        VK_FALSE);
+    shadow_map_sampler_ = vk_unique_device_->createSamplerUnique(sampler_info);
+
+    const vk::ImageView shadow_map_view = *shadow_map_view_;
+    vk::FramebufferCreateInfo framebuffer_info(
+        vk::FramebufferCreateFlags{},
+        *shadow_map_render_pass_,
+        1,
+        &shadow_map_view,
+        kShadowMapSize,
+        kShadowMapSize,
+        1);
+    shadow_map_framebuffer_ =
+        vk_unique_device_->createFramebufferUnique(framebuffer_info);
+}
+
+void Device::DestroyShadowMapResources()
+{
+    shadow_map_framebuffer_.reset();
+    shadow_map_render_pass_.reset();
+    shadow_map_sampler_.reset();
+    shadow_map_view_.reset();
+    shadow_map_image_.reset();
+    shadow_map_memory_.reset();
+}
+
+std::optional<vk::DescriptorImageInfo> Device::GetShadowMapDescriptorInfo()
+    const
+{
+    if (!shadow_map_sampler_ || !shadow_map_view_)
+    {
+        return std::nullopt;
+    }
+    return vk::DescriptorImageInfo(
+        *shadow_map_sampler_,
+        *shadow_map_view_,
+        vk::ImageLayout::eShaderReadOnlyOptimal);
+}
+
+void Device::CreateShadowMapPipeline()
+{
+    DestroyShadowMapPipeline();
+
+    if (!vk_unique_device_ || !shadow_map_render_pass_ ||
+        !current_level_data_ || !active_program_info_ ||
+        active_program_info_->scene_type != frame::proto::SceneType::SCENE ||
+        use_compute_raytracing_ || use_raytracing_pipeline_)
+    {
+        return;
+    }
+    if (!shader_compiler_)
+    {
+        shader_compiler_ = std::make_unique<ShaderCompiler>();
+    }
+
+    std::vector<std::uint32_t> vert_code;
+    try
+    {
+        vert_code = shader_compiler_->CompileFile(
+            current_level_data_->asset_root / "shader" / "vulkan" /
+                "raster_shadow.vert",
+            shaderc_vertex_shader);
+    }
+    catch (const std::exception& ex)
+    {
+        logger_->warn("Failed to compile raster shadow shader: {}", ex.what());
+        return;
+    }
+
+    vk::ShaderModuleCreateInfo shader_module_info(
+        vk::ShaderModuleCreateFlags{},
+        vert_code.size() * sizeof(std::uint32_t),
+        vert_code.data());
+    auto vert_module =
+        vk_unique_device_->createShaderModuleUnique(shader_module_info);
+    vk::PipelineShaderStageCreateInfo shader_stage(
+        vk::PipelineShaderStageCreateFlags{},
+        vk::ShaderStageFlagBits::eVertex,
+        *vert_module,
+        "main");
+
+    vk::VertexInputBindingDescription binding_description(
+        0,
+        static_cast<std::uint32_t>(sizeof(MeshVertex)),
+        vk::VertexInputRate::eVertex);
+    vk::VertexInputAttributeDescription position_attribute(
+        0,
+        0,
+        vk::Format::eR32G32B32Sfloat,
+        static_cast<std::uint32_t>(offsetof(MeshVertex, position)));
+    vk::PipelineVertexInputStateCreateInfo vertex_input(
+        vk::PipelineVertexInputStateCreateFlags{},
+        1,
+        &binding_description,
+        1,
+        &position_attribute);
+    vk::PipelineInputAssemblyStateCreateInfo input_assembly(
+        vk::PipelineInputAssemblyStateCreateFlags{},
+        vk::PrimitiveTopology::eTriangleList,
+        VK_FALSE);
+    vk::PipelineViewportStateCreateInfo viewport_state(
+        vk::PipelineViewportStateCreateFlags{}, 1, nullptr, 1, nullptr);
+    vk::PipelineRasterizationStateCreateInfo rasterizer(
+        vk::PipelineRasterizationStateCreateFlags{},
+        VK_FALSE,
+        VK_FALSE,
+        vk::PolygonMode::eFill,
+        vk::CullModeFlagBits::eNone,
+        vk::FrontFace::eCounterClockwise,
+        VK_TRUE,
+        1.25f,
+        0.0f,
+        1.75f,
+        1.0f);
+    vk::PipelineMultisampleStateCreateInfo multisampling(
+        vk::PipelineMultisampleStateCreateFlags{}, vk::SampleCountFlagBits::e1);
+    vk::PipelineDepthStencilStateCreateInfo depth_stencil(
+        vk::PipelineDepthStencilStateCreateFlags{},
+        VK_TRUE,
+        VK_TRUE,
+        vk::CompareOp::eLessOrEqual,
+        VK_FALSE,
+        VK_FALSE);
+    std::array<vk::DynamicState, 2> dynamic_states = {
+        vk::DynamicState::eViewport, vk::DynamicState::eScissor};
+    vk::PipelineDynamicStateCreateInfo dynamic_state(
+        vk::PipelineDynamicStateCreateFlags{},
+        static_cast<std::uint32_t>(dynamic_states.size()),
+        dynamic_states.data());
+
+    struct alignas(16) ShadowPushConstants
+    {
+        glm::mat4 light_view_projection;
+        glm::mat4 model;
+    };
+    vk::PushConstantRange push_constant_range(
+        vk::ShaderStageFlagBits::eVertex,
+        0,
+        static_cast<std::uint32_t>(sizeof(ShadowPushConstants)));
+    vk::PipelineLayoutCreateInfo layout_info(
+        vk::PipelineLayoutCreateFlags{}, 0, nullptr, 1, &push_constant_range);
+    shadow_map_pipeline_layout_ =
+        vk_unique_device_->createPipelineLayoutUnique(layout_info);
+
+    vk::GraphicsPipelineCreateInfo pipeline_info(
+        vk::PipelineCreateFlags{},
+        1,
+        &shader_stage,
+        &vertex_input,
+        &input_assembly,
+        nullptr,
+        &viewport_state,
+        &rasterizer,
+        &multisampling,
+        &depth_stencil,
+        nullptr,
+        &dynamic_state,
+        *shadow_map_pipeline_layout_,
+        *shadow_map_render_pass_);
+    auto pipeline_result =
+        vk_unique_device_->createGraphicsPipelineUnique(nullptr, pipeline_info);
+    if (pipeline_result.result != vk::Result::eSuccess)
+    {
+        throw std::runtime_error("Failed to create Vulkan shadow pipeline.");
+    }
+    shadow_map_pipeline_ = std::move(pipeline_result.value);
+}
+
+void Device::DestroyShadowMapPipeline()
+{
+    shadow_map_pipeline_.reset();
+    shadow_map_pipeline_layout_.reset();
+}
+
 void Device::CopyBuffer(vk::Buffer src, vk::Buffer dst, vk::DeviceSize size)
 {
     if (command_queue_)
@@ -4189,6 +4492,7 @@ void Device::DestroyTextureResources()
 void Device::DestroyDescriptorResources()
 {
     descriptor_set_ = VK_NULL_HANDLE;
+    material_descriptor_sets_.clear();
     descriptor_pool_.reset();
     descriptor_set_layout_.reset();
     if (buffer_resources_)
@@ -4197,6 +4501,20 @@ void Device::DestroyDescriptorResources()
     }
     storage_buffers_ready_ = false;
     DestroyComputeOutputImage();
+}
+
+vk::DescriptorSet Device::GetDescriptorSetForMaterial(
+    EntityId material_id) const
+{
+    if (material_id != NullId)
+    {
+        const auto it = material_descriptor_sets_.find(material_id);
+        if (it != material_descriptor_sets_.end())
+        {
+            return it->second;
+        }
+    }
+    return descriptor_set_;
 }
 
 void Device::DestroyGpuSkinningResources()
@@ -4236,9 +4554,7 @@ void Device::CreateGpuSkinningResources()
     };
 
     const auto source_geometries = BuildRaytracingSourceGeometryData(
-        *level_,
-        static_cast<double>(elapsed_time_seconds_),
-        false);
+        *level_, static_cast<double>(elapsed_time_seconds_), false);
     std::vector<PendingGpuSkinningResource> pending_resources = {};
     pending_resources.reserve(source_geometries.size());
 
@@ -4265,7 +4581,8 @@ void Device::CreateGpuSkinningResources()
             continue;
         }
 
-        const auto& triangle_indices = skinned_mesh->GetSkinningTriangleIndices();
+        const auto& triangle_indices =
+            skinned_mesh->GetSkinningTriangleIndices();
         if (triangle_indices.empty())
         {
             continue;
@@ -4291,19 +4608,15 @@ void Device::CreateGpuSkinningResources()
         pending.source_index_bytes = BuildFlatBytes(triangle_indices);
         auto bone_matrices = skinned_mesh->EvaluateBoneMatrices(0.0);
         pending.bone_capacity = std::max<std::uint32_t>(
-            1u,
-            static_cast<std::uint32_t>(bone_matrices.size()));
+            1u, static_cast<std::uint32_t>(bone_matrices.size()));
 
         const bool transmissive = source_geometry.material_id == 0u;
-        const auto reference_color = ResolveRaytracingReferenceColor(
-            *level_,
-            transmissive);
+        const auto reference_color =
+            ResolveRaytracingReferenceColor(*level_, transmissive);
         const auto source_color = ResolveRaytracingSourceMaterialColor(
-            *level_,
-            source_geometry.source_material_id);
-        const auto color_multiplier = ResolveRaytracingColorMultiplier(
-            source_color,
-            reference_color);
+            *level_, source_geometry.source_material_id);
+        const auto color_multiplier =
+            ResolveRaytracingColorMultiplier(source_color, reference_color);
         pending.color_multiplier = glm::vec4(
             color_multiplier[0],
             color_multiplier[1],
@@ -4335,15 +4648,16 @@ void Device::CreateGpuSkinningResources()
         shader_compiler_ = std::make_unique<ShaderCompiler>();
     }
 
-    const auto shader_path = current_level_data_
-        ? current_level_data_->asset_root / "shader" / "vulkan" / "skinning.comp"
-        : std::filesystem::path("asset/shader/vulkan/skinning.comp");
+    const auto shader_path =
+        current_level_data_
+            ? current_level_data_->asset_root / "shader" / "vulkan" /
+                  "skinning.comp"
+            : std::filesystem::path("asset/shader/vulkan/skinning.comp");
     std::vector<std::uint32_t> compute_code = {};
     try
     {
-        compute_code = shader_compiler_->CompileFile(
-            shader_path,
-            shaderc_compute_shader);
+        compute_code =
+            shader_compiler_->CompileFile(shader_path, shaderc_compute_shader);
     }
     catch (const std::exception& ex)
     {
@@ -4354,14 +4668,13 @@ void Device::CreateGpuSkinningResources()
         return;
     }
 
-    auto create_shader_module =
-        [&](const std::vector<std::uint32_t>& code) {
-            vk::ShaderModuleCreateInfo shader_info(
-                vk::ShaderModuleCreateFlags{},
-                code.size() * sizeof(std::uint32_t),
-                code.data());
-            return vk_unique_device_->createShaderModuleUnique(shader_info);
-        };
+    auto create_shader_module = [&](const std::vector<std::uint32_t>& code) {
+        vk::ShaderModuleCreateInfo shader_info(
+            vk::ShaderModuleCreateFlags{},
+            code.size() * sizeof(std::uint32_t),
+            code.data());
+        return vk_unique_device_->createShaderModuleUnique(shader_info);
+    };
 
     const std::array<vk::DescriptorSetLayoutBinding, 4> layout_bindings = {{
         vk::DescriptorSetLayoutBinding(
@@ -4394,7 +4707,8 @@ void Device::CreateGpuSkinningResources()
 
     const vk::DescriptorPoolSize pool_size(
         vk::DescriptorType::eStorageBuffer,
-        static_cast<std::uint32_t>(pending_resources.size() * layout_bindings.size()));
+        static_cast<std::uint32_t>(
+            pending_resources.size() * layout_bindings.size()));
     vk::DescriptorPoolCreateInfo pool_info(
         vk::DescriptorPoolCreateFlags{},
         static_cast<std::uint32_t>(pending_resources.size()),
@@ -4404,19 +4718,17 @@ void Device::CreateGpuSkinningResources()
         vk_unique_device_->createDescriptorPoolUnique(pool_info);
 
     std::vector<vk::DescriptorSetLayout> set_layouts(
-        pending_resources.size(),
-        *gpu_skinning_descriptor_set_layout_);
+        pending_resources.size(), *gpu_skinning_descriptor_set_layout_);
     vk::DescriptorSetAllocateInfo alloc_info(
         *gpu_skinning_descriptor_pool_,
         static_cast<std::uint32_t>(set_layouts.size()),
         set_layouts.data());
-    auto descriptor_sets = vk_unique_device_->allocateDescriptorSets(alloc_info);
+    auto descriptor_sets =
+        vk_unique_device_->allocateDescriptorSets(alloc_info);
 
     auto shader_module = create_shader_module(compute_code);
     const vk::PushConstantRange push_constant_range(
-        vk::ShaderStageFlagBits::eCompute,
-        0,
-        sizeof(GpuSkinningPushConstants));
+        vk::ShaderStageFlagBits::eCompute, 0, sizeof(GpuSkinningPushConstants));
     const vk::DescriptorSetLayout descriptor_layouts[] = {
         *gpu_skinning_descriptor_set_layout_};
     vk::PipelineLayoutCreateInfo pipeline_layout_info(
@@ -4434,12 +4746,9 @@ void Device::CreateGpuSkinningResources()
         *shader_module,
         "main");
     vk::ComputePipelineCreateInfo pipeline_info(
-        vk::PipelineCreateFlags{},
-        stage_info,
-        *gpu_skinning_pipeline_layout_);
-    auto pipeline_result = vk_unique_device_->createComputePipelineUnique(
-        nullptr,
-        pipeline_info);
+        vk::PipelineCreateFlags{}, stage_info, *gpu_skinning_pipeline_layout_);
+    auto pipeline_result =
+        vk_unique_device_->createComputePipelineUnique(nullptr, pipeline_info);
     if (pipeline_result.result != vk::Result::eSuccess)
     {
         throw std::runtime_error(
@@ -4447,17 +4756,16 @@ void Device::CreateGpuSkinningResources()
     }
     gpu_skinning_pipeline_ = std::move(pipeline_result.value);
 
-    auto create_device_local_buffer =
-        [&](vk::DeviceSize size,
-            vk::BufferUsageFlags usage,
-            vk::UniqueBuffer& buffer,
-            vk::UniqueDeviceMemory& memory) {
-            buffer = gpu_memory_manager_->CreateBuffer(
-                size,
-                usage | vk::BufferUsageFlagBits::eTransferDst,
-                vk::MemoryPropertyFlagBits::eDeviceLocal,
-                memory);
-        };
+    auto create_device_local_buffer = [&](vk::DeviceSize size,
+                                          vk::BufferUsageFlags usage,
+                                          vk::UniqueBuffer& buffer,
+                                          vk::UniqueDeviceMemory& memory) {
+        buffer = gpu_memory_manager_->CreateBuffer(
+            size,
+            usage | vk::BufferUsageFlagBits::eTransferDst,
+            vk::MemoryPropertyFlagBits::eDeviceLocal,
+            memory);
+    };
 
     gpu_skinning_resources_.reserve(pending_resources.size());
     for (std::size_t i = 0; i < pending_resources.size(); ++i)
@@ -4519,7 +4827,8 @@ void Device::CreateGpuSkinningResources()
             vk::DescriptorBufferInfo(
                 *resource.source_vertex_buffer,
                 0,
-                static_cast<vk::DeviceSize>(pending.source_vertex_bytes.size())),
+                static_cast<vk::DeviceSize>(
+                    pending.source_vertex_bytes.size())),
             vk::DescriptorBufferInfo(
                 *resource.source_index_buffer,
                 0,
@@ -4530,9 +4839,7 @@ void Device::CreateGpuSkinningResources()
                 static_cast<vk::DeviceSize>(
                     resource.bone_capacity * sizeof(glm::mat4))),
             vk::DescriptorBufferInfo(
-                *resource.output_buffer,
-                0,
-                resource.output_buffer_size),
+                *resource.output_buffer, 0, resource.output_buffer_size),
         }};
         const std::array<vk::WriteDescriptorSet, 4> descriptor_writes = {{
             vk::WriteDescriptorSet(
@@ -4590,35 +4897,33 @@ std::vector<EntityId> Device::UpdateGpuSkinnedMeshes()
 
     auto find_storage_buffer_resource =
         [&](EntityId buffer_id) -> const BufferResource* {
-            if (!buffer_resources_ || buffer_id == NullId)
-            {
-                return nullptr;
-            }
-            const auto& name = level_->GetNameFromId(buffer_id);
-            for (const auto& storage : buffer_resources_->GetStorageBuffers())
-            {
-                if (storage.name == name)
-                {
-                    return &storage;
-                }
-            }
+        if (!buffer_resources_ || buffer_id == NullId)
+        {
             return nullptr;
-        };
+        }
+        const auto& name = level_->GetNameFromId(buffer_id);
+        for (const auto& storage : buffer_resources_->GetStorageBuffers())
+        {
+            if (storage.name == name)
+            {
+                return &storage;
+            }
+        }
+        return nullptr;
+    };
 
     const BufferResource* transmissive_aggregate = nullptr;
     const BufferResource* opaque_aggregate = nullptr;
     if (active_program_info_)
     {
-        if (const auto it =
-                active_program_info_->buffer_ids_by_inner.find(
-                    "TriangleBufferTransmissive");
+        if (const auto it = active_program_info_->buffer_ids_by_inner.find(
+                "TriangleBufferTransmissive");
             it != active_program_info_->buffer_ids_by_inner.end())
         {
             transmissive_aggregate = find_storage_buffer_resource(it->second);
         }
-        if (const auto it =
-                active_program_info_->buffer_ids_by_inner.find(
-                    "TriangleBufferOpaque");
+        if (const auto it = active_program_info_->buffer_ids_by_inner.find(
+                "TriangleBufferOpaque");
             it != active_program_info_->buffer_ids_by_inner.end())
         {
             opaque_aggregate = find_storage_buffer_resource(it->second);
@@ -4641,18 +4946,19 @@ std::vector<EntityId> Device::UpdateGpuSkinnedMeshes()
 
     auto find_hardware_geometry =
         [&](GpuSkinningResource& resource) -> HardwareRaytracingGeometry* {
-            for (auto& geometry : hardware_raytracing_geometries_)
+        for (auto& geometry : hardware_raytracing_geometries_)
+        {
+            if (geometry.source_buffer_id ==
+                    resource.source_triangle_buffer_id &&
+                geometry.source_node_id == resource.source_node_id &&
+                geometry.source_material_id == resource.source_material_id &&
+                geometry.triangle_offset == resource.triangle_offset)
             {
-                if (geometry.source_buffer_id == resource.source_triangle_buffer_id &&
-                    geometry.source_node_id == resource.source_node_id &&
-                    geometry.source_material_id == resource.source_material_id &&
-                    geometry.triangle_offset == resource.triangle_offset)
-                {
-                    return &geometry;
-                }
+                return &geometry;
             }
-            return nullptr;
-        };
+        }
+        return nullptr;
+    };
 
     auto& animated_rt_stats = GetAnimatedRaytraceTimingStats();
     std::vector<PendingGpuDispatch> pending_dispatches = {};
@@ -4704,8 +5010,7 @@ std::vector<EntityId> Device::UpdateGpuSkinnedMeshes()
         }
 
         std::vector<glm::mat4> upload_matrices(
-            resource.bone_capacity,
-            glm::mat4(1.0f));
+            resource.bone_capacity, glm::mat4(1.0f));
         std::copy(
             bone_matrices.begin(),
             bone_matrices.end(),
@@ -4723,8 +5028,9 @@ std::vector<EntityId> Device::UpdateGpuSkinnedMeshes()
 
         PendingGpuDispatch pending = {};
         pending.resource = &resource;
-        pending.aggregate_buffer =
-            resource.material_id == 0u ? transmissive_aggregate : opaque_aggregate;
+        pending.aggregate_buffer = resource.material_id == 0u
+                                       ? transmissive_aggregate
+                                       : opaque_aggregate;
         pending.hardware_geometry = find_hardware_geometry(resource);
         if (pending.hardware_geometry)
         {
@@ -4757,14 +5063,13 @@ std::vector<EntityId> Device::UpdateGpuSkinnedMeshes()
                 vk::GeometryTypeKHR::eTriangles);
             pending.as_geometry.setGeometry(pending.geometry_data);
             pending.as_geometry.setFlags(vk::GeometryFlagBitsKHR::eOpaque);
-            pending.build_info =
-                vk::AccelerationStructureBuildGeometryInfoKHR(
-                    vk::AccelerationStructureTypeKHR::eBottomLevel,
-                    GetHardwareRaytracingBuildFlags(),
-                    vk::BuildAccelerationStructureModeKHR::eUpdate,
-                    {},
-                    {},
-                    pending.as_geometry);
+            pending.build_info = vk::AccelerationStructureBuildGeometryInfoKHR(
+                vk::AccelerationStructureTypeKHR::eBottomLevel,
+                GetHardwareRaytracingBuildFlags(),
+                vk::BuildAccelerationStructureModeKHR::eUpdate,
+                {},
+                {},
+                pending.as_geometry);
             pending.build_info.setSrcAccelerationStructure(
                 *pending.hardware_geometry->blas);
             pending.build_info.setDstAccelerationStructure(
@@ -4776,24 +5081,20 @@ std::vector<EntityId> Device::UpdateGpuSkinnedMeshes()
                     pending.hardware_geometry->triangle_count);
             const auto scratch_address = build_scratch_address(
                 std::max(
-                    size_info.buildScratchSize,
-                    size_info.updateScratchSize),
+                    size_info.buildScratchSize, size_info.updateScratchSize),
                 pending.scratch_buffer,
                 pending.scratch_memory);
             pending.build_info.setScratchData(
                 vk::DeviceOrHostAddressKHR(scratch_address));
             pending.range_info = vk::AccelerationStructureBuildRangeInfoKHR(
-                pending.hardware_geometry->triangle_count,
-                0,
-                0,
-                0);
+                pending.hardware_geometry->triangle_count, 0, 0, 0);
         }
 
         pending_dispatches.push_back(std::move(pending));
         animated_rt_stats.uploaded_triangle_bytes +=
             static_cast<std::size_t>(resource.output_buffer_size);
-        if (updated_source_triangle_buffer_seen.insert(
-                resource.source_triangle_buffer_id)
+        if (updated_source_triangle_buffer_seen
+                .insert(resource.source_triangle_buffer_id)
                 .second)
         {
             updated_source_triangle_buffer_ids.push_back(
@@ -4806,14 +5107,14 @@ std::vector<EntityId> Device::UpdateGpuSkinnedMeshes()
         return {};
     }
     RecordVulkanProfileCounter(
-        "raytrace.gpu_skinning_dispatches",
-        pending_dispatches.size());
+        "raytrace.gpu_skinning_dispatches", pending_dispatches.size());
 
     for (auto& pending : pending_dispatches)
     {
         if (pending.hardware_geometry)
         {
-            // build_info keeps a pointer to as_geometry; refresh it after vector moves.
+            // build_info keeps a pointer to as_geometry; refresh it after
+            // vector moves.
             pending.build_info.setGeometries(pending.as_geometry);
         }
     }
@@ -4821,133 +5122,127 @@ std::vector<EntityId> Device::UpdateGpuSkinnedMeshes()
     const auto submit_start = SteadyClock::now();
     {
         VulkanProfileScope submit_scope("raytrace.gpu_skinning_submit_wait");
-        command_queue_->SubmitOneTime(
-            [&](vk::CommandBuffer command_buffer)
+        command_queue_->SubmitOneTime([&](vk::CommandBuffer command_buffer) {
+            command_buffer.bindPipeline(
+                vk::PipelineBindPoint::eCompute, *gpu_skinning_pipeline_);
+
+            for (const auto& pending : pending_dispatches)
             {
-                command_buffer.bindPipeline(
+                command_buffer.bindDescriptorSets(
                     vk::PipelineBindPoint::eCompute,
-                    *gpu_skinning_pipeline_);
+                    *gpu_skinning_pipeline_layout_,
+                    0,
+                    pending.resource->descriptor_set,
+                    {});
 
-                for (const auto& pending : pending_dispatches)
+                GpuSkinningPushConstants push_constants = {};
+                push_constants.output_vertex_count =
+                    pending.resource->output_vertex_count;
+                push_constants.color_multiplier =
+                    pending.resource->color_multiplier;
+                push_constants.atlas_uv_bounds =
+                    pending.resource->atlas_uv_bounds;
+                command_buffer.pushConstants(
+                    *gpu_skinning_pipeline_layout_,
+                    vk::ShaderStageFlagBits::eCompute,
+                    0,
+                    sizeof(GpuSkinningPushConstants),
+                    &push_constants);
+
+                const std::uint32_t group_count =
+                    (pending.resource->output_vertex_count +
+                     kGpuSkinningWorkgroupSize - 1u) /
+                    kGpuSkinningWorkgroupSize;
+                command_buffer.dispatch(group_count, 1, 1);
+            }
+
+            std::vector<vk::BufferMemoryBarrier> output_barriers = {};
+            output_barriers.reserve(pending_dispatches.size());
+            for (const auto& pending : pending_dispatches)
+            {
+                output_barriers.emplace_back(
+                    vk::AccessFlagBits::eShaderWrite,
+                    vk::AccessFlagBits::eTransferRead,
+                    VK_QUEUE_FAMILY_IGNORED,
+                    VK_QUEUE_FAMILY_IGNORED,
+                    *pending.resource->output_buffer,
+                    0,
+                    pending.resource->output_buffer_size);
+            }
+            command_buffer.pipelineBarrier(
+                vk::PipelineStageFlagBits::eComputeShader,
+                vk::PipelineStageFlagBits::eTransfer,
+                {},
+                nullptr,
+                output_barriers,
+                nullptr);
+
+            std::vector<vk::BufferMemoryBarrier> geometry_copy_barriers = {};
+            geometry_copy_barriers.reserve(pending_dispatches.size());
+            for (const auto& pending : pending_dispatches)
+            {
+                if (pending.aggregate_buffer &&
+                    pending.aggregate_buffer->buffer)
                 {
-                    command_buffer.bindDescriptorSets(
-                        vk::PipelineBindPoint::eCompute,
-                        *gpu_skinning_pipeline_layout_,
-                        0,
-                        pending.resource->descriptor_set,
-                        {});
-
-                    GpuSkinningPushConstants push_constants = {};
-                    push_constants.output_vertex_count =
-                        pending.resource->output_vertex_count;
-                    push_constants.color_multiplier =
-                        pending.resource->color_multiplier;
-                    push_constants.atlas_uv_bounds =
-                        pending.resource->atlas_uv_bounds;
-                    command_buffer.pushConstants(
-                        *gpu_skinning_pipeline_layout_,
-                        vk::ShaderStageFlagBits::eCompute,
-                        0,
-                        sizeof(GpuSkinningPushConstants),
-                        &push_constants);
-
-                    const std::uint32_t group_count =
-                        (pending.resource->output_vertex_count +
-                         kGpuSkinningWorkgroupSize - 1u) /
-                        kGpuSkinningWorkgroupSize;
-                    command_buffer.dispatch(group_count, 1, 1);
-                }
-
-                std::vector<vk::BufferMemoryBarrier> output_barriers = {};
-                output_barriers.reserve(pending_dispatches.size());
-                for (const auto& pending : pending_dispatches)
-                {
-                    output_barriers.emplace_back(
-                        vk::AccessFlagBits::eShaderWrite,
-                        vk::AccessFlagBits::eTransferRead,
-                        VK_QUEUE_FAMILY_IGNORED,
-                        VK_QUEUE_FAMILY_IGNORED,
-                        *pending.resource->output_buffer,
-                        0,
-                        pending.resource->output_buffer_size);
-                }
-                command_buffer.pipelineBarrier(
-                    vk::PipelineStageFlagBits::eComputeShader,
-                    vk::PipelineStageFlagBits::eTransfer,
-                    {},
-                    nullptr,
-                    output_barriers,
-                    nullptr);
-
-                std::vector<vk::BufferMemoryBarrier> geometry_copy_barriers = {};
-                geometry_copy_barriers.reserve(pending_dispatches.size());
-                for (const auto& pending : pending_dispatches)
-                {
-                    if (pending.aggregate_buffer &&
-                        pending.aggregate_buffer->buffer)
-                    {
-                        const vk::DeviceSize dst_offset =
-                            static_cast<vk::DeviceSize>(
-                                pending.resource->triangle_offset) *
-                            static_cast<vk::DeviceSize>(
-                                kRaytraceTriangleVertexStrideBytes * 3u);
-                        if (dst_offset + pending.resource->output_buffer_size <=
-                            pending.aggregate_buffer->size)
-                        {
-                            command_buffer.copyBuffer(
-                                *pending.resource->output_buffer,
-                                *pending.aggregate_buffer->buffer,
-                                vk::BufferCopy(
-                                    0,
-                                    dst_offset,
-                                    pending.resource->output_buffer_size));
-                        }
-                    }
-
-                    if (pending.hardware_geometry)
+                    const vk::DeviceSize dst_offset =
+                        static_cast<vk::DeviceSize>(
+                            pending.resource->triangle_offset) *
+                        static_cast<vk::DeviceSize>(
+                            kRaytraceTriangleVertexStrideBytes * 3u);
+                    if (dst_offset + pending.resource->output_buffer_size <=
+                        pending.aggregate_buffer->size)
                     {
                         command_buffer.copyBuffer(
                             *pending.resource->output_buffer,
-                            *pending.hardware_geometry->vertex_buffer,
+                            *pending.aggregate_buffer->buffer,
                             vk::BufferCopy(
                                 0,
-                                0,
+                                dst_offset,
                                 pending.resource->output_buffer_size));
-                        geometry_copy_barriers.emplace_back(
-                            vk::AccessFlagBits::eTransferWrite,
-                            vk::AccessFlagBits::eAccelerationStructureReadKHR,
-                            VK_QUEUE_FAMILY_IGNORED,
-                            VK_QUEUE_FAMILY_IGNORED,
-                            *pending.hardware_geometry->vertex_buffer,
-                            0,
-                            pending.resource->output_buffer_size);
                     }
                 }
 
-                if (!geometry_copy_barriers.empty())
+                if (pending.hardware_geometry)
                 {
-                    command_buffer.pipelineBarrier(
-                        vk::PipelineStageFlagBits::eTransfer,
-                        vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR,
-                        {},
-                        nullptr,
-                        geometry_copy_barriers,
-                        nullptr);
+                    command_buffer.copyBuffer(
+                        *pending.resource->output_buffer,
+                        *pending.hardware_geometry->vertex_buffer,
+                        vk::BufferCopy(
+                            0, 0, pending.resource->output_buffer_size));
+                    geometry_copy_barriers.emplace_back(
+                        vk::AccessFlagBits::eTransferWrite,
+                        vk::AccessFlagBits::eAccelerationStructureReadKHR,
+                        VK_QUEUE_FAMILY_IGNORED,
+                        VK_QUEUE_FAMILY_IGNORED,
+                        *pending.hardware_geometry->vertex_buffer,
+                        0,
+                        pending.resource->output_buffer_size);
                 }
+            }
 
-                for (const auto& pending : pending_dispatches)
+            if (!geometry_copy_barriers.empty())
+            {
+                command_buffer.pipelineBarrier(
+                    vk::PipelineStageFlagBits::eTransfer,
+                    vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR,
+                    {},
+                    nullptr,
+                    geometry_copy_barriers,
+                    nullptr);
+            }
+
+            for (const auto& pending : pending_dispatches)
+            {
+                if (!pending.hardware_geometry)
                 {
-                    if (!pending.hardware_geometry)
-                    {
-                        continue;
-                    }
-                    const vk::AccelerationStructureBuildRangeInfoKHR*
-                        range_infos[] = {&pending.range_info};
-                    command_buffer.buildAccelerationStructuresKHR(
-                        pending.build_info,
-                        range_infos);
+                    continue;
                 }
-            });
+                const vk::AccelerationStructureBuildRangeInfoKHR*
+                    range_infos[] = {&pending.range_info};
+                command_buffer.buildAccelerationStructuresKHR(
+                    pending.build_info, range_infos);
+            }
+        });
     }
     animated_rt_stats.dynamic_geometry_submit_ms +=
         ElapsedMilliseconds(submit_start);
@@ -4963,15 +5258,15 @@ std::vector<EntityId> Device::UpdateGpuSkinnedMeshes()
         [](const PendingGpuDispatch& pending) {
             return pending.hardware_geometry != nullptr;
         });
-    const std::size_t blas_update_count = static_cast<std::size_t>(std::count_if(
-        pending_dispatches.begin(),
-        pending_dispatches.end(),
-        [](const PendingGpuDispatch& pending) {
-            return pending.hardware_geometry != nullptr;
-        }));
+    const std::size_t blas_update_count =
+        static_cast<std::size_t>(std::count_if(
+            pending_dispatches.begin(),
+            pending_dispatches.end(),
+            [](const PendingGpuDispatch& pending) {
+                return pending.hardware_geometry != nullptr;
+            }));
     RecordVulkanProfileCounter(
-        "raytrace.gpu_skinning_blas_updates",
-        blas_update_count);
+        "raytrace.gpu_skinning_blas_updates", blas_update_count);
     if (has_blas_updates)
     {
         const auto transform_start = SteadyClock::now();
@@ -5009,7 +5304,8 @@ void Device::CreateHardwareRaytracingScene()
             if (bytes.empty())
             {
                 throw std::runtime_error(
-                    "Cannot create Vulkan hardware raytracing input buffer from empty data.");
+                    "Cannot create Vulkan hardware raytracing input buffer "
+                    "from empty data.");
             }
 
             vk::UniqueDeviceMemory staging_memory;
@@ -5020,18 +5316,14 @@ void Device::CreateHardwareRaytracingScene()
                     vk::MemoryPropertyFlagBits::eHostCoherent,
                 staging_memory);
 
-            void* mapped =
-                vk_unique_device_->mapMemory(
-                    *staging_memory,
-                    0,
-                    static_cast<vk::DeviceSize>(bytes.size()));
+            void* mapped = vk_unique_device_->mapMemory(
+                *staging_memory, 0, static_cast<vk::DeviceSize>(bytes.size()));
             std::memcpy(mapped, bytes.data(), bytes.size());
             vk_unique_device_->unmapMemory(*staging_memory);
 
             out_buffer = gpu_memory_manager_->CreateBuffer(
                 static_cast<vk::DeviceSize>(bytes.size()),
-                usage |
-                    vk::BufferUsageFlagBits::eTransferDst |
+                usage | vk::BufferUsageFlagBits::eTransferDst |
                     vk::BufferUsageFlagBits::eShaderDeviceAddress,
                 vk::MemoryPropertyFlagBits::eDeviceLocal,
                 out_memory,
@@ -5056,12 +5348,9 @@ void Device::CreateHardwareRaytracingScene()
                 out_memory,
                 vk::MemoryAllocateFlagBits::eDeviceAddress);
             vk::AccelerationStructureCreateInfoKHR as_info(
-                {},
-                *out_buffer,
-                0,
-                size,
-                type);
-            out_as = vk_unique_device_->createAccelerationStructureKHRUnique(as_info);
+                {}, *out_buffer, 0, size, type);
+            out_as = vk_unique_device_->createAccelerationStructureKHRUnique(
+                as_info);
         };
 
     const auto build_scratch_buffer =
@@ -5083,276 +5372,262 @@ void Device::CreateHardwareRaytracingScene()
     const bool use_source_instances =
         !RaytraceSceneRequiresWorldSpaceBuffers(*level_);
     hardware_raytracing_uses_source_instances_ = use_source_instances;
-    const auto source_geometries = use_source_instances
-        ? BuildRaytracingSourceGeometryData(
-              *level_,
-              static_cast<double>(elapsed_time_seconds_),
-              false)
-        : std::vector<RaytracingSourceGeometryData>{};
+    const auto source_geometries =
+        use_source_instances
+            ? BuildRaytracingSourceGeometryData(
+                  *level_, static_cast<double>(elapsed_time_seconds_), false)
+            : std::vector<RaytracingSourceGeometryData>{};
     instances.reserve(
-        use_source_instances ? source_geometries.size() : static_cast<std::size_t>(2));
+        use_source_instances ? source_geometries.size()
+                             : static_cast<std::size_t>(2));
 
     std::uint32_t next_instance_custom_index = 0;
-    const auto append_source_geometry =
-        [&](const RaytracingSourceGeometryData& source_geometry) {
-            const auto& triangle_bytes = source_geometry.triangle_bytes;
-            const auto vertex_count = static_cast<std::uint32_t>(
-                triangle_bytes.size() / kRaytraceTriangleVertexStrideBytes);
-            const auto primitive_count = vertex_count / 3;
-            if (primitive_count == 0)
-            {
-                return;
-            }
-            const auto index_bytes = BuildSequentialIndexBytes(vertex_count);
+    const auto append_source_geometry = [&](const RaytracingSourceGeometryData&
+                                                source_geometry) {
+        const auto& triangle_bytes = source_geometry.triangle_bytes;
+        const auto vertex_count = static_cast<std::uint32_t>(
+            triangle_bytes.size() / kRaytraceTriangleVertexStrideBytes);
+        const auto primitive_count = vertex_count / 3;
+        if (primitive_count == 0)
+        {
+            return;
+        }
+        const auto index_bytes = BuildSequentialIndexBytes(vertex_count);
 
-            HardwareRaytracingGeometry geometry = {};
-            geometry.source_inner_name =
-                level_->GetNameFromId(source_geometry.source_node_id);
-            geometry.source_node_id = source_geometry.source_node_id;
-            geometry.source_buffer_id = source_geometry.triangle_buffer_id;
-            geometry.source_material_id = source_geometry.source_material_id;
-            geometry.triangle_offset = source_geometry.triangle_offset;
-            create_gpu_input_buffer(
-                triangle_bytes,
-                vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR,
-                geometry.vertex_buffer,
-                geometry.vertex_memory);
-            create_gpu_input_buffer(
-                index_bytes,
-                vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR,
-                geometry.index_buffer,
-                geometry.index_memory);
+        HardwareRaytracingGeometry geometry = {};
+        geometry.source_inner_name =
+            level_->GetNameFromId(source_geometry.source_node_id);
+        geometry.source_node_id = source_geometry.source_node_id;
+        geometry.source_buffer_id = source_geometry.triangle_buffer_id;
+        geometry.source_material_id = source_geometry.source_material_id;
+        geometry.triangle_offset = source_geometry.triangle_offset;
+        create_gpu_input_buffer(
+            triangle_bytes,
+            vk::BufferUsageFlagBits::
+                eAccelerationStructureBuildInputReadOnlyKHR,
+            geometry.vertex_buffer,
+            geometry.vertex_memory);
+        create_gpu_input_buffer(
+            index_bytes,
+            vk::BufferUsageFlagBits::
+                eAccelerationStructureBuildInputReadOnlyKHR,
+            geometry.index_buffer,
+            geometry.index_memory);
 
-            const auto vertex_address = vk_unique_device_->getBufferAddress(
-                vk::BufferDeviceAddressInfo(*geometry.vertex_buffer));
-            const auto index_address = vk_unique_device_->getBufferAddress(
-                vk::BufferDeviceAddressInfo(*geometry.index_buffer));
-            geometry.vertex_buffer_size =
-                static_cast<vk::DeviceSize>(triangle_bytes.size());
-            geometry.vertex_count = vertex_count;
-            geometry.index_buffer_size =
-                static_cast<vk::DeviceSize>(index_bytes.size());
-            geometry.triangle_count = primitive_count;
-            geometry.instance_custom_index = next_instance_custom_index++;
-            geometry.material_id = source_geometry.material_id;
+        const auto vertex_address = vk_unique_device_->getBufferAddress(
+            vk::BufferDeviceAddressInfo(*geometry.vertex_buffer));
+        const auto index_address = vk_unique_device_->getBufferAddress(
+            vk::BufferDeviceAddressInfo(*geometry.index_buffer));
+        geometry.vertex_buffer_size =
+            static_cast<vk::DeviceSize>(triangle_bytes.size());
+        geometry.vertex_count = vertex_count;
+        geometry.index_buffer_size =
+            static_cast<vk::DeviceSize>(index_bytes.size());
+        geometry.triangle_count = primitive_count;
+        geometry.instance_custom_index = next_instance_custom_index++;
+        geometry.material_id = source_geometry.material_id;
 
-            vk::AccelerationStructureGeometryTrianglesDataKHR triangles(
-                vk::Format::eR32G32B32Sfloat,
-                vk::DeviceOrHostAddressConstKHR(vertex_address),
-                kRaytraceTriangleVertexStrideBytes,
-                GetAccelerationStructureMaxVertex(vertex_count),
-                vk::IndexType::eUint32,
-                vk::DeviceOrHostAddressConstKHR(index_address));
-            vk::AccelerationStructureGeometryDataKHR geometry_data;
-            geometry_data.setTriangles(triangles);
-            vk::AccelerationStructureGeometryKHR as_geometry(
-                vk::GeometryTypeKHR::eTriangles);
-            as_geometry.setGeometry(geometry_data);
-            as_geometry.setFlags(vk::GeometryFlagBitsKHR::eOpaque);
+        vk::AccelerationStructureGeometryTrianglesDataKHR triangles(
+            vk::Format::eR32G32B32Sfloat,
+            vk::DeviceOrHostAddressConstKHR(vertex_address),
+            kRaytraceTriangleVertexStrideBytes,
+            GetAccelerationStructureMaxVertex(vertex_count),
+            vk::IndexType::eUint32,
+            vk::DeviceOrHostAddressConstKHR(index_address));
+        vk::AccelerationStructureGeometryDataKHR geometry_data;
+        geometry_data.setTriangles(triangles);
+        vk::AccelerationStructureGeometryKHR as_geometry(
+            vk::GeometryTypeKHR::eTriangles);
+        as_geometry.setGeometry(geometry_data);
+        as_geometry.setFlags(vk::GeometryFlagBitsKHR::eOpaque);
 
-            vk::AccelerationStructureBuildGeometryInfoKHR build_info(
-                vk::AccelerationStructureTypeKHR::eBottomLevel,
-                GetHardwareRaytracingBuildFlags(),
-                vk::BuildAccelerationStructureModeKHR::eBuild,
-                {},
-                {},
-                as_geometry);
+        vk::AccelerationStructureBuildGeometryInfoKHR build_info(
+            vk::AccelerationStructureTypeKHR::eBottomLevel,
+            GetHardwareRaytracingBuildFlags(),
+            vk::BuildAccelerationStructureModeKHR::eBuild,
+            {},
+            {},
+            as_geometry);
 
-            const auto size_info =
-                vk_unique_device_->getAccelerationStructureBuildSizesKHR(
-                    vk::AccelerationStructureBuildTypeKHR::eDevice,
-                    build_info,
-                    primitive_count);
+        const auto size_info =
+            vk_unique_device_->getAccelerationStructureBuildSizesKHR(
+                vk::AccelerationStructureBuildTypeKHR::eDevice,
+                build_info,
+                primitive_count);
 
-            create_acceleration_structure(
-                vk::AccelerationStructureTypeKHR::eBottomLevel,
-                size_info.accelerationStructureSize,
-                geometry.blas,
-                geometry.blas_buffer,
-                geometry.blas_memory);
+        create_acceleration_structure(
+            vk::AccelerationStructureTypeKHR::eBottomLevel,
+            size_info.accelerationStructureSize,
+            geometry.blas,
+            geometry.blas_buffer,
+            geometry.blas_memory);
 
-            vk::UniqueBuffer scratch_buffer;
-            vk::UniqueDeviceMemory scratch_memory;
-            const auto scratch_address = build_scratch_buffer(
-                size_info.buildScratchSize,
-                scratch_buffer,
-                scratch_memory);
+        vk::UniqueBuffer scratch_buffer;
+        vk::UniqueDeviceMemory scratch_memory;
+        const auto scratch_address = build_scratch_buffer(
+            size_info.buildScratchSize, scratch_buffer, scratch_memory);
 
-            build_info.setDstAccelerationStructure(*geometry.blas);
-            build_info.setScratchData(
-                vk::DeviceOrHostAddressKHR(scratch_address));
-            vk::AccelerationStructureBuildRangeInfoKHR range_info(
-                primitive_count,
-                0,
-                0,
-                0);
-            const vk::AccelerationStructureBuildRangeInfoKHR* range_infos[] = {
-                &range_info};
-            command_queue_->SubmitOneTime(
-                [&](vk::CommandBuffer command_buffer) {
-                    command_buffer.buildAccelerationStructuresKHR(
-                        build_info,
-                        range_infos);
-                });
+        build_info.setDstAccelerationStructure(*geometry.blas);
+        build_info.setScratchData(vk::DeviceOrHostAddressKHR(scratch_address));
+        vk::AccelerationStructureBuildRangeInfoKHR range_info(
+            primitive_count, 0, 0, 0);
+        const vk::AccelerationStructureBuildRangeInfoKHR* range_infos[] = {
+            &range_info};
+        command_queue_->SubmitOneTime([&](vk::CommandBuffer command_buffer) {
+            command_buffer.buildAccelerationStructuresKHR(
+                build_info, range_infos);
+        });
 
-            geometry.blas_address =
-                vk_unique_device_->getAccelerationStructureAddressKHR(
-                    vk::AccelerationStructureDeviceAddressInfoKHR(
-                        *geometry.blas));
+        geometry.blas_address =
+            vk_unique_device_->getAccelerationStructureAddressKHR(
+                vk::AccelerationStructureDeviceAddressInfoKHR(*geometry.blas));
 
-            vk::AccelerationStructureInstanceKHR instance{};
-            auto* node = dynamic_cast<NodeMesh*>(
-                &level_->GetSceneNodeFromId(source_geometry.source_node_id));
-            if (node)
-            {
-                instance.transform = MakeAccelerationStructureTransform(
-                    node->GetLocalModel(static_cast<double>(elapsed_time_seconds_)));
-            }
-            else
-            {
-                instance.transform = MakeIdentityTransform();
-            }
-            instance.instanceCustomIndex = geometry.instance_custom_index;
-            instance.mask = 0xFF;
-            instance.instanceShaderBindingTableRecordOffset = 0;
-            instance.flags = static_cast<VkGeometryInstanceFlagsKHR>(
-                vk::GeometryInstanceFlagBitsKHR::eTriangleFacingCullDisable);
-            instance.accelerationStructureReference = geometry.blas_address;
-            instances.push_back(instance);
-            hardware_raytracing_geometries_.push_back(std::move(geometry));
-        };
-    const auto append_geometry =
-        [&](const char* inner_name,
-            std::uint32_t material_id) {
-            if (!active_program_info_)
-            {
-                return;
-            }
-            const auto it =
-                active_program_info_->buffer_ids_by_inner.find(inner_name);
-            if (it == active_program_info_->buffer_ids_by_inner.end())
-            {
-                return;
-            }
-            auto* triangle_buffer = dynamic_cast<frame::vulkan::Buffer*>(
-                &level_->GetBufferFromId(it->second));
-            if (!triangle_buffer)
-            {
-                return;
-            }
-            const auto& triangle_bytes = triangle_buffer->GetRawData();
-            const auto vertex_count = static_cast<std::uint32_t>(
-                triangle_bytes.size() / kRaytraceTriangleVertexStrideBytes);
-            const auto primitive_count = vertex_count / 3;
-            if (primitive_count == 0)
-            {
-                return;
-            }
-            const auto index_bytes = BuildSequentialIndexBytes(vertex_count);
-
-            HardwareRaytracingGeometry geometry = {};
-            geometry.source_inner_name = inner_name;
-            geometry.source_buffer_id = it->second;
-            create_gpu_input_buffer(
-                triangle_bytes,
-                vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR,
-                geometry.vertex_buffer,
-                geometry.vertex_memory);
-            create_gpu_input_buffer(
-                index_bytes,
-                vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR,
-                geometry.index_buffer,
-                geometry.index_memory);
-
-            const auto vertex_address = vk_unique_device_->getBufferAddress(
-                vk::BufferDeviceAddressInfo(*geometry.vertex_buffer));
-            const auto index_address = vk_unique_device_->getBufferAddress(
-                vk::BufferDeviceAddressInfo(*geometry.index_buffer));
-            geometry.vertex_buffer_size =
-                static_cast<vk::DeviceSize>(triangle_bytes.size());
-            geometry.vertex_count = vertex_count;
-            geometry.index_buffer_size =
-                static_cast<vk::DeviceSize>(index_bytes.size());
-            geometry.triangle_count = primitive_count;
-            geometry.instance_custom_index = next_instance_custom_index++;
-            geometry.material_id = material_id;
-            geometry.triangle_offset = 0;
-
-            vk::AccelerationStructureGeometryTrianglesDataKHR triangles(
-                vk::Format::eR32G32B32Sfloat,
-                vk::DeviceOrHostAddressConstKHR(vertex_address),
-                kRaytraceTriangleVertexStrideBytes,
-                GetAccelerationStructureMaxVertex(vertex_count),
-                vk::IndexType::eUint32,
-                vk::DeviceOrHostAddressConstKHR(index_address));
-            vk::AccelerationStructureGeometryDataKHR geometry_data;
-            geometry_data.setTriangles(triangles);
-            vk::AccelerationStructureGeometryKHR as_geometry(
-                vk::GeometryTypeKHR::eTriangles);
-            as_geometry.setGeometry(geometry_data);
-            as_geometry.setFlags(vk::GeometryFlagBitsKHR::eOpaque);
-
-            vk::AccelerationStructureBuildGeometryInfoKHR build_info(
-                vk::AccelerationStructureTypeKHR::eBottomLevel,
-                GetHardwareRaytracingBuildFlags(),
-                vk::BuildAccelerationStructureModeKHR::eBuild,
-                {},
-                {},
-                as_geometry);
-
-            const auto size_info =
-                vk_unique_device_->getAccelerationStructureBuildSizesKHR(
-                    vk::AccelerationStructureBuildTypeKHR::eDevice,
-                    build_info,
-                    primitive_count);
-
-            create_acceleration_structure(
-                vk::AccelerationStructureTypeKHR::eBottomLevel,
-                size_info.accelerationStructureSize,
-                geometry.blas,
-                geometry.blas_buffer,
-                geometry.blas_memory);
-
-            vk::UniqueBuffer scratch_buffer;
-            vk::UniqueDeviceMemory scratch_memory;
-            const auto scratch_address = build_scratch_buffer(
-                size_info.buildScratchSize,
-                scratch_buffer,
-                scratch_memory);
-
-            build_info.setDstAccelerationStructure(*geometry.blas);
-            build_info.setScratchData(
-                vk::DeviceOrHostAddressKHR(scratch_address));
-            vk::AccelerationStructureBuildRangeInfoKHR range_info(
-                primitive_count,
-                0,
-                0,
-                0);
-            const vk::AccelerationStructureBuildRangeInfoKHR* range_infos[] = {
-                &range_info};
-            command_queue_->SubmitOneTime(
-                [&](vk::CommandBuffer command_buffer) {
-                    command_buffer.buildAccelerationStructuresKHR(
-                        build_info,
-                        range_infos);
-                });
-
-            geometry.blas_address =
-                vk_unique_device_->getAccelerationStructureAddressKHR(
-                    vk::AccelerationStructureDeviceAddressInfoKHR(
-                        *geometry.blas));
-
-            vk::AccelerationStructureInstanceKHR instance{};
+        vk::AccelerationStructureInstanceKHR instance{};
+        auto* node = dynamic_cast<NodeMesh*>(
+            &level_->GetSceneNodeFromId(source_geometry.source_node_id));
+        if (node)
+        {
+            instance.transform =
+                MakeAccelerationStructureTransform(node->GetLocalModel(
+                    static_cast<double>(elapsed_time_seconds_)));
+        }
+        else
+        {
             instance.transform = MakeIdentityTransform();
-            instance.instanceCustomIndex = geometry.instance_custom_index;
-            instance.mask = 0xFF;
-            instance.instanceShaderBindingTableRecordOffset = 0;
-            instance.flags = static_cast<VkGeometryInstanceFlagsKHR>(
-                vk::GeometryInstanceFlagBitsKHR::eTriangleFacingCullDisable);
-            instance.accelerationStructureReference = geometry.blas_address;
-            instances.push_back(instance);
-            hardware_raytracing_geometries_.push_back(std::move(geometry));
-        };
+        }
+        instance.instanceCustomIndex = geometry.instance_custom_index;
+        instance.mask = 0xFF;
+        instance.instanceShaderBindingTableRecordOffset = 0;
+        instance.flags = static_cast<VkGeometryInstanceFlagsKHR>(
+            vk::GeometryInstanceFlagBitsKHR::eTriangleFacingCullDisable);
+        instance.accelerationStructureReference = geometry.blas_address;
+        instances.push_back(instance);
+        hardware_raytracing_geometries_.push_back(std::move(geometry));
+    };
+    const auto append_geometry = [&](const char* inner_name,
+                                     std::uint32_t material_id) {
+        if (!active_program_info_)
+        {
+            return;
+        }
+        const auto it =
+            active_program_info_->buffer_ids_by_inner.find(inner_name);
+        if (it == active_program_info_->buffer_ids_by_inner.end())
+        {
+            return;
+        }
+        auto* triangle_buffer = dynamic_cast<frame::vulkan::Buffer*>(
+            &level_->GetBufferFromId(it->second));
+        if (!triangle_buffer)
+        {
+            return;
+        }
+        const auto& triangle_bytes = triangle_buffer->GetRawData();
+        const auto vertex_count = static_cast<std::uint32_t>(
+            triangle_bytes.size() / kRaytraceTriangleVertexStrideBytes);
+        const auto primitive_count = vertex_count / 3;
+        if (primitive_count == 0)
+        {
+            return;
+        }
+        const auto index_bytes = BuildSequentialIndexBytes(vertex_count);
+
+        HardwareRaytracingGeometry geometry = {};
+        geometry.source_inner_name = inner_name;
+        geometry.source_buffer_id = it->second;
+        create_gpu_input_buffer(
+            triangle_bytes,
+            vk::BufferUsageFlagBits::
+                eAccelerationStructureBuildInputReadOnlyKHR,
+            geometry.vertex_buffer,
+            geometry.vertex_memory);
+        create_gpu_input_buffer(
+            index_bytes,
+            vk::BufferUsageFlagBits::
+                eAccelerationStructureBuildInputReadOnlyKHR,
+            geometry.index_buffer,
+            geometry.index_memory);
+
+        const auto vertex_address = vk_unique_device_->getBufferAddress(
+            vk::BufferDeviceAddressInfo(*geometry.vertex_buffer));
+        const auto index_address = vk_unique_device_->getBufferAddress(
+            vk::BufferDeviceAddressInfo(*geometry.index_buffer));
+        geometry.vertex_buffer_size =
+            static_cast<vk::DeviceSize>(triangle_bytes.size());
+        geometry.vertex_count = vertex_count;
+        geometry.index_buffer_size =
+            static_cast<vk::DeviceSize>(index_bytes.size());
+        geometry.triangle_count = primitive_count;
+        geometry.instance_custom_index = next_instance_custom_index++;
+        geometry.material_id = material_id;
+        geometry.triangle_offset = 0;
+
+        vk::AccelerationStructureGeometryTrianglesDataKHR triangles(
+            vk::Format::eR32G32B32Sfloat,
+            vk::DeviceOrHostAddressConstKHR(vertex_address),
+            kRaytraceTriangleVertexStrideBytes,
+            GetAccelerationStructureMaxVertex(vertex_count),
+            vk::IndexType::eUint32,
+            vk::DeviceOrHostAddressConstKHR(index_address));
+        vk::AccelerationStructureGeometryDataKHR geometry_data;
+        geometry_data.setTriangles(triangles);
+        vk::AccelerationStructureGeometryKHR as_geometry(
+            vk::GeometryTypeKHR::eTriangles);
+        as_geometry.setGeometry(geometry_data);
+        as_geometry.setFlags(vk::GeometryFlagBitsKHR::eOpaque);
+
+        vk::AccelerationStructureBuildGeometryInfoKHR build_info(
+            vk::AccelerationStructureTypeKHR::eBottomLevel,
+            GetHardwareRaytracingBuildFlags(),
+            vk::BuildAccelerationStructureModeKHR::eBuild,
+            {},
+            {},
+            as_geometry);
+
+        const auto size_info =
+            vk_unique_device_->getAccelerationStructureBuildSizesKHR(
+                vk::AccelerationStructureBuildTypeKHR::eDevice,
+                build_info,
+                primitive_count);
+
+        create_acceleration_structure(
+            vk::AccelerationStructureTypeKHR::eBottomLevel,
+            size_info.accelerationStructureSize,
+            geometry.blas,
+            geometry.blas_buffer,
+            geometry.blas_memory);
+
+        vk::UniqueBuffer scratch_buffer;
+        vk::UniqueDeviceMemory scratch_memory;
+        const auto scratch_address = build_scratch_buffer(
+            size_info.buildScratchSize, scratch_buffer, scratch_memory);
+
+        build_info.setDstAccelerationStructure(*geometry.blas);
+        build_info.setScratchData(vk::DeviceOrHostAddressKHR(scratch_address));
+        vk::AccelerationStructureBuildRangeInfoKHR range_info(
+            primitive_count, 0, 0, 0);
+        const vk::AccelerationStructureBuildRangeInfoKHR* range_infos[] = {
+            &range_info};
+        command_queue_->SubmitOneTime([&](vk::CommandBuffer command_buffer) {
+            command_buffer.buildAccelerationStructuresKHR(
+                build_info, range_infos);
+        });
+
+        geometry.blas_address =
+            vk_unique_device_->getAccelerationStructureAddressKHR(
+                vk::AccelerationStructureDeviceAddressInfoKHR(*geometry.blas));
+
+        vk::AccelerationStructureInstanceKHR instance{};
+        instance.transform = MakeIdentityTransform();
+        instance.instanceCustomIndex = geometry.instance_custom_index;
+        instance.mask = 0xFF;
+        instance.instanceShaderBindingTableRecordOffset = 0;
+        instance.flags = static_cast<VkGeometryInstanceFlagsKHR>(
+            vk::GeometryInstanceFlagBitsKHR::eTriangleFacingCullDisable);
+        instance.accelerationStructureReference = geometry.blas_address;
+        instances.push_back(instance);
+        hardware_raytracing_geometries_.push_back(std::move(geometry));
+    };
 
     if (use_source_instances)
     {
@@ -5372,13 +5647,13 @@ void Device::CreateHardwareRaytracingScene()
         use_hardware_raytracing_ = false;
         hardware_raytracing_uses_source_instances_ = false;
         logger_->warn(
-            "No eligible meshes found for Vulkan hardware raytracing; falling back to software traversal.");
+            "No eligible meshes found for Vulkan hardware raytracing; falling "
+            "back to software traversal.");
         return;
     }
 
-    const vk::DeviceSize instance_bytes =
-        static_cast<vk::DeviceSize>(
-            instances.size() * sizeof(vk::AccelerationStructureInstanceKHR));
+    const vk::DeviceSize instance_bytes = static_cast<vk::DeviceSize>(
+        instances.size() * sizeof(vk::AccelerationStructureInstanceKHR));
     hardware_raytracing_instance_buffer_ = gpu_memory_manager_->CreateBuffer(
         instance_bytes,
         vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR |
@@ -5388,12 +5663,14 @@ void Device::CreateHardwareRaytracingScene()
         hardware_raytracing_instance_memory_,
         vk::MemoryAllocateFlagBits::eDeviceAddress);
     void* mapped_instances = vk_unique_device_->mapMemory(
-        *hardware_raytracing_instance_memory_,
-        0,
-        instance_bytes);
-    std::memcpy(mapped_instances, instances.data(), static_cast<std::size_t>(instance_bytes));
+        *hardware_raytracing_instance_memory_, 0, instance_bytes);
+    std::memcpy(
+        mapped_instances,
+        instances.data(),
+        static_cast<std::size_t>(instance_bytes));
     vk_unique_device_->unmapMemory(*hardware_raytracing_instance_memory_);
-    hardware_raytracing_instance_bytes_.resize(static_cast<std::size_t>(instance_bytes));
+    hardware_raytracing_instance_bytes_.resize(
+        static_cast<std::size_t>(instance_bytes));
     if (instance_bytes > 0)
     {
         std::memcpy(
@@ -5407,8 +5684,7 @@ void Device::CreateHardwareRaytracingScene()
     const auto instance_address = vk_unique_device_->getBufferAddress(
         vk::BufferDeviceAddressInfo(*hardware_raytracing_instance_buffer_));
     vk::AccelerationStructureGeometryInstancesDataKHR instances_data(
-        VK_FALSE,
-        vk::DeviceOrHostAddressConstKHR(instance_address));
+        VK_FALSE, vk::DeviceOrHostAddressConstKHR(instance_address));
     vk::AccelerationStructureGeometryDataKHR tlas_geometry_data;
     tlas_geometry_data.setInstances(instances_data);
     vk::AccelerationStructureGeometryKHR tlas_geometry(
@@ -5424,10 +5700,11 @@ void Device::CreateHardwareRaytracingScene()
         tlas_geometry);
     const std::uint32_t instance_count =
         static_cast<std::uint32_t>(instances.size());
-    const auto tlas_size = vk_unique_device_->getAccelerationStructureBuildSizesKHR(
-        vk::AccelerationStructureBuildTypeKHR::eDevice,
-        tlas_build_info,
-        instance_count);
+    const auto tlas_size =
+        vk_unique_device_->getAccelerationStructureBuildSizesKHR(
+            vk::AccelerationStructureBuildTypeKHR::eDevice,
+            tlas_build_info,
+            instance_count);
     create_acceleration_structure(
         vk::AccelerationStructureTypeKHR::eTopLevel,
         tlas_size.accelerationStructureSize,
@@ -5438,25 +5715,18 @@ void Device::CreateHardwareRaytracingScene()
     vk::UniqueBuffer tlas_scratch_buffer;
     vk::UniqueDeviceMemory tlas_scratch_memory;
     const auto tlas_scratch_address = build_scratch_buffer(
-        tlas_size.buildScratchSize,
-        tlas_scratch_buffer,
-        tlas_scratch_memory);
+        tlas_size.buildScratchSize, tlas_scratch_buffer, tlas_scratch_memory);
     tlas_build_info.setDstAccelerationStructure(*hardware_raytracing_tlas_);
     tlas_build_info.setScratchData(
         vk::DeviceOrHostAddressKHR(tlas_scratch_address));
     vk::AccelerationStructureBuildRangeInfoKHR tlas_range_info(
-        instance_count,
-        0,
-        0,
-        0);
+        instance_count, 0, 0, 0);
     const vk::AccelerationStructureBuildRangeInfoKHR* tlas_ranges[] = {
         &tlas_range_info};
-    command_queue_->SubmitOneTime(
-        [&](vk::CommandBuffer command_buffer) {
-            command_buffer.buildAccelerationStructuresKHR(
-                tlas_build_info,
-                tlas_ranges);
-        });
+    command_queue_->SubmitOneTime([&](vk::CommandBuffer command_buffer) {
+        command_buffer.buildAccelerationStructuresKHR(
+            tlas_build_info, tlas_ranges);
+    });
 
     UpdateHardwareRaytracingInstanceStorageBuffer();
 
@@ -5510,9 +5780,7 @@ void Device::DestroySwapchainPreviewImage()
     }
 }
 
-
-void Device::CreateTextureResources(
-    const frame::json::LevelData& level_data)
+void Device::CreateTextureResources(const frame::json::LevelData& level_data)
 {
     if (!level_ || !texture_resources_)
     {
@@ -5525,6 +5793,7 @@ void Device::CreateTextureResources(
 void Device::CreateDescriptorResources()
 {
     descriptor_set_ = VK_NULL_HANDLE;
+    material_descriptor_sets_.clear();
     descriptor_pool_.reset();
     descriptor_set_layout_.reset();
     storage_buffers_ready_ = false;
@@ -5545,6 +5814,8 @@ void Device::CreateDescriptorResources()
     layout_bindings.reserve(binding_defs.size());
 
     std::vector<std::uint32_t> texture_bindings;
+    std::vector<std::string> texture_binding_names;
+    std::vector<bool> texture_binding_is_shadow_map;
     std::vector<EntityId> texture_ids;
     std::vector<std::uint32_t> storage_bindings;
     std::vector<EntityId> storage_ids;
@@ -5594,11 +5865,29 @@ void Device::CreateDescriptorResources()
                     binding.binding);
                 return;
             }
-            if (auto it =
-                    active_program_info_->texture_ids_by_inner.find(binding.name);
+            if (binding.name == "shadow_map")
+            {
+                if (!GetShadowMapDescriptorInfo())
+                {
+                    logger_->error(
+                        "Program {} requested a shadow map but no Vulkan "
+                        "shadow map texture is available.",
+                        active_program_info_->program_name);
+                    return;
+                }
+                texture_bindings.push_back(binding.binding);
+                texture_binding_names.push_back(binding.name);
+                texture_binding_is_shadow_map.push_back(true);
+                texture_ids.push_back(NullId);
+                break;
+            }
+            if (auto it = active_program_info_->texture_ids_by_inner.find(
+                    binding.name);
                 it != active_program_info_->texture_ids_by_inner.end())
             {
                 texture_bindings.push_back(binding.binding);
+                texture_binding_names.push_back(binding.name);
+                texture_binding_is_shadow_map.push_back(false);
                 texture_ids.push_back(it->second);
             }
             else
@@ -5629,8 +5918,8 @@ void Device::CreateDescriptorResources()
                     binding.binding);
                 return;
             }
-            if (auto it =
-                    active_program_info_->buffer_ids_by_inner.find(binding.name);
+            if (auto it = active_program_info_->buffer_ids_by_inner.find(
+                    binding.name);
                 it != active_program_info_->buffer_ids_by_inner.end())
             {
                 storage_bindings.push_back(binding.binding);
@@ -5660,10 +5949,7 @@ void Device::CreateDescriptorResources()
         }
 
         layout_bindings.emplace_back(
-            binding.binding,
-            descriptor_type,
-            1,
-            descriptor_stages);
+            binding.binding, descriptor_type, 1, descriptor_stages);
     }
 
     if (use_hardware_raytracing_)
@@ -5671,14 +5957,16 @@ void Device::CreateDescriptorResources()
         if (!hardware_raytracing_tlas_)
         {
             logger_->error(
-                "Program {} requested Vulkan hardware raytracing without a TLAS.",
+                "Program {} requested Vulkan hardware raytracing without a "
+                "TLAS.",
                 active_program_info_->program_name);
             return;
         }
         if (!used_bindings.insert(kHardwareRaytracingAsBinding).second)
         {
             logger_->error(
-                "Program {} collides with reserved hardware raytracing binding {}.",
+                "Program {} collides with reserved hardware raytracing binding "
+                "{}.",
                 active_program_info_->program_name,
                 kHardwareRaytracingAsBinding);
             return;
@@ -5687,9 +5975,8 @@ void Device::CreateDescriptorResources()
             kHardwareRaytracingAsBinding,
             vk::DescriptorType::eAccelerationStructureKHR,
             1,
-            use_raytracing_pipeline_
-                ? vk::ShaderStageFlagBits::eRaygenKHR
-                : vk::ShaderStageFlagBits::eCompute);
+            use_raytracing_pipeline_ ? vk::ShaderStageFlagBits::eRaygenKHR
+                                     : vk::ShaderStageFlagBits::eCompute);
         needs_acceleration_structure = true;
     }
 
@@ -5698,14 +5985,16 @@ void Device::CreateDescriptorResources()
         if (!use_compute_raytracing_)
         {
             logger_->error(
-                "Program {} declares compute output bindings but compute is disabled.",
+                "Program {} declares compute output bindings but compute is "
+                "disabled.",
                 active_program_info_->program_name);
             return;
         }
         if (output_image_bindings.empty())
         {
             logger_->error(
-                "Program {} is missing a storage image binding for compute output.",
+                "Program {} is missing a storage image binding for compute "
+                "output.",
                 active_program_info_->program_name);
             return;
         }
@@ -5744,7 +6033,6 @@ void Device::CreateDescriptorResources()
         return;
     }
 
-
     const BufferResource* uniform = nullptr;
     if (!uniform_bindings.empty())
     {
@@ -5759,7 +6047,7 @@ void Device::CreateDescriptorResources()
     }
 
     std::vector<vk::DescriptorImageInfo> texture_infos;
-    if (!texture_ids.empty())
+    if (!texture_bindings.empty())
     {
         if (texture_resources_->Empty())
         {
@@ -5768,20 +6056,50 @@ void Device::CreateDescriptorResources()
                 active_program_info_->program_name);
             return;
         }
+        texture_infos.resize(texture_bindings.size());
+        std::vector<EntityId> material_texture_ids;
+        std::vector<std::size_t> material_texture_slots;
+        material_texture_ids.reserve(texture_bindings.size());
+        material_texture_slots.reserve(texture_bindings.size());
+        for (std::size_t i = 0; i < texture_bindings.size(); ++i)
+        {
+            if (texture_binding_is_shadow_map[i])
+            {
+                auto shadow_info = GetShadowMapDescriptorInfo();
+                if (!shadow_info)
+                {
+                    logger_->error(
+                        "Program {} missing Vulkan shadow map descriptor.",
+                        active_program_info_->program_name);
+                    return;
+                }
+                texture_infos[i] = *shadow_info;
+            }
+            else
+            {
+                material_texture_ids.push_back(texture_ids[i]);
+                material_texture_slots.push_back(i);
+            }
+        }
+        std::vector<vk::DescriptorImageInfo> material_texture_infos;
         std::vector<EntityId> resolved_ids;
-        if (!texture_resources_->CollectDescriptorInfos(
-                texture_ids,
-                texture_infos,
-                resolved_ids))
+        if (!material_texture_ids.empty() &&
+            !texture_resources_->CollectDescriptorInfos(
+                material_texture_ids, material_texture_infos, resolved_ids))
         {
             return;
         }
-        if (texture_infos.size() != texture_ids.size())
+        if (material_texture_infos.size() != material_texture_ids.size())
         {
             logger_->error(
                 "Program {} texture descriptor count mismatch.",
                 active_program_info_->program_name);
             return;
+        }
+        for (std::size_t i = 0; i < material_texture_infos.size(); ++i)
+        {
+            texture_infos[material_texture_slots[i]] =
+                material_texture_infos[i];
         }
     }
 
@@ -5810,6 +6128,33 @@ void Device::CreateDescriptorResources()
         }
     }
 
+    const bool can_use_material_descriptor_sets =
+        level_ && !texture_bindings.empty() && !use_compute_raytracing_ &&
+        !use_raytracing_pipeline_ && output_image_bindings.empty() &&
+        output_sampler_bindings.empty() && storage_bindings.empty() &&
+        uniform_bindings.size() <= 1 && !needs_acceleration_structure;
+    std::vector<EntityId> material_descriptor_ids;
+    if (can_use_material_descriptor_sets)
+    {
+        std::unordered_set<EntityId> seen_material_ids;
+        const auto append_material_ids =
+            [&](frame::proto::NodeMesh::RenderTimeEnum render_time) {
+                for (const auto& pair : level_->GetMeshMaterialIds(render_time))
+                {
+                    const auto material_id = pair.second;
+                    if (material_id != NullId &&
+                        seen_material_ids.insert(material_id).second)
+                    {
+                        material_descriptor_ids.push_back(material_id);
+                    }
+                }
+            };
+        append_material_ids(frame::proto::NodeMesh::SKYBOX_RENDER_TIME);
+        append_material_ids(frame::proto::NodeMesh::SCENE_RENDER_TIME);
+        append_material_ids(frame::proto::NodeMesh::PRE_RENDER_TIME);
+        append_material_ids(frame::proto::NodeMesh::POST_PROCESS_TIME);
+    }
+
     vk::DescriptorSetLayoutCreateInfo layout_info(
         vk::DescriptorSetLayoutCreateFlags{},
         static_cast<std::uint32_t>(layout_bindings.size()),
@@ -5818,14 +6163,15 @@ void Device::CreateDescriptorResources()
         vk_unique_device_->createDescriptorSetLayoutUnique(layout_info);
 
     std::vector<vk::DescriptorPoolSize> pool_sizes;
-    const std::uint32_t combined_count =
-        static_cast<std::uint32_t>(texture_bindings.size() +
-                                   output_sampler_bindings.size());
+    const std::uint32_t descriptor_set_count =
+        1u + static_cast<std::uint32_t>(material_descriptor_ids.size());
+    const std::uint32_t combined_count = static_cast<std::uint32_t>(
+        texture_bindings.size() * descriptor_set_count +
+        output_sampler_bindings.size());
     if (combined_count > 0)
     {
         pool_sizes.emplace_back(
-            vk::DescriptorType::eCombinedImageSampler,
-            combined_count);
+            vk::DescriptorType::eCombinedImageSampler, combined_count);
     }
     if (!output_image_bindings.empty())
     {
@@ -5843,13 +6189,13 @@ void Device::CreateDescriptorResources()
     {
         pool_sizes.emplace_back(
             vk::DescriptorType::eUniformBuffer,
-            static_cast<std::uint32_t>(uniform_bindings.size()));
+            static_cast<std::uint32_t>(
+                uniform_bindings.size() * descriptor_set_count));
     }
     if (needs_acceleration_structure)
     {
         pool_sizes.emplace_back(
-            vk::DescriptorType::eAccelerationStructureKHR,
-            1);
+            vk::DescriptorType::eAccelerationStructureKHR, 1);
     }
     if (pool_sizes.empty())
     {
@@ -5858,18 +6204,23 @@ void Device::CreateDescriptorResources()
 
     vk::DescriptorPoolCreateInfo pool_info(
         vk::DescriptorPoolCreateFlags{},
-        1,
+        descriptor_set_count,
         static_cast<std::uint32_t>(pool_sizes.size()),
         pool_sizes.data());
     descriptor_pool_ = vk_unique_device_->createDescriptorPoolUnique(pool_info);
 
-    const vk::DescriptorSetLayout layouts[] = {*descriptor_set_layout_};
+    std::vector<vk::DescriptorSetLayout> layouts(
+        descriptor_set_count, *descriptor_set_layout_);
     vk::DescriptorSetAllocateInfo alloc_info(
-        *descriptor_pool_,
-        1,
-        layouts);
-    descriptor_set_ =
-        vk_unique_device_->allocateDescriptorSets(alloc_info).front();
+        *descriptor_pool_, descriptor_set_count, layouts.data());
+    auto descriptor_sets =
+        vk_unique_device_->allocateDescriptorSets(alloc_info);
+    descriptor_set_ = descriptor_sets.front();
+    for (std::size_t i = 0; i < material_descriptor_ids.size(); ++i)
+    {
+        material_descriptor_sets_[material_descriptor_ids[i]] =
+            descriptor_sets[i + 1u];
+    }
 
     std::vector<vk::DescriptorImageInfo> output_image_infos;
     std::vector<vk::DescriptorImageInfo> output_sampler_infos;
@@ -5931,9 +6282,7 @@ void Device::CreateDescriptorResources()
     for (std::size_t i = 0; i < storage_buffers.size(); ++i)
     {
         storage_infos.emplace_back(
-            *storage_buffers[i].buffer,
-            0,
-            storage_buffers[i].size);
+            *storage_buffers[i].buffer, 0, storage_buffers[i].size);
         descriptor_writes.emplace_back(
             descriptor_set_,
             storage_bindings[i],
@@ -5946,10 +6295,7 @@ void Device::CreateDescriptorResources()
 
     if (uniform && !uniform_bindings.empty())
     {
-        uniform_infos.emplace_back(
-            *uniform->buffer,
-            0,
-            uniform->size);
+        uniform_infos.emplace_back(*uniform->buffer, 0, uniform->size);
         descriptor_writes.emplace_back(
             descriptor_set_,
             uniform_bindings.front(),
@@ -5963,9 +6309,7 @@ void Device::CreateDescriptorResources()
     if (needs_acceleration_structure)
     {
         acceleration_handles.push_back(hardware_raytracing_tlas_.get());
-        acceleration_writes.emplace_back(
-            1,
-            acceleration_handles.data());
+        acceleration_writes.emplace_back(1, acceleration_handles.data());
         descriptor_writes.emplace_back(
             descriptor_set_,
             kHardwareRaytracingAsBinding,
@@ -5980,11 +6324,136 @@ void Device::CreateDescriptorResources()
         descriptor_writes.data(),
         0,
         nullptr);
+
+    auto build_material_texture_infos = [&](EntityId material_id) {
+        std::unordered_map<std::string, EntityId> texture_ids_by_inner =
+            active_program_info_->texture_ids_by_inner;
+        if (material_id != NullId)
+        {
+            try
+            {
+                const auto& material = level_->GetMaterialFromId(material_id);
+                for (const auto texture_id : material.GetTextureIds())
+                {
+                    const auto inner_name = material.GetInnerName(texture_id);
+                    if (!inner_name.empty())
+                    {
+                        texture_ids_by_inner[inner_name] = texture_id;
+                    }
+                }
+            }
+            catch (const std::exception& ex)
+            {
+                logger_->warn(
+                    "Failed to inspect material id {} for Vulkan descriptor "
+                    "overrides: {}",
+                    material_id,
+                    ex.what());
+            }
+        }
+
+        std::vector<vk::DescriptorImageInfo> material_texture_infos(
+            texture_binding_names.size());
+        std::vector<EntityId> material_texture_ids;
+        std::vector<std::size_t> material_texture_slots;
+        material_texture_ids.reserve(texture_binding_names.size());
+        material_texture_slots.reserve(texture_binding_names.size());
+        for (std::size_t i = 0; i < texture_binding_names.size(); ++i)
+        {
+            if (texture_binding_is_shadow_map[i])
+            {
+                auto shadow_info = GetShadowMapDescriptorInfo();
+                if (!shadow_info)
+                {
+                    return std::vector<vk::DescriptorImageInfo>{};
+                }
+                material_texture_infos[i] = *shadow_info;
+                continue;
+            }
+            const auto& binding_name = texture_binding_names[i];
+            const auto it = texture_ids_by_inner.find(binding_name);
+            if (it == texture_ids_by_inner.end())
+            {
+                logger_->warn(
+                    "Material id {} has no texture for Vulkan binding '{}'.",
+                    material_id,
+                    binding_name);
+                return std::vector<vk::DescriptorImageInfo>{};
+            }
+            material_texture_ids.push_back(it->second);
+            material_texture_slots.push_back(i);
+        }
+
+        std::vector<vk::DescriptorImageInfo> resolved_texture_infos;
+        std::vector<EntityId> resolved_material_texture_ids;
+        if (!material_texture_ids.empty() &&
+            !texture_resources_->CollectDescriptorInfos(
+                material_texture_ids,
+                resolved_texture_infos,
+                resolved_material_texture_ids))
+        {
+            return std::vector<vk::DescriptorImageInfo>{};
+        }
+        if (resolved_texture_infos.size() != material_texture_ids.size())
+        {
+            return std::vector<vk::DescriptorImageInfo>{};
+        }
+        for (std::size_t i = 0; i < resolved_texture_infos.size(); ++i)
+        {
+            material_texture_infos[material_texture_slots[i]] =
+                resolved_texture_infos[i];
+        }
+        return material_texture_infos;
+    };
+
+    for (const auto material_id : material_descriptor_ids)
+    {
+        const auto set_it = material_descriptor_sets_.find(material_id);
+        if (set_it == material_descriptor_sets_.end())
+        {
+            continue;
+        }
+        std::vector<vk::DescriptorImageInfo> material_texture_infos;
+        material_texture_infos = build_material_texture_infos(material_id);
+        if (material_texture_infos.size() != texture_bindings.size())
+        {
+            material_descriptor_sets_.erase(set_it);
+            continue;
+        }
+
+        std::vector<vk::WriteDescriptorSet> material_writes;
+        std::vector<vk::DescriptorBufferInfo> material_uniform_infos;
+        material_writes.reserve(
+            material_texture_infos.size() + uniform_bindings.size());
+        for (std::size_t i = 0; i < material_texture_infos.size(); ++i)
+        {
+            material_writes.emplace_back(
+                set_it->second,
+                texture_bindings[i],
+                0,
+                1,
+                vk::DescriptorType::eCombinedImageSampler,
+                &material_texture_infos[i]);
+        }
+        if (uniform && !uniform_bindings.empty())
+        {
+            material_uniform_infos.emplace_back(
+                *uniform->buffer, 0, uniform->size);
+            material_writes.emplace_back(
+                set_it->second,
+                uniform_bindings.front(),
+                0,
+                1,
+                vk::DescriptorType::eUniformBuffer,
+                nullptr,
+                &material_uniform_infos.back());
+        }
+        vk_unique_device_->updateDescriptorSets(
+            static_cast<std::uint32_t>(material_writes.size()),
+            material_writes.data(),
+            0,
+            nullptr);
+    }
 }
 
-
 } // namespace frame::vulkan
-
-
-
-

--- a/frame/vulkan/device.h
+++ b/frame/vulkan/device.h
@@ -21,12 +21,12 @@
 #include "frame/camera.h"
 #include "frame/device_interface.h"
 #include "frame/level_data_startup_internal.h"
-#include "frame/texture_interface.h"
 #include "frame/logger.h"
+#include "frame/texture_interface.h"
 #include "frame/vulkan/buffer_resources.h"
 #include "frame/vulkan/mesh_resources.h"
 #include "frame/vulkan/vulkan_dispatch.h"
- 
+
 namespace frame::vulkan
 {
 
@@ -59,17 +59,13 @@ struct RaytracingSourceGeometryData
  * @class Device
  * @brief This is the Vulkan implementation of the device interface.
  */
-class Device :
-    public DeviceInterface,
-    public frame::internal::LevelDataStartupInterface
+class Device : public DeviceInterface,
+               public frame::internal::LevelDataStartupInterface
 {
   public:
     using GuiRenderCallback = std::function<void(vk::CommandBuffer)>;
 
-    Device(
-        void* vk_instance,
-        glm::uvec2 size,
-        vk::SurfaceKHR& surface);
+    Device(void* vk_instance, glm::uvec2 size, vk::SurfaceKHR& surface);
     ~Device();
 
   public:
@@ -158,8 +154,10 @@ class Device :
     {
         return command_resources_.get();
     }
-    std::optional<vk::DescriptorImageInfo> GetComputeOutputDescriptorInfo() const;
-    std::optional<vk::DescriptorImageInfo> GetSwapchainPreviewDescriptorInfo() const;
+    std::optional<vk::DescriptorImageInfo> GetComputeOutputDescriptorInfo()
+        const;
+    std::optional<vk::DescriptorImageInfo> GetSwapchainPreviewDescriptorInfo()
+        const;
 
   private:
     friend class TextureResources;
@@ -173,6 +171,11 @@ class Device :
     void DestroyComputePipeline();
     void CreateRaytracingPipeline();
     void DestroyRaytracingPipeline();
+    void CreateShadowMapResources();
+    void DestroyShadowMapResources();
+    void CreateShadowMapPipeline();
+    void DestroyShadowMapPipeline();
+    std::optional<vk::DescriptorImageInfo> GetShadowMapDescriptorInfo() const;
     void CreateHardwareRaytracingScene();
     void DestroyHardwareRaytracingScene();
     void CreateComputeOutputImage();
@@ -186,6 +189,7 @@ class Device :
     void DestroyTextureResources();
     void CreateDescriptorResources();
     void DestroyDescriptorResources();
+    vk::DescriptorSet GetDescriptorSetForMaterial(EntityId material_id) const;
     void CreateGpuSkinningResources();
     void DestroyGpuSkinningResources();
     void UpdateRaytraceBuffers();
@@ -195,14 +199,16 @@ class Device :
         const std::vector<EntityId>& updated_source_triangle_buffer_ids);
     bool UpdateHardwareRaytracingAggregateSceneBuffers(
         const std::vector<EntityId>& updated_source_triangle_buffer_ids,
-        const std::vector<RaytracingSourceGeometryData>& prepared_source_geometries);
+        const std::vector<RaytracingSourceGeometryData>&
+            prepared_source_geometries);
     void UpdateHardwareRaytracingScene();
     bool UpdateHardwareRaytracingDynamicGeometry();
     bool UpdateHardwareRaytracingDynamicGeometry(
         const std::vector<EntityId>& updated_source_triangle_buffer_ids);
     bool UpdateHardwareRaytracingDynamicGeometry(
         const std::vector<EntityId>& updated_source_triangle_buffer_ids,
-        const std::vector<RaytracingSourceGeometryData>& prepared_source_geometries);
+        const std::vector<RaytracingSourceGeometryData>&
+            prepared_source_geometries);
     bool UpdateHardwareRaytracingTransforms(bool force_tlas_update = false);
     void RebuildHardwareRaytracingTlas();
     void UpdateHardwareRaytracingDescriptor();
@@ -257,7 +263,17 @@ class Device :
     vk::UniqueDescriptorSetLayout descriptor_set_layout_;
     vk::UniqueDescriptorPool descriptor_pool_;
     vk::DescriptorSet descriptor_set_ = VK_NULL_HANDLE;
+    std::unordered_map<EntityId, vk::DescriptorSet> material_descriptor_sets_;
     std::unique_ptr<TextureResources> texture_resources_;
+    static constexpr std::uint32_t kShadowMapSize = 2048;
+    vk::UniqueImage shadow_map_image_;
+    vk::UniqueDeviceMemory shadow_map_memory_;
+    vk::UniqueImageView shadow_map_view_;
+    vk::UniqueSampler shadow_map_sampler_;
+    vk::UniqueRenderPass shadow_map_render_pass_;
+    vk::UniqueFramebuffer shadow_map_framebuffer_;
+    vk::UniquePipelineLayout shadow_map_pipeline_layout_;
+    vk::UniquePipeline shadow_map_pipeline_;
     static constexpr std::size_t kMaxFramesInFlight = 2;
     bool framebuffer_resized_ = false;
     bool use_compute_raytracing_ = false;
@@ -316,7 +332,8 @@ class Device :
         std::filesystem::path raygen_shader;
         std::filesystem::path miss_shader;
         std::filesystem::path closesthit_shader;
-        frame::proto::SceneType::Enum scene_type = frame::proto::SceneType::NONE;
+        frame::proto::SceneType::Enum scene_type =
+            frame::proto::SceneType::NONE;
         bool uses_time_uniform = false;
         bool use_compute = false;
         std::vector<BindingInfo> bindings;
@@ -371,5 +388,3 @@ class Device :
 };
 
 } // namespace frame::vulkan
-
-

--- a/frame/vulkan/json/parse_level.h
+++ b/frame/vulkan/json/parse_level.h
@@ -26,6 +26,15 @@ inline LevelData ParseLevelData(
 
 inline LevelData ParseLevelData(
     glm::uvec2 size,
+    const frame::proto::Level& proto_level,
+    const std::filesystem::path& asset_root,
+    const frame::json::LevelDataOptions& options)
+{
+    return frame::json::ParseLevelData(size, proto_level, asset_root, options);
+}
+
+inline LevelData ParseLevelData(
+    glm::uvec2 size,
     const std::string& content,
     const std::filesystem::path& asset_root)
 {
@@ -34,10 +43,28 @@ inline LevelData ParseLevelData(
 
 inline LevelData ParseLevelData(
     glm::uvec2 size,
+    const std::string& content,
+    const std::filesystem::path& asset_root,
+    const frame::json::LevelDataOptions& options)
+{
+    return frame::json::ParseLevelData(size, content, asset_root, options);
+}
+
+inline LevelData ParseLevelData(
+    glm::uvec2 size,
     const std::filesystem::path& path,
     const std::filesystem::path& asset_root)
 {
     return frame::json::ParseLevelData(size, path, asset_root);
+}
+
+inline LevelData ParseLevelData(
+    glm::uvec2 size,
+    const std::filesystem::path& path,
+    const std::filesystem::path& asset_root,
+    const frame::json::LevelDataOptions& options)
+{
+    return frame::json::ParseLevelData(size, path, asset_root, options);
 }
 
 } // namespace frame::vulkan::json

--- a/frame/vulkan/mesh_resources.cpp
+++ b/frame/vulkan/mesh_resources.cpp
@@ -1,47 +1,255 @@
 #include "frame/vulkan/mesh_resources.h"
 
+#include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <iterator>
 #include <stdexcept>
+#include <utility>
+
+#include <glm/geometric.hpp>
+#include <glm/vec4.hpp>
+
+#include "frame/vulkan/buffer.h"
+#include "frame/vulkan/skinned_mesh.h"
 
 namespace frame::vulkan
 {
+
+namespace
+{
+
+template <typename T>
+std::vector<T> ReadVectorFromBuffer(const frame::BufferInterface& buffer)
+{
+    const auto* vk_buffer = dynamic_cast<const Buffer*>(&buffer);
+    if (!vk_buffer)
+    {
+        throw std::runtime_error("Expected a Vulkan CPU-backed buffer.");
+    }
+    const auto& bytes = vk_buffer->GetRawData();
+    if (bytes.size() % sizeof(T) != 0)
+    {
+        throw std::runtime_error("Buffer byte size is not element aligned.");
+    }
+    std::vector<T> values(bytes.size() / sizeof(T));
+    if (!values.empty())
+    {
+        std::memcpy(values.data(), bytes.data(), bytes.size());
+    }
+    return values;
+}
+
+bool EvaluateSkinnedRasterMesh(
+    const frame::vulkan::SkinnedMesh& skinned_mesh,
+    double skinning_time_s,
+    std::vector<float>& skinned_points,
+    std::vector<float>& skinned_normals)
+{
+    const auto& points = skinned_mesh.GetSkinningPoints();
+    const auto& normals = skinned_mesh.GetSkinningNormals();
+    const auto& bone_indices = skinned_mesh.GetSkinningBoneIndices();
+    const auto& bone_weights = skinned_mesh.GetSkinningBoneWeights();
+    const std::size_t vertex_count = points.size() / 3u;
+    if (vertex_count == 0 || bone_indices.size() < vertex_count * 4u ||
+        bone_weights.size() < vertex_count * 4u)
+    {
+        return false;
+    }
+
+    const auto bone_matrices =
+        skinned_mesh.EvaluateBoneMatrices(skinning_time_s);
+    if (bone_matrices.empty())
+    {
+        return false;
+    }
+
+    skinned_points.assign(points.size(), 0.0f);
+    skinned_normals.assign(normals.size(), 0.0f);
+    for (std::size_t vertex = 0; vertex < vertex_count; ++vertex)
+    {
+        const std::size_t point_offset = vertex * 3u;
+        const std::size_t bone_offset = vertex * 4u;
+        glm::mat4 skin_matrix(0.0f);
+        float weight_sum = 0.0f;
+        for (std::size_t slot = 0; slot < 4u; ++slot)
+        {
+            const float weight = bone_weights[bone_offset + slot];
+            if (weight <= 0.0f)
+            {
+                continue;
+            }
+            const auto bone_index = bone_indices[bone_offset + slot];
+            if (bone_index < 0 ||
+                bone_index >= static_cast<std::int32_t>(bone_matrices.size()))
+            {
+                continue;
+            }
+            skin_matrix +=
+                bone_matrices[static_cast<std::size_t>(bone_index)] * weight;
+            weight_sum += weight;
+        }
+        if (weight_sum <= 0.0f)
+        {
+            skin_matrix = glm::mat4(1.0f);
+        }
+
+        const glm::vec4 point = skin_matrix * glm::vec4(
+                                                  points[point_offset + 0u],
+                                                  points[point_offset + 1u],
+                                                  points[point_offset + 2u],
+                                                  1.0f);
+        skinned_points[point_offset + 0u] = point.x;
+        skinned_points[point_offset + 1u] = point.y;
+        skinned_points[point_offset + 2u] = point.z;
+
+        if (point_offset + 2u < normals.size())
+        {
+            glm::vec3 normal =
+                glm::mat3(skin_matrix) * glm::vec3(
+                                             normals[point_offset + 0u],
+                                             normals[point_offset + 1u],
+                                             normals[point_offset + 2u]);
+            if (glm::length(normal) > 1.0e-6f)
+            {
+                normal = glm::normalize(normal);
+            }
+            skinned_normals[point_offset + 0u] = normal.x;
+            skinned_normals[point_offset + 1u] = normal.y;
+            skinned_normals[point_offset + 2u] = normal.z;
+        }
+    }
+    return true;
+}
+
+} // namespace
 
 MeshResources::MeshResources(
     vk::Device device,
     GpuMemoryManager& memory_manager,
     CommandQueue& command_queue,
     const Logger& logger)
-    : device_(device),
-      memory_manager_(&memory_manager),
-      command_queue_(&command_queue),
-      logger_(&logger)
+    : device_(device), memory_manager_(&memory_manager),
+      command_queue_(&command_queue), logger_(&logger)
 {
+}
+
+void MeshResources::Build(
+    const frame::LevelInterface& level,
+    const frame::json::LevelData& level_data,
+    bool prefer_level_scene_meshes)
+{
+    std::vector<MeshBuildInfo> mesh_infos = {};
+    if (prefer_level_scene_meshes)
+    {
+        mesh_infos =
+            ExtractMeshes(level, frame::proto::NodeMesh::SKYBOX_RENDER_TIME);
+        auto scene_meshes =
+            ExtractMeshes(level, frame::proto::NodeMesh::SCENE_RENDER_TIME);
+        mesh_infos.insert(
+            mesh_infos.end(),
+            std::make_move_iterator(scene_meshes.begin()),
+            std::make_move_iterator(scene_meshes.end()));
+    }
+    UploadMeshes(std::move(mesh_infos), level_data);
 }
 
 void MeshResources::Build(const frame::json::LevelData& level_data)
 {
+    UploadMeshes({}, level_data);
+}
+
+void MeshResources::UploadMeshes(
+    std::vector<MeshBuildInfo> mesh_infos,
+    const frame::json::LevelData& level_data)
+{
     meshes_.clear();
 
-    std::vector<frame::json::StaticMeshInfo> mesh_infos = level_data.meshes;
+    if (mesh_infos.empty())
+    {
+        mesh_infos.reserve(level_data.meshes.size());
+        for (const auto& mesh_info : level_data.meshes)
+        {
+            mesh_infos.push_back(
+                {.mesh_info = mesh_info, .source_node_id = NullId});
+        }
+    }
     if (mesh_infos.empty())
     {
         mesh_infos.push_back(MakeFallbackQuad());
     }
 
-    for (const auto& mesh_info : mesh_infos)
+    for (const auto& build_info : mesh_infos)
     {
         try
         {
-            meshes_.push_back(BuildMeshResource(mesh_info));
+            auto resource = BuildMeshResource(build_info.mesh_info);
+            resource.source_node_id = build_info.source_node_id;
+            resource.source_mesh_id = build_info.source_mesh_id;
+            resource.source_material_id = build_info.source_material_id;
+            resource.render_time = build_info.render_time;
+            meshes_.push_back(std::move(resource));
         }
         catch (const std::exception& ex)
         {
             (*logger_)->warn(
-                "Skipping mesh {}: {}",
-                mesh_info.name,
-                ex.what());
+                "Skipping mesh {}: {}", build_info.mesh_info.name, ex.what());
         }
+    }
+}
+
+void MeshResources::UpdateAnimatedMeshes(
+    const frame::LevelInterface& level, double time_s)
+{
+    for (auto& resource : meshes_)
+    {
+        if (resource.source_mesh_id == frame::NullId)
+        {
+            continue;
+        }
+
+        const auto* skinned_mesh =
+            dynamic_cast<const frame::vulkan::SkinnedMesh*>(
+                &level.GetMeshFromId(resource.source_mesh_id));
+        if (!skinned_mesh || !skinned_mesh->IsSkinningAnimationEnabled() ||
+            !skinned_mesh->HasGpuSkinningSourceData() ||
+            !skinned_mesh->HasBoneMatricesCallback())
+        {
+            continue;
+        }
+
+        const double skinning_time_s = skinned_mesh->GetSkinningTime(time_s);
+        if (resource.last_skinning_time_s >= 0.0 &&
+            std::abs(resource.last_skinning_time_s - skinning_time_s) < 1.0e-5)
+        {
+            continue;
+        }
+
+        frame::json::StaticMeshInfo mesh_info = {};
+        mesh_info.name = level.GetNameFromId(resource.source_mesh_id);
+        mesh_info.uvs = skinned_mesh->GetSkinningTextures();
+        mesh_info.indices = skinned_mesh->GetSkinningTriangleIndices();
+        if (!EvaluateSkinnedRasterMesh(
+                *skinned_mesh,
+                skinning_time_s,
+                mesh_info.positions,
+                mesh_info.normals))
+        {
+            continue;
+        }
+
+        const auto vertices = BuildMeshVertices(mesh_info);
+        const vk::DeviceSize vertex_size =
+            static_cast<vk::DeviceSize>(vertices.size() * sizeof(MeshVertex));
+        if (vertex_size != resource.vertex_size_bytes)
+        {
+            (*logger_)->warn(
+                "Skipping animated mesh update for {}: vertex size changed.",
+                mesh_info.name);
+            continue;
+        }
+        UploadVertexData(resource, vertices);
+        resource.last_skinning_time_s = skinning_time_s;
     }
 }
 
@@ -50,22 +258,87 @@ void MeshResources::Clear()
     meshes_.clear();
 }
 
-frame::json::StaticMeshInfo MeshResources::MakeFallbackQuad()
+std::vector<MeshResources::MeshBuildInfo> MeshResources::ExtractMeshes(
+    const frame::LevelInterface& level,
+    frame::proto::NodeMesh::RenderTimeEnum render_time)
+{
+    std::vector<MeshBuildInfo> mesh_infos = {};
+    for (const auto& [node_id, material_id] :
+         level.GetMeshMaterialIds(render_time))
+    {
+        if (node_id == frame::NullId)
+        {
+            continue;
+        }
+        const auto& node = level.GetSceneNodeFromId(node_id);
+        const auto mesh_id = node.GetLocalMesh();
+        if (mesh_id == frame::NullId)
+        {
+            continue;
+        }
+        const auto& mesh = level.GetMeshFromId(mesh_id);
+        if (mesh.GetData().render_primitive_enum() !=
+            frame::proto::NodeMesh::TRIANGLE_PRIMITIVE)
+        {
+            continue;
+        }
+        if (mesh.GetPointBufferId() == frame::NullId ||
+            mesh.GetIndexBufferId() == frame::NullId)
+        {
+            continue;
+        }
+
+        frame::json::StaticMeshInfo mesh_info = {};
+        mesh_info.name = level.GetNameFromId(mesh_id);
+        mesh_info.positions = ReadVectorFromBuffer<float>(
+            level.GetBufferFromId(mesh.GetPointBufferId()));
+        if (mesh.GetNormalBufferId() != frame::NullId)
+        {
+            mesh_info.normals = ReadVectorFromBuffer<float>(
+                level.GetBufferFromId(mesh.GetNormalBufferId()));
+        }
+        if (mesh.GetTextureBufferId() != frame::NullId)
+        {
+            mesh_info.uvs = ReadVectorFromBuffer<float>(
+                level.GetBufferFromId(mesh.GetTextureBufferId()));
+        }
+        mesh_info.indices = ReadVectorFromBuffer<std::uint32_t>(
+            level.GetBufferFromId(mesh.GetIndexBufferId()));
+        if (!mesh_info.positions.empty() && !mesh_info.indices.empty())
+        {
+            mesh_infos.push_back(
+                {.mesh_info = std::move(mesh_info),
+                 .source_node_id = node_id,
+                 .source_mesh_id = mesh_id,
+                 .source_material_id = material_id,
+                 .render_time = render_time});
+        }
+    }
+    return mesh_infos;
+}
+
+MeshResources::MeshBuildInfo MeshResources::MakeFallbackQuad()
 {
     frame::json::StaticMeshInfo quad{};
     quad.positions = {
-        -1.0f, -1.0f, 0.0f,
-        1.0f, -1.0f, 0.0f,
-        1.0f,  1.0f, 0.0f,
-        -1.0f, 1.0f, 0.0f};
-    quad.uvs = {
-        0.0f, 0.0f,
-        1.0f, 0.0f,
-        1.0f, 1.0f,
-        0.0f, 1.0f};
+        -1.0f,
+        -1.0f,
+        0.0f,
+        1.0f,
+        -1.0f,
+        0.0f,
+        1.0f,
+        1.0f,
+        0.0f,
+        -1.0f,
+        1.0f,
+        0.0f};
+    quad.uvs = {0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f};
+    quad.normals = {
+        0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f};
     quad.indices = {0, 1, 2, 2, 3, 0};
     quad.name = "FallbackQuad";
-    return quad;
+    return {.mesh_info = std::move(quad), .source_node_id = NullId};
 }
 
 MeshResource MeshResources::BuildMeshResource(
@@ -80,6 +353,7 @@ MeshResource MeshResources::BuildMeshResource(
     MeshResource resource;
     const vk::DeviceSize vertex_size =
         static_cast<vk::DeviceSize>(vertices.size() * sizeof(MeshVertex));
+    resource.vertex_size_bytes = vertex_size;
 
     vk::UniqueDeviceMemory staging_vertex_memory;
     auto staging_vertex_buffer = memory_manager_->CreateBuffer(
@@ -108,8 +382,7 @@ MeshResource MeshResources::BuildMeshResource(
     if (!indices.empty())
     {
         const vk::DeviceSize index_size =
-            static_cast<vk::DeviceSize>(
-                indices.size() * sizeof(std::uint32_t));
+            static_cast<vk::DeviceSize>(indices.size() * sizeof(std::uint32_t));
         vk::UniqueDeviceMemory staging_index_memory;
         auto staging_index_buffer = memory_manager_->CreateBuffer(
             index_size,
@@ -140,6 +413,38 @@ MeshResource MeshResources::BuildMeshResource(
     }
 
     return resource;
+}
+
+void MeshResources::UploadVertexData(
+    MeshResource& resource, const std::vector<MeshVertex>& vertices)
+{
+    if (vertices.empty() || !resource.vertex_buffer)
+    {
+        return;
+    }
+
+    const vk::DeviceSize vertex_size =
+        static_cast<vk::DeviceSize>(vertices.size() * sizeof(MeshVertex));
+    if (vertex_size != resource.vertex_size_bytes)
+    {
+        return;
+    }
+
+    vk::UniqueDeviceMemory staging_vertex_memory;
+    auto staging_vertex_buffer = memory_manager_->CreateBuffer(
+        vertex_size,
+        vk::BufferUsageFlagBits::eTransferSrc,
+        vk::MemoryPropertyFlagBits::eHostVisible |
+            vk::MemoryPropertyFlagBits::eHostCoherent,
+        staging_vertex_memory);
+
+    void* mapped_vertices =
+        device_.mapMemory(*staging_vertex_memory, 0, vertex_size);
+    std::memcpy(mapped_vertices, vertices.data(), vertex_size);
+    device_.unmapMemory(*staging_vertex_memory);
+
+    command_queue_->CopyBuffer(
+        *staging_vertex_buffer, *resource.vertex_buffer, vertex_size);
 }
 
 } // namespace frame::vulkan

--- a/frame/vulkan/mesh_resources.h
+++ b/frame/vulkan/mesh_resources.h
@@ -7,6 +7,7 @@
 #include "frame/vulkan/vulkan_dispatch.h"
 
 #include "frame/json/level_data.h"
+#include "frame/level_interface.h"
 #include "frame/logger.h"
 #include "frame/vulkan/command_queue.h"
 #include "frame/vulkan/gpu_memory_manager.h"
@@ -21,7 +22,14 @@ struct MeshResource
     vk::UniqueDeviceMemory vertex_memory;
     vk::UniqueBuffer index_buffer;
     vk::UniqueDeviceMemory index_memory;
+    EntityId source_node_id = NullId;
+    EntityId source_mesh_id = NullId;
+    EntityId source_material_id = NullId;
     std::uint32_t index_count = 0;
+    vk::DeviceSize vertex_size_bytes = 0;
+    double last_skinning_time_s = -1.0;
+    frame::proto::NodeMesh::RenderTimeEnum render_time =
+        frame::proto::NodeMesh::SCENE_RENDER_TIME;
 };
 
 class MeshResources
@@ -33,7 +41,13 @@ class MeshResources
         CommandQueue& command_queue,
         const Logger& logger);
 
+    void Build(
+        const frame::LevelInterface& level,
+        const frame::json::LevelData& level_data,
+        bool prefer_level_scene_meshes);
     void Build(const frame::json::LevelData& level_data);
+    void UpdateAnimatedMeshes(
+        const frame::LevelInterface& level, double time_s);
     void Clear();
 
     const std::vector<MeshResource>& GetMeshes() const
@@ -47,9 +61,27 @@ class MeshResources
     }
 
   private:
+    struct MeshBuildInfo
+    {
+        frame::json::StaticMeshInfo mesh_info;
+        EntityId source_node_id = NullId;
+        EntityId source_mesh_id = NullId;
+        EntityId source_material_id = NullId;
+        frame::proto::NodeMesh::RenderTimeEnum render_time =
+            frame::proto::NodeMesh::SCENE_RENDER_TIME;
+    };
+
     MeshResource BuildMeshResource(
         const frame::json::StaticMeshInfo& mesh_info);
-    static frame::json::StaticMeshInfo MakeFallbackQuad();
+    void UploadVertexData(
+        MeshResource& resource, const std::vector<MeshVertex>& vertices);
+    void UploadMeshes(
+        std::vector<MeshBuildInfo> mesh_infos,
+        const frame::json::LevelData& level_data);
+    static std::vector<MeshBuildInfo> ExtractMeshes(
+        const frame::LevelInterface& level,
+        frame::proto::NodeMesh::RenderTimeEnum render_time);
+    static MeshBuildInfo MakeFallbackQuad();
 
     vk::Device device_;
     GpuMemoryManager* memory_manager_;

--- a/frame/vulkan/mesh_utils.cpp
+++ b/frame/vulkan/mesh_utils.cpp
@@ -9,10 +9,12 @@ std::vector<MeshVertex> BuildMeshVertices(
     const frame::json::StaticMeshInfo& mesh_info)
 {
     const auto& positions = mesh_info.positions;
+    const auto& normals = mesh_info.normals;
     const auto& uvs = mesh_info.uvs;
     if (positions.empty() || positions.size() % 3 != 0)
     {
-        throw std::runtime_error("Static mesh positions must be non-empty and a multiple of 3.");
+        throw std::runtime_error(
+            "Static mesh positions must be non-empty and a multiple of 3.");
     }
 
     const std::size_t vertex_count = positions.size() / 3;
@@ -21,14 +23,19 @@ std::vector<MeshVertex> BuildMeshVertices(
     {
         MeshVertex vertex{};
         vertex.position = glm::vec3(
-            positions[i * 3 + 0],
-            positions[i * 3 + 1],
-            positions[i * 3 + 2]);
+            positions[i * 3 + 0], positions[i * 3 + 1], positions[i * 3 + 2]);
+        if (normals.size() >= (i + 1) * 3)
+        {
+            vertex.normal = glm::vec3(
+                normals[i * 3 + 0], normals[i * 3 + 1], normals[i * 3 + 2]);
+        }
+        else
+        {
+            vertex.normal = glm::vec3(0.0f, 0.0f, 1.0f);
+        }
         if (uvs.size() >= (i + 1) * 2)
         {
-            vertex.uv = glm::vec2(
-                uvs[i * 2 + 0],
-                uvs[i * 2 + 1]);
+            vertex.uv = glm::vec2(uvs[i * 2 + 0], uvs[i * 2 + 1]);
         }
         else
         {

--- a/frame/vulkan/mesh_utils.h
+++ b/frame/vulkan/mesh_utils.h
@@ -14,10 +14,11 @@ namespace frame::vulkan
 struct MeshVertex
 {
     glm::vec3 position{};
+    glm::vec3 normal{};
     glm::vec2 uv{};
 };
 
 std::vector<MeshVertex> BuildMeshVertices(
     const frame::json::StaticMeshInfo& mesh_info);
 
-}
+} // namespace frame::vulkan

--- a/frame/vulkan/pipeline_resources.cpp
+++ b/frame/vulkan/pipeline_resources.cpp
@@ -22,8 +22,7 @@ namespace frame::vulkan
 namespace
 {
 
-template <typename T>
-T AlignUp(T value, T alignment)
+template <typename T> T AlignUp(T value, T alignment)
 {
     if (alignment == 0)
     {
@@ -80,8 +79,7 @@ void PipelineResources::CreateGraphicsPipeline()
     try
     {
         vert_code = device_.shader_compiler_->CompileFile(
-            device_.active_program_info_->vertex_shader,
-            shaderc_vertex_shader);
+            device_.active_program_info_->vertex_shader, shaderc_vertex_shader);
         frag_code = device_.shader_compiler_->CompileFile(
             device_.active_program_info_->fragment_shader,
             shaderc_fragment_shader);
@@ -96,9 +94,8 @@ void PipelineResources::CreateGraphicsPipeline()
         return;
     }
 
-    use_procedural_quad_pipeline_ =
-        device_.active_program_info_->scene_type ==
-        frame::proto::SceneType::QUAD;
+    use_procedural_quad_pipeline_ = device_.active_program_info_->scene_type ==
+                                    frame::proto::SceneType::QUAD;
 
     struct alignas(16) PushConstants
     {
@@ -123,9 +120,9 @@ void PipelineResources::CreateGraphicsPipeline()
     }
     else
     {
-        push_constant_size_ = static_cast<std::uint32_t>(
-            sizeof(PushConstants));
-        push_constant_stages_ = vk::ShaderStageFlagBits::eVertex;
+        push_constant_size_ = static_cast<std::uint32_t>(sizeof(PushConstants));
+        push_constant_stages_ = vk::ShaderStageFlagBits::eVertex |
+                                vk::ShaderStageFlagBits::eFragment;
     }
 
     auto vert_module = CreateShaderModule(vert_code);
@@ -159,6 +156,11 @@ void PipelineResources::CreateGraphicsPipeline()
         attribute_descriptions.emplace_back(
             1,
             0,
+            vk::Format::eR32G32B32Sfloat,
+            static_cast<std::uint32_t>(offsetof(MeshVertex, normal)));
+        attribute_descriptions.emplace_back(
+            2,
+            0,
             vk::Format::eR32G32Sfloat,
             static_cast<std::uint32_t>(offsetof(MeshVertex, uv)));
     }
@@ -176,11 +178,7 @@ void PipelineResources::CreateGraphicsPipeline()
         VK_FALSE);
 
     vk::PipelineViewportStateCreateInfo viewport_state(
-        vk::PipelineViewportStateCreateFlags{},
-        1,
-        nullptr,
-        1,
-        nullptr);
+        vk::PipelineViewportStateCreateFlags{}, 1, nullptr, 1, nullptr);
 
     vk::PipelineRasterizationStateCreateInfo rasterizer(
         vk::PipelineRasterizationStateCreateFlags{},
@@ -196,15 +194,20 @@ void PipelineResources::CreateGraphicsPipeline()
         1.0f);
 
     vk::PipelineMultisampleStateCreateInfo multisampling(
-        vk::PipelineMultisampleStateCreateFlags{},
-        vk::SampleCountFlagBits::e1);
+        vk::PipelineMultisampleStateCreateFlags{}, vk::SampleCountFlagBits::e1);
+
+    vk::PipelineDepthStencilStateCreateInfo depth_stencil(
+        vk::PipelineDepthStencilStateCreateFlags{},
+        VK_TRUE,
+        VK_TRUE,
+        vk::CompareOp::eLessOrEqual,
+        VK_FALSE,
+        VK_FALSE);
 
     vk::PipelineColorBlendAttachmentState color_blend_attachment{};
     color_blend_attachment.colorWriteMask =
-        vk::ColorComponentFlagBits::eR |
-        vk::ColorComponentFlagBits::eG |
-        vk::ColorComponentFlagBits::eB |
-        vk::ColorComponentFlagBits::eA;
+        vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG |
+        vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA;
     color_blend_attachment.blendEnable = VK_FALSE;
 
     vk::PipelineColorBlendStateCreateInfo color_blending(
@@ -215,8 +218,7 @@ void PipelineResources::CreateGraphicsPipeline()
         &color_blend_attachment);
 
     std::array<vk::DynamicState, 2> dynamic_states = {
-        vk::DynamicState::eViewport,
-        vk::DynamicState::eScissor};
+        vk::DynamicState::eViewport, vk::DynamicState::eScissor};
     vk::PipelineDynamicStateCreateInfo dynamic_state(
         vk::PipelineDynamicStateCreateFlags{},
         static_cast<std::uint32_t>(dynamic_states.size()),
@@ -232,9 +234,7 @@ void PipelineResources::CreateGraphicsPipeline()
     if (push_constant_size_ > 0)
     {
         push_constant_ranges.emplace_back(
-            push_constant_stages_,
-            0,
-            push_constant_size_);
+            push_constant_stages_, 0, push_constant_size_);
     }
 
     vk::PipelineLayoutCreateInfo pipeline_layout_info(
@@ -243,9 +243,8 @@ void PipelineResources::CreateGraphicsPipeline()
         set_layouts.data(),
         static_cast<std::uint32_t>(push_constant_ranges.size()),
         push_constant_ranges.empty() ? nullptr : push_constant_ranges.data());
-    pipeline_layout_ =
-        device_.vk_unique_device_->createPipelineLayoutUnique(
-            pipeline_layout_info);
+    pipeline_layout_ = device_.vk_unique_device_->createPipelineLayoutUnique(
+        pipeline_layout_info);
 
     vk::GraphicsPipelineCreateInfo pipeline_info(
         vk::PipelineCreateFlags{},
@@ -257,7 +256,7 @@ void PipelineResources::CreateGraphicsPipeline()
         &viewport_state,
         &rasterizer,
         &multisampling,
-        nullptr,
+        &depth_stencil,
         &color_blending,
         &dynamic_state,
         *pipeline_layout_,
@@ -265,12 +264,10 @@ void PipelineResources::CreateGraphicsPipeline()
 
     auto pipeline_result =
         device_.vk_unique_device_->createGraphicsPipelineUnique(
-            nullptr,
-            pipeline_info);
+            nullptr, pipeline_info);
     if (pipeline_result.result != vk::Result::eSuccess)
     {
-        throw std::runtime_error(
-            "Failed to create Vulkan graphics pipeline.");
+        throw std::runtime_error("Failed to create Vulkan graphics pipeline.");
     }
     graphics_pipeline_ = std::move(pipeline_result.value);
 }
@@ -339,25 +336,19 @@ void PipelineResources::CreateComputePipeline()
 
     const vk::DescriptorSetLayout layouts[] = {*device_.descriptor_set_layout_};
     vk::PipelineLayoutCreateInfo layout_info(
-        vk::PipelineLayoutCreateFlags{},
-        1,
-        layouts);
+        vk::PipelineLayoutCreateFlags{}, 1, layouts);
     compute_pipeline_layout_ =
         device_.vk_unique_device_->createPipelineLayoutUnique(layout_info);
 
     vk::ComputePipelineCreateInfo pipeline_info(
-        vk::PipelineCreateFlags{},
-        stage_info,
-        *compute_pipeline_layout_);
+        vk::PipelineCreateFlags{}, stage_info, *compute_pipeline_layout_);
 
     auto pipeline_result =
         device_.vk_unique_device_->createComputePipelineUnique(
-            nullptr,
-            pipeline_info);
+            nullptr, pipeline_info);
     if (pipeline_result.result != vk::Result::eSuccess)
     {
-        throw std::runtime_error(
-            "Failed to create Vulkan compute pipeline.");
+        throw std::runtime_error("Failed to create Vulkan compute pipeline.");
     }
     compute_pipeline_ = std::move(pipeline_result.value);
     device_.logger_->info("Created raytracing compute pipeline.");
@@ -409,11 +400,9 @@ void PipelineResources::CreateRaytracingPipeline()
     try
     {
         raygen_code = device_.shader_compiler_->CompileFile(
-            device_.active_program_info_->raygen_shader,
-            shaderc_raygen_shader);
+            device_.active_program_info_->raygen_shader, shaderc_raygen_shader);
         miss_code = device_.shader_compiler_->CompileFile(
-            device_.active_program_info_->miss_shader,
-            shaderc_miss_shader);
+            device_.active_program_info_->miss_shader, shaderc_miss_shader);
         closesthit_code = device_.shader_compiler_->CompileFile(
             device_.active_program_info_->closesthit_shader,
             shaderc_closesthit_shader);
@@ -433,7 +422,7 @@ void PipelineResources::CreateRaytracingPipeline()
     auto miss_module = CreateShaderModule(miss_code);
     auto closesthit_module = CreateShaderModule(closesthit_code);
 
-    std::array<vk::PipelineShaderStageCreateInfo, 3> shader_stages = { {
+    std::array<vk::PipelineShaderStageCreateInfo, 3> shader_stages = {{
         {vk::PipelineShaderStageCreateFlags{},
          vk::ShaderStageFlagBits::eRaygenKHR,
          *raygen_module,
@@ -446,9 +435,9 @@ void PipelineResources::CreateRaytracingPipeline()
          vk::ShaderStageFlagBits::eClosestHitKHR,
          *closesthit_module,
          "main"},
-    } };
+    }};
 
-    std::array<vk::RayTracingShaderGroupCreateInfoKHR, 3> shader_groups = { {
+    std::array<vk::RayTracingShaderGroupCreateInfoKHR, 3> shader_groups = {{
         {vk::RayTracingShaderGroupTypeKHR::eGeneral,
          0,
          VK_SHADER_UNUSED_KHR,
@@ -464,13 +453,11 @@ void PipelineResources::CreateRaytracingPipeline()
          2,
          VK_SHADER_UNUSED_KHR,
          VK_SHADER_UNUSED_KHR},
-    } };
+    }};
 
     const vk::DescriptorSetLayout layouts[] = {*device_.descriptor_set_layout_};
     vk::PipelineLayoutCreateInfo layout_info(
-        vk::PipelineLayoutCreateFlags{},
-        1,
-        layouts);
+        vk::PipelineLayoutCreateFlags{}, 1, layouts);
     raytracing_pipeline_layout_ =
         device_.vk_unique_device_->createPipelineLayoutUnique(layout_info);
 
@@ -481,9 +468,7 @@ void PipelineResources::CreateRaytracingPipeline()
     pipeline_info.setLayout(*raytracing_pipeline_layout_);
     auto pipeline_result =
         device_.vk_unique_device_->createRayTracingPipelineKHRUnique(
-            vk::DeferredOperationKHR{},
-            vk::PipelineCache{},
-            pipeline_info);
+            vk::DeferredOperationKHR{}, vk::PipelineCache{}, pipeline_info);
     if (pipeline_result.result != vk::Result::eSuccess)
     {
         throw std::runtime_error(
@@ -506,8 +491,7 @@ void PipelineResources::CreateRaytracingPipeline()
     const std::uint32_t raygen_size = raygen_stride;
     const std::uint32_t miss_size =
         AlignUp(handle_size_aligned, base_alignment);
-    const std::uint32_t hit_size =
-        AlignUp(handle_size_aligned, base_alignment);
+    const std::uint32_t hit_size = AlignUp(handle_size_aligned, base_alignment);
     const vk::DeviceSize sbt_size =
         static_cast<vk::DeviceSize>(raygen_size + miss_size + hit_size);
 
@@ -534,16 +518,13 @@ void PipelineResources::CreateRaytracingPipeline()
             vk::MemoryPropertyFlagBits::eHostCoherent,
         raytracing_sbt_memory_,
         vk::MemoryAllocateFlagBits::eDeviceAddress);
-    auto* mapped = static_cast<std::uint8_t*>(device_.vk_unique_device_->mapMemory(
-        *raytracing_sbt_memory_,
-        0,
-        sbt_size));
+    auto* mapped =
+        static_cast<std::uint8_t*>(device_.vk_unique_device_->mapMemory(
+            *raytracing_sbt_memory_, 0, sbt_size));
     std::memset(mapped, 0, static_cast<std::size_t>(sbt_size));
     std::memcpy(mapped, shader_handles.data(), handle_size);
     std::memcpy(
-        mapped + raygen_size,
-        shader_handles.data() + handle_size,
-        handle_size);
+        mapped + raygen_size, shader_handles.data() + handle_size, handle_size);
     std::memcpy(
         mapped + raygen_size + miss_size,
         shader_handles.data() + handle_size * 2,
@@ -554,17 +535,11 @@ void PipelineResources::CreateRaytracingPipeline()
         device_.vk_unique_device_->getBufferAddress(
             vk::BufferDeviceAddressInfo(*raytracing_sbt_buffer_));
     raygen_sbt_region_ = vk::StridedDeviceAddressRegionKHR(
-        sbt_address,
-        raygen_stride,
-        raygen_size);
+        sbt_address, raygen_stride, raygen_size);
     miss_sbt_region_ = vk::StridedDeviceAddressRegionKHR(
-        sbt_address + raygen_size,
-        miss_stride,
-        miss_size);
+        sbt_address + raygen_size, miss_stride, miss_size);
     hit_sbt_region_ = vk::StridedDeviceAddressRegionKHR(
-        sbt_address + raygen_size + miss_size,
-        hit_stride,
-        hit_size);
+        sbt_address + raygen_size + miss_size, hit_stride, hit_size);
     callable_sbt_region_ = vk::StridedDeviceAddressRegionKHR();
 
     device_.logger_->info("Created Vulkan ray tracing pipeline.");

--- a/frame/vulkan/renderer.cpp
+++ b/frame/vulkan/renderer.cpp
@@ -10,8 +10,8 @@
 #include <glm/gtc/matrix_inverse.hpp>
 
 #include "frame/camera.h"
-#include "frame/vulkan/device.h"
 #include "frame/vulkan/command_resources.h"
+#include "frame/vulkan/device.h"
 #include "frame/vulkan/frame_profiler.h"
 #include "frame/vulkan/mesh_resources.h"
 #include "frame/vulkan/output_image_resources.h"
@@ -91,8 +91,7 @@ void Renderer::Display(double dt)
     const vk::Fence fence =
         device_.sync_resources_->GetInFlightFence(current_frame_);
     const VkFence fence_handle = static_cast<VkFence>(fence);
-    const VkResult wait_result = [&]()
-    {
+    const VkResult wait_result = [&]() {
         VulkanProfileScope scope("renderer.wait_fence");
         return vkWaitForFences(
             static_cast<VkDevice>(*device_.vk_unique_device_),
@@ -112,10 +111,18 @@ void Renderer::Display(double dt)
         }
         return;
     }
+    if (device_.mesh_resources_ && device_.level_ &&
+        device_.active_program_info_ &&
+        device_.active_program_info_->scene_type ==
+            frame::proto::SceneType::SCENE)
+    {
+        device_.mesh_resources_->UpdateAnimatedMeshes(
+            *device_.level_,
+            static_cast<double>(device_.elapsed_time_seconds_));
+    }
 
     const auto& swapchain = device_.swapchain_resources_->GetSwapchain();
-    auto acquire = [&]()
-    {
+    auto acquire = [&]() {
         VulkanProfileScope scope("renderer.acquire_image");
         return device_.vk_unique_device_->acquireNextImageKHR(
             *swapchain,
@@ -143,8 +150,7 @@ void Renderer::Display(double dt)
     }
 
     const std::uint32_t image_index = acquire.value;
-    const VkResult reset_result = [&]()
-    {
+    const VkResult reset_result = [&]() {
         VulkanProfileScope scope("renderer.reset_fence");
         return vkResetFences(
             static_cast<VkDevice>(*device_.vk_unique_device_),
@@ -191,8 +197,7 @@ void Renderer::Display(double dt)
         signal_semaphores);
 
     const VkSubmitInfo submit_info_c = submit_info;
-    const VkResult submit_result = [&]()
-    {
+    const VkResult submit_result = [&]() {
         VulkanProfileScope scope("renderer.queue_submit");
         return vkQueueSubmit(
             static_cast<VkQueue>(device_.graphics_queue_),
@@ -213,14 +218,9 @@ void Renderer::Display(double dt)
     }
 
     vk::PresentInfoKHR present_info(
-        1,
-        signal_semaphores,
-        1,
-        &swapchain.get(),
-        &image_index);
+        1, signal_semaphores, 1, &swapchain.get(), &image_index);
 
-    const vk::Result present_result = [&]()
-    {
+    const vk::Result present_result = [&]() {
         VulkanProfileScope scope("renderer.present");
         return device_.present_queue_.presentKHR(present_info);
     }();
@@ -250,8 +250,7 @@ void Renderer::Reset()
 }
 
 void Renderer::RecordCommandBuffer(
-    vk::CommandBuffer command_buffer,
-    std::uint32_t image_index)
+    vk::CommandBuffer command_buffer, std::uint32_t image_index)
 {
     VulkanProfileScope record_scope("renderer.record_body");
 
@@ -270,8 +269,7 @@ void Renderer::RecordCommandBuffer(
     const auto& gui_framebuffers =
         device_.swapchain_resources_->GetGuiFramebuffers();
 
-    const SceneState scene_state = [&]()
-    {
+    const SceneState scene_state = [&]() {
         VulkanProfileScope scope("renderer.build_scene_state");
         return device_.BuildFrameSceneState(extent);
     }();
@@ -284,9 +282,103 @@ void Renderer::RecordCommandBuffer(
         raytrace_scene_renderer_->Render(command_buffer, extent);
     }
 
-    std::array<vk::ClearValue, 1> clear_values{};
-    clear_values[0].color = vk::ClearColorValue(
-        std::array<float, 4>{0.1f, 0.1f, 0.1f, 1.0f});
+    auto render_shadow_map = [&]() {
+        if (!device_.shadow_map_render_pass_ ||
+            !device_.shadow_map_framebuffer_ || !device_.shadow_map_pipeline_ ||
+            !device_.shadow_map_pipeline_layout_ || !device_.mesh_resources_ ||
+            device_.mesh_resources_->Empty() ||
+            scene_state.shadow_enabled < 0.5f)
+        {
+            return;
+        }
+
+        VulkanProfileScope scope("renderer.shadow_map_record");
+        vk::ClearValue clear_value{};
+        clear_value.depthStencil = vk::ClearDepthStencilValue(1.0f, 0);
+        vk::RenderPassBeginInfo shadow_pass_info(
+            *device_.shadow_map_render_pass_,
+            *device_.shadow_map_framebuffer_,
+            vk::Rect2D(
+                {0, 0}, {Device::kShadowMapSize, Device::kShadowMapSize}),
+            1,
+            &clear_value);
+        command_buffer.beginRenderPass(
+            shadow_pass_info, vk::SubpassContents::eInline);
+        command_buffer.bindPipeline(
+            vk::PipelineBindPoint::eGraphics, *device_.shadow_map_pipeline_);
+
+        vk::Viewport viewport(
+            0.0f,
+            0.0f,
+            static_cast<float>(Device::kShadowMapSize),
+            static_cast<float>(Device::kShadowMapSize),
+            0.0f,
+            1.0f);
+        command_buffer.setViewport(0, 1, &viewport);
+        vk::Rect2D scissor(
+            {0, 0}, {Device::kShadowMapSize, Device::kShadowMapSize});
+        command_buffer.setScissor(0, 1, &scissor);
+
+        struct alignas(16) ShadowPushConstants
+        {
+            glm::mat4 light_view_projection;
+            glm::mat4 model;
+        };
+
+        for (const auto& mesh : device_.mesh_resources_->GetMeshes())
+        {
+            if (mesh.render_time != frame::proto::NodeMesh::SCENE_RENDER_TIME)
+            {
+                continue;
+            }
+
+            glm::mat4 mesh_model = glm::mat4(1.0f);
+            if (mesh.source_node_id != NullId && device_.level_)
+            {
+                try
+                {
+                    auto& node =
+                        device_.level_->GetSceneNodeFromId(mesh.source_node_id);
+                    mesh_model = node.GetLocalModel(
+                        static_cast<double>(device_.elapsed_time_seconds_));
+                }
+                catch (const std::exception& ex)
+                {
+                    device_.logger_->warn(
+                        "Failed to compute shadow mesh model matrix: {}",
+                        ex.what());
+                }
+            }
+
+            ShadowPushConstants push_constants{
+                scene_state.light_view_projection, mesh_model};
+            command_buffer.pushConstants(
+                *device_.shadow_map_pipeline_layout_,
+                vk::ShaderStageFlagBits::eVertex,
+                0,
+                sizeof(ShadowPushConstants),
+                &push_constants);
+            const vk::DeviceSize offsets[] = {0};
+            command_buffer.bindVertexBuffers(0, *mesh.vertex_buffer, offsets);
+            if (mesh.index_buffer)
+            {
+                command_buffer.bindIndexBuffer(
+                    *mesh.index_buffer, 0, vk::IndexType::eUint32);
+                command_buffer.drawIndexed(mesh.index_count, 1, 0, 0, 0);
+            }
+            else
+            {
+                command_buffer.draw(mesh.index_count, 1, 0, 0);
+            }
+        }
+        command_buffer.endRenderPass();
+    };
+    render_shadow_map();
+
+    std::array<vk::ClearValue, 2> clear_values{};
+    clear_values[0].color =
+        vk::ClearColorValue(std::array<float, 4>{0.1f, 0.1f, 0.1f, 1.0f});
+    clear_values[1].depthStencil = vk::ClearDepthStencilValue(1.0f, 0);
 
     auto draw_scene = [&]() -> bool {
         VulkanProfileScope scope("renderer.draw_scene_record");
@@ -311,15 +403,18 @@ void Renderer::RecordCommandBuffer(
         vk::Rect2D scissor({0, 0}, extent);
         command_buffer.setScissor(0, 1, &scissor);
 
-        if (device_.descriptor_set_layout_ && device_.descriptor_set_)
-        {
+        auto bind_descriptor_set = [&](vk::DescriptorSet descriptor_set) {
+            if (!device_.descriptor_set_layout_ || !descriptor_set)
+            {
+                return;
+            }
             command_buffer.bindDescriptorSets(
                 vk::PipelineBindPoint::eGraphics,
                 device_.pipeline_resources_->GetGraphicsPipelineLayout(),
                 0,
-                device_.descriptor_set_,
+                descriptor_set,
                 {});
-        }
+        };
 
         glm::mat4 projection = scene_state.projection;
         glm::mat4 view = scene_state.view;
@@ -350,7 +445,8 @@ void Renderer::RecordCommandBuffer(
                     camera_for_frame.SetPosition(
                         glm::vec3(
                             glm::vec4(
-                                device_.level_->GetDefaultCamera().GetPosition(),
+                                device_.level_->GetDefaultCamera()
+                                    .GetPosition(),
                                 1.0f) *
                             inverse_model));
                 }
@@ -367,7 +463,15 @@ void Renderer::RecordCommandBuffer(
                 glm::mat4 rotation = glm::mat4(1.0f);
                 view = rotation * view;
 
-                const auto mesh_pairs = device_.level_->GetMeshMaterialIds();
+                auto render_time = frame::proto::NodeMesh::SCENE_RENDER_TIME;
+                if (device_.active_program_info_ &&
+                    device_.active_program_info_->scene_type ==
+                        frame::proto::SceneType::CUBE)
+                {
+                    render_time = frame::proto::NodeMesh::SKYBOX_RENDER_TIME;
+                }
+                const auto mesh_pairs =
+                    device_.level_->GetMeshMaterialIds(render_time);
                 if (!mesh_pairs.empty())
                 {
                     auto node_id = mesh_pairs.front().first;
@@ -383,13 +487,17 @@ void Renderer::RecordCommandBuffer(
             }
         }
 
-        if (device_.pipeline_resources_->GetPushConstantSize() > 0)
-        {
+        auto push_scene_constants = [&](const glm::mat4& model_matrix,
+                                        float time_s) {
+            if (device_.pipeline_resources_->GetPushConstantSize() == 0)
+            {
+                return;
+            }
             if (device_.pipeline_resources_->UsesProceduralQuadPipeline() &&
                 device_.active_program_info_ &&
                 device_.active_program_info_->uses_time_uniform)
             {
-                float time = device_.elapsed_time_seconds_;
+                const float time = device_.elapsed_time_seconds_;
                 command_buffer.pushConstants(
                     device_.pipeline_resources_->GetGraphicsPipelineLayout(),
                     device_.pipeline_resources_->GetPushConstantStages(),
@@ -405,11 +513,7 @@ void Renderer::RecordCommandBuffer(
                     glm::mat4 view;
                     glm::mat4 model;
                     float time_s;
-                } push_constants{
-                    projection,
-                    view,
-                    model,
-                    device_.elapsed_time_seconds_};
+                } push_constants{projection, view, model_matrix, time_s};
                 command_buffer.pushConstants(
                     device_.pipeline_resources_->GetGraphicsPipelineLayout(),
                     device_.pipeline_resources_->GetPushConstantStages(),
@@ -417,31 +521,61 @@ void Renderer::RecordCommandBuffer(
                     device_.pipeline_resources_->GetPushConstantSize(),
                     &push_constants);
             }
-        }
+        };
 
         if (device_.pipeline_resources_->UsesProceduralQuadPipeline())
         {
+            bind_descriptor_set(device_.descriptor_set_);
+            push_scene_constants(model, device_.elapsed_time_seconds_);
             command_buffer.draw(6, 1, 0, 0);
             return true;
         }
         if (device_.mesh_resources_ && !device_.mesh_resources_->Empty())
         {
-            const auto& mesh = device_.mesh_resources_->GetMeshes().front();
-            const vk::DeviceSize offsets[] = {0};
-            command_buffer.bindVertexBuffers(0, *mesh.vertex_buffer, offsets);
-            if (mesh.index_buffer)
+            bool drew_mesh = false;
+            for (const auto& mesh : device_.mesh_resources_->GetMeshes())
             {
-                command_buffer.bindIndexBuffer(
-                    *mesh.index_buffer,
-                    0,
-                    vk::IndexType::eUint32);
-                command_buffer.drawIndexed(mesh.index_count, 1, 0, 0, 0);
+                glm::mat4 mesh_model = model;
+                if (mesh.source_node_id != NullId && device_.level_)
+                {
+                    try
+                    {
+                        auto& node = device_.level_->GetSceneNodeFromId(
+                            mesh.source_node_id);
+                        mesh_model = node.GetLocalModel(
+                            static_cast<double>(device_.elapsed_time_seconds_));
+                    }
+                    catch (const std::exception& ex)
+                    {
+                        device_.logger_->warn(
+                            "Failed to compute mesh model matrix: {}",
+                            ex.what());
+                    }
+                }
+                const float push_time =
+                    mesh.render_time ==
+                            frame::proto::NodeMesh::SKYBOX_RENDER_TIME
+                        ? -1.0f
+                        : device_.elapsed_time_seconds_;
+                bind_descriptor_set(device_.GetDescriptorSetForMaterial(
+                    mesh.source_material_id));
+                push_scene_constants(mesh_model, push_time);
+                const vk::DeviceSize offsets[] = {0};
+                command_buffer.bindVertexBuffers(
+                    0, *mesh.vertex_buffer, offsets);
+                if (mesh.index_buffer)
+                {
+                    command_buffer.bindIndexBuffer(
+                        *mesh.index_buffer, 0, vk::IndexType::eUint32);
+                    command_buffer.drawIndexed(mesh.index_count, 1, 0, 0, 0);
+                }
+                else
+                {
+                    command_buffer.draw(mesh.index_count, 1, 0, 0);
+                }
+                drew_mesh = true;
             }
-            else
-            {
-                command_buffer.draw(mesh.index_count, 1, 0, 0);
-            }
-            return true;
+            return drew_mesh;
         }
         return false;
     };
@@ -459,8 +593,7 @@ void Renderer::RecordCommandBuffer(
             clear_values.data());
 
         command_buffer.beginRenderPass(
-            render_pass_info,
-            vk::SubpassContents::eInline);
+            render_pass_info, vk::SubpassContents::eInline);
         scene_content_rendered = draw_scene();
         command_buffer.endRenderPass();
         scene_pass_executed = true;
@@ -489,8 +622,7 @@ void Renderer::RecordCommandBuffer(
 
     if (device_.output_image_resources_ &&
         device_.output_image_resources_->HasSwapchainPreviewImage() &&
-        scene_content_rendered &&
-        image_index < images.size() &&
+        scene_content_rendered && image_index < images.size() &&
         extent.width > 0 && extent.height > 0)
     {
         VulkanProfileScope scope("renderer.preview_copy_record");
@@ -507,11 +639,13 @@ void Renderer::RecordCommandBuffer(
                 swapchain_image,
                 {vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1}),
             vk::ImageMemoryBarrier(
-                device_.output_image_resources_->IsSwapchainPreviewInShaderRead()
+                device_.output_image_resources_
+                        ->IsSwapchainPreviewInShaderRead()
                     ? vk::AccessFlagBits::eShaderRead
                     : vk::AccessFlags{},
                 vk::AccessFlagBits::eTransferWrite,
-                device_.output_image_resources_->IsSwapchainPreviewInShaderRead()
+                device_.output_image_resources_
+                        ->IsSwapchainPreviewInShaderRead()
                     ? vk::ImageLayout::eShaderReadOnlyOptimal
                     : vk::ImageLayout::eUndefined,
                 vk::ImageLayout::eTransferDstOptimal,
@@ -544,9 +678,8 @@ void Renderer::RecordCommandBuffer(
         std::array<vk::ImageMemoryBarrier, 2> from_copy_barriers = {
             vk::ImageMemoryBarrier(
                 vk::AccessFlagBits::eTransferRead,
-                device_.gui_render_callback_
-                    ? vk::AccessFlagBits::eTransferRead
-                    : vk::AccessFlags{},
+                device_.gui_render_callback_ ? vk::AccessFlagBits::eTransferRead
+                                             : vk::AccessFlags{},
                 vk::ImageLayout::eTransferSrcOptimal,
                 vk::ImageLayout::eTransferSrcOptimal,
                 VK_QUEUE_FAMILY_IGNORED,
@@ -585,15 +718,15 @@ void Renderer::RecordCommandBuffer(
             0,
             nullptr);
         command_buffer.beginRenderPass(
-            gui_pass_info,
-            vk::SubpassContents::eInline);
+            gui_pass_info, vk::SubpassContents::eInline);
         try
         {
             device_.gui_render_callback_(command_buffer);
         }
         catch (const std::exception& ex)
         {
-            device_.logger_->error("Failed to render Vulkan GUI: {}", ex.what());
+            device_.logger_->error(
+                "Failed to render Vulkan GUI: {}", ex.what());
         }
         command_buffer.endRenderPass();
     }

--- a/frame/vulkan/scene_state.cpp
+++ b/frame/vulkan/scene_state.cpp
@@ -1,10 +1,13 @@
 #include "frame/vulkan/scene_state.h"
 
+#include <cmath>
 #include <exception>
 #include <optional>
 #include <string>
 
+#include <glm/ext/matrix_clip_space.hpp>
 #include <glm/gtc/matrix_inverse.hpp>
+#include <glm/gtc/matrix_transform.hpp>
 
 #include "frame/camera.h"
 
@@ -64,9 +67,10 @@ SceneState BuildSceneState(
             auto inverse_model = glm::inverse(matrix_node);
             camera_for_frame.SetFront(
                 level.GetDefaultCamera().GetFront() * glm::mat3(inverse_model));
-            camera_for_frame.SetPosition(glm::vec3(
-                glm::vec4(level.GetDefaultCamera().GetPosition(), 1.0f) *
-                inverse_model));
+            camera_for_frame.SetPosition(
+                glm::vec3(
+                    glm::vec4(level.GetDefaultCamera().GetPosition(), 1.0f) *
+                    inverse_model));
         }
 
         if (swapchain_extent.y != 0)
@@ -93,8 +97,7 @@ SceneState BuildSceneState(
     try
     {
         bool model_set = false;
-        if (!force_identity_model &&
-            !preferred_scene_root.empty() &&
+        if (!force_identity_model && !preferred_scene_root.empty() &&
             preferred_scene_root != "root")
         {
             if (auto maybe_root_id =
@@ -113,7 +116,8 @@ SceneState BuildSceneState(
             auto& material = level.GetMaterialFromId(preferred_material);
             for (const auto& node_name : material.GetNodeNames())
             {
-                if (auto maybe_node_id = FindSceneNodeIdByName(level, node_name);
+                if (auto maybe_node_id =
+                        FindSceneNodeIdByName(level, node_name);
                     maybe_node_id)
                 {
                     const auto node_id = *maybe_node_id;
@@ -125,8 +129,7 @@ SceneState BuildSceneState(
                 }
             }
         }
-        if (!force_identity_model &&
-            !model_set &&
+        if (!force_identity_model && !model_set &&
             preferred_material != frame::NullId)
         {
             for (const auto& pair : level.GetMeshMaterialIds())
@@ -141,8 +144,7 @@ SceneState BuildSceneState(
                 }
             }
         }
-        if (!force_identity_model &&
-            !model_set &&
+        if (!force_identity_model && !model_set &&
             preferred_material != frame::NullId)
         {
             // Search all render-time buckets for a mesh using this material.
@@ -195,8 +197,8 @@ SceneState BuildSceneState(
         if (!skybox_pairs.empty())
         {
             auto& node = level.GetSceneNodeFromId(skybox_pairs.front().first);
-            state.env_map_model = node.GetLocalModel(
-                static_cast<double>(elapsed_time_seconds));
+            state.env_map_model =
+                node.GetLocalModel(static_cast<double>(elapsed_time_seconds));
         }
     }
     catch (const std::exception& ex)
@@ -213,6 +215,25 @@ SceneState BuildSceneState(
             state.light_dir = light.GetVector();
             state.light_color = light.GetColorIntensity();
             state.light_type = static_cast<float>(light.GetType());
+            if (light.GetShadowType() != frame::ShadowTypeEnum::NO_SHADOW &&
+                light.GetType() == frame::LightTypeEnum::DIRECTIONAL_LIGHT &&
+                glm::length(state.light_dir) > 0.0f)
+            {
+                const glm::vec3 direction = glm::normalize(state.light_dir);
+                const glm::vec3 center(0.0f, 0.0f, 0.0f);
+                const glm::vec3 up =
+                    std::abs(glm::dot(direction, glm::vec3(0.0f, 1.0f, 0.0f))) >
+                            0.95f
+                        ? glm::vec3(1.0f, 0.0f, 0.0f)
+                        : glm::vec3(0.0f, 1.0f, 0.0f);
+                const glm::vec3 position = center - direction * 8.0f;
+                const glm::mat4 light_view =
+                    glm::lookAtRH(position, center, up);
+                const glm::mat4 light_projection =
+                    glm::orthoRH_ZO(-6.0f, 6.0f, -6.0f, 6.0f, 0.1f, 20.0f);
+                state.light_view_projection = light_projection * light_view;
+                state.shadow_enabled = 1.0f;
+            }
         }
     }
     catch (const std::exception& ex)
@@ -238,9 +259,10 @@ UniformBlock MakeUniformBlock(
     block.light_dir = glm::vec4(state.light_dir, state.light_type);
     block.light_color = glm::vec4(state.light_color, 1.0f);
     block.time_s = glm::vec4(elapsed_time_seconds, 0.0f, 0.0f, 0.0f);
+    block.light_view_projection = state.light_view_projection;
+    block.shadow_params = glm::vec4(
+        state.shadow_enabled, state.shadow_bias, state.shadow_map_size, 0.0f);
     return block;
 }
 
 } // namespace frame::vulkan
-
-

--- a/frame/vulkan/scene_state.h
+++ b/frame/vulkan/scene_state.h
@@ -5,8 +5,8 @@
 #include <glm/glm.hpp>
 #include <string>
 
-#include "frame/logger.h"
 #include "frame/level_interface.h"
+#include "frame/logger.h"
 
 namespace frame::vulkan
 {
@@ -24,6 +24,8 @@ struct alignas(16) UniformBlock
     glm::vec4 light_dir;
     glm::vec4 light_color;
     glm::vec4 time_s;
+    glm::mat4 light_view_projection;
+    glm::vec4 shadow_params;
 };
 
 struct SceneState
@@ -36,6 +38,10 @@ struct SceneState
     glm::vec3 light_dir = glm::vec3(0.0f);
     glm::vec3 light_color = glm::vec3(1.0f);
     float light_type = 0.0f;
+    glm::mat4 light_view_projection = glm::mat4(1.0f);
+    float shadow_enabled = 0.0f;
+    float shadow_bias = 0.0035f;
+    float shadow_map_size = 2048.0f;
 };
 
 SceneState BuildSceneState(

--- a/frame/vulkan/swapchain_resources.cpp
+++ b/frame/vulkan/swapchain_resources.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <limits>
+#include <stdexcept>
 
 namespace frame::vulkan
 {
@@ -14,12 +15,9 @@ SwapchainResources::SwapchainResources(
     std::uint32_t graphics_queue_family_index,
     std::uint32_t present_queue_family_index,
     const Logger& logger)
-    : physical_device_(physical_device),
-      device_(device),
-      surface_(surface),
+    : physical_device_(physical_device), device_(device), surface_(surface),
       graphics_queue_family_index_(graphics_queue_family_index),
-      present_queue_family_index_(present_queue_family_index),
-      logger_(logger)
+      present_queue_family_index_(present_queue_family_index), logger_(logger)
 {
 }
 
@@ -29,15 +27,12 @@ void SwapchainResources::Create(glm::uvec2 size)
 
     const auto capabilities =
         physical_device_.getSurfaceCapabilitiesKHR(surface_);
-    const auto formats =
-        physical_device_.getSurfaceFormatsKHR(surface_);
+    const auto formats = physical_device_.getSurfaceFormatsKHR(surface_);
     const auto present_modes =
         physical_device_.getSurfacePresentModesKHR(surface_);
 
-    const vk::SurfaceFormatKHR surface_format =
-        SelectSurfaceFormat(formats);
-    const vk::PresentModeKHR present_mode =
-        SelectPresentMode(present_modes);
+    const vk::SurfaceFormatKHR surface_format = SelectSurfaceFormat(formats);
+    const vk::PresentModeKHR present_mode = SelectPresentMode(present_modes);
     const vk::Extent2D extent = SelectSwapExtent(capabilities, size);
 
     std::uint32_t image_count = capabilities.minImageCount + 1;
@@ -59,8 +54,7 @@ void SwapchainResources::Create(glm::uvec2 size)
             vk::ImageUsageFlagBits::eTransferSrc);
 
     std::array<std::uint32_t, 2> queue_family_indices = {
-        graphics_queue_family_index_,
-        present_queue_family_index_};
+        graphics_queue_family_index_, present_queue_family_index_};
     if (graphics_queue_family_index_ != present_queue_family_index_)
     {
         swapchain_info.imageSharingMode = vk::SharingMode::eConcurrent;
@@ -95,9 +89,10 @@ void SwapchainResources::Create(glm::uvec2 size)
             image_format_,
             {},
             {vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1});
-        image_views_.push_back(
-            device_.createImageViewUnique(view_info));
+        image_views_.push_back(device_.createImageViewUnique(view_info));
     }
+
+    CreateDepthResources();
 
     vk::AttachmentDescription color_attachment(
         {},
@@ -109,9 +104,21 @@ void SwapchainResources::Create(glm::uvec2 size)
         vk::AttachmentStoreOp::eDontCare,
         ScenePassInitialLayout(),
         ScenePassFinalLayout());
+    vk::AttachmentDescription depth_attachment(
+        {},
+        depth_format_,
+        vk::SampleCountFlagBits::e1,
+        vk::AttachmentLoadOp::eClear,
+        vk::AttachmentStoreOp::eDontCare,
+        vk::AttachmentLoadOp::eDontCare,
+        vk::AttachmentStoreOp::eDontCare,
+        vk::ImageLayout::eUndefined,
+        vk::ImageLayout::eDepthStencilAttachmentOptimal);
 
     vk::AttachmentReference color_ref(
         0, vk::ImageLayout::eColorAttachmentOptimal);
+    vk::AttachmentReference depth_ref(
+        1, vk::ImageLayout::eDepthStencilAttachmentOptimal);
 
     vk::SubpassDescription subpass(
         {},
@@ -121,7 +128,7 @@ void SwapchainResources::Create(glm::uvec2 size)
         1,
         &color_ref,
         nullptr,
-        nullptr,
+        &depth_ref,
         0,
         nullptr);
 
@@ -129,14 +136,19 @@ void SwapchainResources::Create(glm::uvec2 size)
         VK_SUBPASS_EXTERNAL,
         0,
         vk::PipelineStageFlagBits::eTopOfPipe,
-        vk::PipelineStageFlagBits::eColorAttachmentOutput,
+        vk::PipelineStageFlagBits::eColorAttachmentOutput |
+            vk::PipelineStageFlagBits::eEarlyFragmentTests,
         {},
-        vk::AccessFlagBits::eColorAttachmentWrite);
+        vk::AccessFlagBits::eColorAttachmentWrite |
+            vk::AccessFlagBits::eDepthStencilAttachmentWrite);
+
+    std::array<vk::AttachmentDescription, 2> attachments = {
+        color_attachment, depth_attachment};
 
     vk::RenderPassCreateInfo render_pass_info(
         {},
-        1,
-        &color_attachment,
+        static_cast<std::uint32_t>(attachments.size()),
+        attachments.data(),
         1,
         &subpass,
         1,
@@ -146,13 +158,15 @@ void SwapchainResources::Create(glm::uvec2 size)
 
     framebuffers_.clear();
     framebuffers_.reserve(image_views_.size());
-    for (const auto& view : image_views_)
+    for (std::size_t i = 0; i < image_views_.size(); ++i)
     {
+        std::array<vk::ImageView, 2> framebuffer_attachments = {
+            *image_views_[i], *depth_image_views_[i]};
         vk::FramebufferCreateInfo framebuffer_info(
             {},
             *render_pass_,
-            1,
-            &view.get(),
+            static_cast<std::uint32_t>(framebuffer_attachments.size()),
+            framebuffer_attachments.data(),
             extent_.width,
             extent_.height,
             1);
@@ -242,6 +256,9 @@ void SwapchainResources::Destroy()
     gui_render_pass_.reset();
     framebuffers_.clear();
     render_pass_.reset();
+    depth_image_views_.clear();
+    depth_images_.clear();
+    depth_memories_.clear();
     image_views_.clear();
     images_.clear();
     swapchain_.reset();
@@ -295,9 +312,94 @@ vk::PresentModeKHR SwapchainResources::SelectPresentMode(
     return vk::PresentModeKHR::eFifo;
 }
 
+vk::Format SwapchainResources::SelectDepthFormat() const
+{
+    constexpr std::array<vk::Format, 3> kCandidates = {
+        vk::Format::eD32Sfloat,
+        vk::Format::eD32SfloatS8Uint,
+        vk::Format::eD24UnormS8Uint};
+
+    for (const auto format : kCandidates)
+    {
+        const auto properties = physical_device_.getFormatProperties(format);
+        if (static_cast<bool>(
+                properties.optimalTilingFeatures &
+                vk::FormatFeatureFlagBits::eDepthStencilAttachment))
+        {
+            return format;
+        }
+    }
+    throw std::runtime_error("No supported Vulkan depth format found.");
+}
+
+std::uint32_t SwapchainResources::FindMemoryType(
+    std::uint32_t type_filter, vk::MemoryPropertyFlags properties) const
+{
+    const auto memory_properties = physical_device_.getMemoryProperties();
+    for (std::uint32_t i = 0; i < memory_properties.memoryTypeCount; ++i)
+    {
+        if ((type_filter & (1u << i)) == 0u)
+        {
+            continue;
+        }
+        if ((memory_properties.memoryTypes[i].propertyFlags & properties) ==
+            properties)
+        {
+            return i;
+        }
+    }
+    throw std::runtime_error("No suitable Vulkan memory type found.");
+}
+
+void SwapchainResources::CreateDepthResources()
+{
+    depth_format_ = SelectDepthFormat();
+    depth_image_views_.clear();
+    depth_images_.clear();
+    depth_memories_.clear();
+    depth_image_views_.reserve(images_.size());
+    depth_images_.reserve(images_.size());
+    depth_memories_.reserve(images_.size());
+
+    for (std::size_t i = 0; i < images_.size(); ++i)
+    {
+        vk::ImageCreateInfo image_info(
+            {},
+            vk::ImageType::e2D,
+            depth_format_,
+            vk::Extent3D(extent_.width, extent_.height, 1),
+            1,
+            1,
+            vk::SampleCountFlagBits::e1,
+            vk::ImageTiling::eOptimal,
+            vk::ImageUsageFlagBits::eDepthStencilAttachment,
+            vk::SharingMode::eExclusive);
+        auto depth_image = device_.createImageUnique(image_info);
+        const auto memory_requirements =
+            device_.getImageMemoryRequirements(*depth_image);
+        vk::MemoryAllocateInfo alloc_info(
+            memory_requirements.size,
+            FindMemoryType(
+                memory_requirements.memoryTypeBits,
+                vk::MemoryPropertyFlagBits::eDeviceLocal));
+        auto depth_memory = device_.allocateMemoryUnique(alloc_info);
+        device_.bindImageMemory(*depth_image, *depth_memory, 0);
+
+        vk::ImageViewCreateInfo view_info(
+            {},
+            *depth_image,
+            vk::ImageViewType::e2D,
+            depth_format_,
+            {},
+            {vk::ImageAspectFlagBits::eDepth, 0, 1, 0, 1});
+        depth_image_views_.push_back(device_.createImageViewUnique(view_info));
+        depth_images_.push_back(std::move(depth_image));
+        depth_memories_.push_back(std::move(depth_memory));
+    }
+}
+
 vk::Extent2D SwapchainResources::SelectSwapExtent(
-    const vk::SurfaceCapabilitiesKHR& capabilities,
-    glm::uvec2 size) const
+    const vk::SurfaceCapabilitiesKHR& capabilities, glm::uvec2 size) const
 {
     if (capabilities.currentExtent.width !=
         std::numeric_limits<std::uint32_t>::max())
@@ -306,8 +408,7 @@ vk::Extent2D SwapchainResources::SelectSwapExtent(
     }
 
     vk::Extent2D actual_extent{
-        static_cast<std::uint32_t>(size.x),
-        static_cast<std::uint32_t>(size.y)};
+        static_cast<std::uint32_t>(size.x), static_cast<std::uint32_t>(size.y)};
 
     actual_extent.width = std::clamp(
         actual_extent.width,

--- a/frame/vulkan/swapchain_resources.h
+++ b/frame/vulkan/swapchain_resources.h
@@ -92,6 +92,10 @@ class SwapchainResources
     {
         return image_format_;
     }
+    vk::Format GetDepthFormat() const
+    {
+        return depth_format_;
+    }
 
   private:
     vk::SurfaceFormatKHR SelectSurfaceFormat(
@@ -99,8 +103,11 @@ class SwapchainResources
     vk::PresentModeKHR SelectPresentMode(
         const std::vector<vk::PresentModeKHR>& modes) const;
     vk::Extent2D SelectSwapExtent(
-        const vk::SurfaceCapabilitiesKHR& capabilities,
-        glm::uvec2 size) const;
+        const vk::SurfaceCapabilitiesKHR& capabilities, glm::uvec2 size) const;
+    vk::Format SelectDepthFormat() const;
+    std::uint32_t FindMemoryType(
+        std::uint32_t type_filter, vk::MemoryPropertyFlags properties) const;
+    void CreateDepthResources();
 
     vk::PhysicalDevice physical_device_;
     vk::Device device_;
@@ -109,10 +116,14 @@ class SwapchainResources
     std::uint32_t present_queue_family_index_ = 0;
     const Logger& logger_;
     vk::Format image_format_ = vk::Format::eUndefined;
+    vk::Format depth_format_ = vk::Format::eUndefined;
     vk::Extent2D extent_{};
     vk::UniqueSwapchainKHR swapchain_;
     std::vector<vk::Image> images_;
     std::vector<vk::UniqueImageView> image_views_;
+    std::vector<vk::UniqueImage> depth_images_;
+    std::vector<vk::UniqueDeviceMemory> depth_memories_;
+    std::vector<vk::UniqueImageView> depth_image_views_;
     vk::UniqueRenderPass render_pass_;
     std::vector<vk::UniqueFramebuffer> framebuffers_;
     vk::UniqueRenderPass gui_render_pass_;

--- a/tests/frame/CMakeLists.txt
+++ b/tests/frame/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(FrameTest
   camera_test.cpp
   camera_test.h
   device_mock.h
+  draw_test.cpp
   main.cpp
   plugin_mock.h
   program_mock.h
@@ -12,6 +13,8 @@ add_executable(FrameTest
   window_factory_test.cpp
   window_factory_test.h
 )
+
+frame_enable_internal_backend_access(FrameTest)
 
 target_include_directories(FrameTest
   PUBLIC
@@ -26,6 +29,7 @@ target_link_libraries(FrameTest
     GTest::gmock
     GTest::gtest
     ${FRAME_LINK_GROUP_BEGIN}
+    FrameCommon
     ${FRAME_CORE_LIBS}
     ${FRAME_LINK_GROUP_END}
 )

--- a/tests/frame/draw_test.cpp
+++ b/tests/frame/draw_test.cpp
@@ -1,0 +1,292 @@
+#include <algorithm>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "absl/flags/flag.h"
+
+#include "frame/common/application.h"
+#include "frame/common/draw.h"
+#include "frame/device_interface.h"
+#include "frame/file/file_system.h"
+#include "frame/json/program_key.h"
+#include "frame/level_data_startup_internal.h"
+
+namespace test
+{
+namespace
+{
+
+class LevelDataStartupDevice final
+    : public frame::DeviceInterface,
+      public frame::internal::LevelDataStartupInterface
+{
+  public:
+    void StartupFromLevelData(const frame::json::LevelData& level_data) override
+    {
+        ++startup_count;
+        captured_level_data = level_data;
+    }
+
+    void Clear(const glm::vec4&) const override
+    {
+    }
+
+    void Startup(std::unique_ptr<frame::LevelInterface>&& level) override
+    {
+        level_ = std::move(level);
+    }
+
+    void AddPlugin(std::unique_ptr<frame::PluginInterface>&&) override
+    {
+    }
+
+    std::vector<frame::PluginInterface*> GetPluginPtrs() override
+    {
+        return {};
+    }
+
+    std::vector<std::string> GetPluginNames() const override
+    {
+        return {};
+    }
+
+    void RemovePluginByName(const std::string&) override
+    {
+    }
+
+    void Display(double) override
+    {
+    }
+
+    void Cleanup() override
+    {
+    }
+
+    void Resize(glm::uvec2 size) override
+    {
+        size_ = size;
+    }
+
+    glm::uvec2 GetSize() const override
+    {
+        return size_;
+    }
+
+    frame::LevelInterface& GetLevel() override
+    {
+        if (!level_)
+        {
+            throw std::runtime_error("No level loaded.");
+        }
+        return *level_;
+    }
+
+    void* GetDeviceContext() const override
+    {
+        return nullptr;
+    }
+
+    void ScreenShot(const std::string&) const override
+    {
+    }
+
+    void SetStereo(
+        frame::StereoEnum stereo_enum,
+        float interocular_distance,
+        glm::vec3 focus_point = glm::vec3(0.0f),
+        bool invert_left_right = false) override
+    {
+        stereo_enum_ = stereo_enum;
+        interocular_distance_ = interocular_distance;
+        focus_point_ = focus_point;
+        invert_left_right_ = invert_left_right;
+    }
+
+    frame::RenderingAPIEnum GetDeviceEnum() const override
+    {
+        return frame::RenderingAPIEnum::OPENGL;
+    }
+
+    frame::StereoEnum GetStereoEnum() const override
+    {
+        return stereo_enum_;
+    }
+
+    float GetInteroccularDistance() const override
+    {
+        return interocular_distance_;
+    }
+
+    glm::vec3 GetFocusPoint() const override
+    {
+        return focus_point_;
+    }
+
+    std::unique_ptr<frame::BufferInterface> CreatePointBuffer(
+        std::vector<float>&&) override
+    {
+        return nullptr;
+    }
+
+    std::unique_ptr<frame::BufferInterface> CreateIndexBuffer(
+        std::vector<std::uint32_t>&&) override
+    {
+        return nullptr;
+    }
+
+    std::unique_ptr<frame::MeshInterface> CreateMesh(
+        const frame::MeshParameter&) override
+    {
+        return nullptr;
+    }
+
+    int startup_count = 0;
+    std::optional<frame::json::LevelData> captured_level_data = std::nullopt;
+
+  private:
+    glm::uvec2 size_ = glm::uvec2(320, 200);
+    frame::StereoEnum stereo_enum_ = frame::StereoEnum::NONE;
+    float interocular_distance_ = 0.0f;
+    glm::vec3 focus_point_ = glm::vec3(0.0f);
+    bool invert_left_right_ = false;
+    std::unique_ptr<frame::LevelInterface> level_ = nullptr;
+};
+
+class RenderingFlagGuard
+{
+  public:
+    RenderingFlagGuard() : previous_value_(absl::GetFlag(FLAGS_rendering))
+    {
+    }
+
+    ~RenderingFlagGuard()
+    {
+        absl::SetFlag(&FLAGS_rendering, previous_value_);
+    }
+
+  private:
+    std::string previous_value_;
+};
+
+frame::json::LevelData StartupDrawWithRenderingFlag(const std::string& flag)
+{
+    absl::SetFlag(&FLAGS_rendering, flag);
+
+    LevelDataStartupDevice device;
+    frame::common::Draw draw(
+        glm::uvec2(320, 200),
+        frame::file::FindFile("asset/json/raytracing.json"),
+        device);
+    draw.Startup(glm::uvec2(320, 200));
+
+    EXPECT_EQ(device.startup_count, 1);
+    EXPECT_TRUE(device.captured_level_data.has_value());
+    return *device.captured_level_data;
+}
+
+bool HasNode(const frame::json::LevelData& level_data, const std::string& name)
+{
+    return std::find_if(
+               level_data.proto.scene_tree().node_meshes().begin(),
+               level_data.proto.scene_tree().node_meshes().end(),
+               [&](const frame::proto::NodeMesh& node) {
+                   return node.name() == name;
+               }) != level_data.proto.scene_tree().node_meshes().end();
+}
+
+std::optional<frame::json::RenderPassProgramInfo> FindRenderPass(
+    const frame::json::LevelData& level_data,
+    frame::proto::NodeMesh::RenderTimeEnum render_time)
+{
+    const auto it = std::find_if(
+        level_data.render_pass_programs.begin(),
+        level_data.render_pass_programs.end(),
+        [&](const frame::json::RenderPassProgramInfo& pass) {
+            return pass.render_time == render_time;
+        });
+    if (it == level_data.render_pass_programs.end())
+    {
+        return std::nullopt;
+    }
+    return *it;
+}
+
+bool HasRaytracingProgram(const frame::json::LevelData& level_data)
+{
+    return std::any_of(
+        level_data.programs.begin(),
+        level_data.programs.end(),
+        [](const frame::json::ProgramInfo& program) {
+            return frame::json::IsRaytracingProgramKey(
+                frame::json::ResolveProgramKey(program.proto));
+        });
+}
+
+} // namespace
+
+TEST(DrawRenderingOverrideTest, RasterAliasesStartRasterLevelData)
+{
+    RenderingFlagGuard flag_guard;
+
+    const std::vector<std::string> aliases = {
+        "raster", "rasterise", "rasterising", "rasterize", "rasterizing"};
+    for (const auto& alias : aliases)
+    {
+        const auto level_data = StartupDrawWithRenderingFlag(alias);
+
+        EXPECT_FALSE(HasNode(level_data, "RayTracingRendering")) << alias;
+        EXPECT_FALSE(HasRaytracingProgram(level_data)) << alias;
+        const auto scene_pass = FindRenderPass(
+            level_data, frame::proto::NodeMesh::SCENE_RENDER_TIME);
+        ASSERT_TRUE(scene_pass.has_value()) << alias;
+        EXPECT_EQ(scene_pass->program_name, "RasterSceneProgram") << alias;
+        EXPECT_TRUE(scene_pass->preprocess_program_name.empty()) << alias;
+    }
+}
+
+TEST(DrawRenderingOverrideTest, RaytraceAliasesStartRaytraceLevelData)
+{
+    RenderingFlagGuard flag_guard;
+
+    const std::vector<std::string> aliases = {"raytrace", "raytracing"};
+    for (const auto& alias : aliases)
+    {
+        const auto level_data = StartupDrawWithRenderingFlag(alias);
+
+        EXPECT_TRUE(HasNode(level_data, "RayTracingRendering")) << alias;
+        EXPECT_TRUE(HasRaytracingProgram(level_data)) << alias;
+        const auto scene_pass = FindRenderPass(
+            level_data, frame::proto::NodeMesh::SCENE_RENDER_TIME);
+        ASSERT_TRUE(scene_pass.has_value()) << alias;
+        EXPECT_EQ(scene_pass->program_name, "RayTraceProgram") << alias;
+        const auto preprocess_pass =
+            FindRenderPass(level_data, frame::proto::NodeMesh::PRE_RENDER_TIME);
+        ASSERT_TRUE(preprocess_pass.has_value()) << alias;
+        EXPECT_EQ(preprocess_pass->program_name, "RayTraceProgram") << alias;
+        EXPECT_EQ(
+            preprocess_pass->preprocess_program_name,
+            "RayTracePreprocessProgram")
+            << alias;
+    }
+}
+
+TEST(DrawRenderingOverrideTest, UnknownRenderingFlagThrows)
+{
+    RenderingFlagGuard flag_guard;
+    absl::SetFlag(&FLAGS_rendering, "scanline");
+
+    LevelDataStartupDevice device;
+    frame::common::Draw draw(
+        glm::uvec2(320, 200),
+        frame::file::FindFile("asset/json/raytracing.json"),
+        device);
+
+    EXPECT_THROW(draw.Startup(glm::uvec2(320, 200)), std::invalid_argument);
+    EXPECT_EQ(device.startup_count, 0);
+}
+
+} // namespace test

--- a/tests/frame/json/parse_level_test.cpp
+++ b/tests/frame/json/parse_level_test.cpp
@@ -1,9 +1,13 @@
 #include "frame/json/parse_level_test.h"
 
+#include <algorithm>
+
 #include "frame/file/file_system.h"
 #include "frame/json/parse_level.h"
-#include "frame/vulkan/json/parse_level.h"
+#include "frame/json/program_key.h"
 #include "frame/vulkan/build_level.h"
+#include "frame/vulkan/json/parse_level.h"
+#include "frame/vulkan/skinned_mesh.h"
 
 namespace test
 {
@@ -11,17 +15,17 @@ namespace test
 TEST_F(ParseLevelTest, BuildVulkanLevelFromJson)
 {
     const auto asset_root = frame::file::FindDirectory("asset");
-    const auto level_path =
-        frame::file::FindFile("asset/json/level_test.json");
+    const auto level_path = frame::file::FindFile("asset/json/level_test.json");
     const auto level_proto = frame::json::LoadLevelProto(level_path);
-    const auto level_data =
-        frame::json::ParseLevelData(glm::uvec2(320, 200), level_path, asset_root);
+    const auto level_data = frame::json::ParseLevelData(
+        glm::uvec2(320, 200), level_path, asset_root);
 
     auto built = frame::vulkan::BuildLevel(glm::uvec2(320, 200), level_data);
     ASSERT_NE(built.level, nullptr);
     EXPECT_EQ(
         built.level->GetDefaultRootSceneNodeId(),
-        built.level->GetIdFromName(level_proto.scene_tree().default_root_name()));
+        built.level->GetIdFromName(
+            level_proto.scene_tree().default_root_name()));
 }
 
 TEST_F(ParseLevelTest, CreateLevelDataFromPath)
@@ -50,6 +54,255 @@ TEST_F(ParseLevelTest, CreateLevelDataFromPathVulkan)
     EXPECT_EQ(level_data.textures.front().name, "skybox");
     EXPECT_EQ(level_data.textures.back().name, "output");
     EXPECT_EQ(level_data.asset_root, asset_root);
+}
+
+TEST_F(ParseLevelTest, RasterOptionBuildsRasterSceneProgramForRaytracingJson)
+{
+    const auto asset_root = frame::file::FindDirectory("asset");
+    const frame::json::LevelDataOptions options{
+        .render_preset = frame::json::RenderPreset::Raster};
+    const auto level_data = frame::json::ParseLevelData(
+        glm::uvec2(320, 200),
+        frame::file::FindFile("asset/json/raytracing.json"),
+        asset_root,
+        options);
+
+    const auto has_node = [&](const std::string& name) {
+        return std::find_if(
+                   level_data.proto.scene_tree().node_meshes().begin(),
+                   level_data.proto.scene_tree().node_meshes().end(),
+                   [&](const frame::proto::NodeMesh& node) {
+                       return node.name() == name;
+                   }) != level_data.proto.scene_tree().node_meshes().end();
+    };
+    EXPECT_FALSE(has_node("RayTracingRendering"));
+    EXPECT_TRUE(
+        std::all_of(
+            level_data.proto.scene_tree().node_meshes().begin(),
+            level_data.proto.scene_tree().node_meshes().end(),
+            [](const frame::proto::NodeMesh& node) {
+                return node.acceleration_structure_enum() ==
+                       frame::proto::NodeMesh::NO_ACCELERATION;
+            }));
+
+    const auto raster_program = std::find_if(
+        level_data.programs.begin(),
+        level_data.programs.end(),
+        [](const frame::json::ProgramInfo& program) {
+            return program.name == "RasterSceneProgram";
+        });
+    ASSERT_NE(raster_program, level_data.programs.end());
+    EXPECT_FALSE(
+        frame::json::IsRaytracingProgramKey(
+            frame::json::ResolveProgramKey(raster_program->proto)));
+    const auto has_binding = [&](const std::string& name) {
+        return std::find_if(
+                   raster_program->proto.bindings().begin(),
+                   raster_program->proto.bindings().end(),
+                   [&](const frame::proto::ProgramBinding& binding) {
+                       return binding.name() == name &&
+                              binding.binding_type() ==
+                                  frame::proto::ProgramBinding::
+                                      COMBINED_IMAGE_SAMPLER;
+                   }) != raster_program->proto.bindings().end();
+    };
+    EXPECT_TRUE(has_binding("albedo_texture"));
+    EXPECT_TRUE(has_binding("normal_texture"));
+    EXPECT_TRUE(has_binding("roughness_texture"));
+    EXPECT_TRUE(has_binding("metallic_texture"));
+    EXPECT_TRUE(has_binding("ao_texture"));
+    EXPECT_TRUE(has_binding("specular_factor_texture"));
+    EXPECT_TRUE(has_binding("specular_color_texture"));
+    EXPECT_TRUE(has_binding("shadow_map"));
+    EXPECT_TRUE(has_binding("transmission_texture"));
+    EXPECT_TRUE(has_binding("ior_texture"));
+    EXPECT_TRUE(has_binding("thickness_texture"));
+    EXPECT_TRUE(has_binding("attenuation_color_texture"));
+    EXPECT_TRUE(has_binding("skybox_env"));
+    EXPECT_FALSE(
+        std::any_of(
+            level_data.programs.begin(),
+            level_data.programs.end(),
+            [](const frame::json::ProgramInfo& program) {
+                return frame::json::IsRaytracingProgramKey(
+                    frame::json::ResolveProgramKey(program.proto));
+            }));
+
+    const auto has_pass =
+        [&](frame::proto::NodeMesh::RenderTimeEnum render_time,
+            const std::string& program_name) {
+            return std::find_if(
+                       level_data.render_pass_programs.begin(),
+                       level_data.render_pass_programs.end(),
+                       [&](const frame::json::RenderPassProgramInfo& pass) {
+                           return pass.render_time == render_time &&
+                                  pass.program_name == program_name;
+                       }) != level_data.render_pass_programs.end();
+        };
+    EXPECT_TRUE(has_pass(
+        frame::proto::NodeMesh::SCENE_RENDER_TIME, "RasterSceneProgram"));
+    EXPECT_TRUE(
+        has_pass(frame::proto::NodeMesh::SKYBOX_RENDER_TIME, "CubemapProgram"));
+
+    auto built = frame::vulkan::BuildLevel(glm::uvec2(320, 200), level_data);
+    ASSERT_NE(built.level, nullptr);
+    const auto scene_program_id = built.level->GetRenderPassProgramId(
+        frame::proto::NodeMesh::SCENE_RENDER_TIME);
+    ASSERT_NE(scene_program_id, frame::NullId);
+    EXPECT_EQ(
+        built.level->GetNameFromId(scene_program_id), "RasterSceneProgram");
+    EXPECT_EQ(
+        built.level->GetRenderPassPreprocessProgramId(
+            frame::proto::NodeMesh::SCENE_RENDER_TIME),
+        frame::NullId);
+    for (const auto& [node_id, material_id] : built.level->GetMeshMaterialIds(
+             frame::proto::NodeMesh::SCENE_RENDER_TIME))
+    {
+        if (material_id != frame::NullId)
+        {
+            const auto& material = built.level->GetMaterialFromId(material_id);
+            bool has_specular_factor = false;
+            bool has_specular_color = false;
+            for (const auto texture_id : material.GetTextureIds())
+            {
+                has_specular_factor |= material.GetInnerName(texture_id) ==
+                                       "specular_factor_texture";
+                has_specular_color |= material.GetInnerName(texture_id) ==
+                                      "specular_color_texture";
+            }
+            EXPECT_TRUE(has_specular_factor);
+            EXPECT_TRUE(has_specular_color);
+        }
+        const auto mesh_id =
+            built.level->GetSceneNodeFromId(node_id).GetLocalMesh();
+        if (mesh_id == frame::NullId)
+        {
+            continue;
+        }
+        EXPECT_EQ(
+            built.level->GetMeshFromId(mesh_id).GetBvhBufferId(),
+            frame::NullId);
+    }
+}
+
+TEST_F(ParseLevelTest, RasterOptionKeepsSkinnedMeshAnimatedWithoutBvh)
+{
+    const auto asset_root = frame::file::FindDirectory("asset");
+    const frame::json::LevelDataOptions options{
+        .render_preset = frame::json::RenderPreset::Raster};
+    const auto level_data = frame::json::ParseLevelData(
+        glm::uvec2(320, 200),
+        frame::file::FindFile("asset/json/skinned_mesh.json"),
+        asset_root,
+        options);
+
+    const auto has_node = [&](const std::string& name) {
+        return std::find_if(
+                   level_data.proto.scene_tree().node_meshes().begin(),
+                   level_data.proto.scene_tree().node_meshes().end(),
+                   [&](const frame::proto::NodeMesh& node) {
+                       return node.name() == name;
+                   }) != level_data.proto.scene_tree().node_meshes().end();
+    };
+    EXPECT_TRUE(has_node("CesiumManMesh"));
+    EXPECT_FALSE(has_node("RayTracingRendering"));
+    EXPECT_TRUE(
+        std::all_of(
+            level_data.proto.scene_tree().node_meshes().begin(),
+            level_data.proto.scene_tree().node_meshes().end(),
+            [](const frame::proto::NodeMesh& node) {
+                return node.acceleration_structure_enum() ==
+                       frame::proto::NodeMesh::NO_ACCELERATION;
+            }));
+
+    const auto scene_pass = std::find_if(
+        level_data.render_pass_programs.begin(),
+        level_data.render_pass_programs.end(),
+        [](const frame::json::RenderPassProgramInfo& pass) {
+            return pass.render_time ==
+                   frame::proto::NodeMesh::SCENE_RENDER_TIME;
+        });
+    ASSERT_NE(scene_pass, level_data.render_pass_programs.end());
+    EXPECT_EQ(scene_pass->program_name, "RasterSceneProgram");
+    EXPECT_TRUE(scene_pass->preprocess_program_name.empty());
+    EXPECT_FALSE(
+        std::any_of(
+            level_data.programs.begin(),
+            level_data.programs.end(),
+            [](const frame::json::ProgramInfo& program) {
+                return frame::json::IsRaytracingProgramKey(
+                    frame::json::ResolveProgramKey(program.proto));
+            }));
+
+    auto built = frame::vulkan::BuildLevel(glm::uvec2(320, 200), level_data);
+    ASSERT_NE(built.level, nullptr);
+    auto& level = *built.level;
+    const auto mesh_node_id = level.GetIdFromName("CesiumManMesh");
+    ASSERT_NE(mesh_node_id, frame::NullId);
+    const auto mesh_id = level.GetSceneNodeFromId(mesh_node_id).GetLocalMesh();
+    ASSERT_NE(mesh_id, frame::NullId);
+    auto* skinned_mesh = dynamic_cast<frame::vulkan::SkinnedMesh*>(
+        &level.GetMeshFromId(mesh_id));
+    ASSERT_NE(skinned_mesh, nullptr);
+    EXPECT_TRUE(skinned_mesh->IsSkinningAnimationEnabled());
+    EXPECT_TRUE(skinned_mesh->HasBoneMatricesCallback());
+    EXPECT_TRUE(skinned_mesh->HasGpuSkinningSourceData());
+    EXPECT_TRUE(skinned_mesh->HasRaytraceTriangleCallback());
+    EXPECT_FALSE(skinned_mesh->HasRaytraceBvhCallback());
+    EXPECT_EQ(skinned_mesh->GetBvhBufferId(), frame::NullId);
+}
+
+TEST_F(ParseLevelTest, RasterOptionKeepsCubemapOnlyLevelOnCubemapProgram)
+{
+    const auto asset_root = frame::file::FindDirectory("asset");
+    const frame::json::LevelDataOptions options{
+        .render_preset = frame::json::RenderPreset::Raster};
+    const auto level_data = frame::json::ParseLevelData(
+        glm::uvec2(320, 200),
+        frame::file::FindFile("asset/json/cubemap.json"),
+        asset_root,
+        options);
+
+    ASSERT_EQ(level_data.programs.size(), 1u);
+    EXPECT_EQ(level_data.programs.front().name, "CubemapProgram");
+    ASSERT_EQ(level_data.render_pass_programs.size(), 1u);
+    EXPECT_EQ(
+        level_data.render_pass_programs.front().render_time,
+        frame::proto::NodeMesh::SKYBOX_RENDER_TIME);
+    EXPECT_EQ(
+        level_data.render_pass_programs.front().program_name, "CubemapProgram");
+}
+
+TEST_F(ParseLevelTest, RaytraceOptionKeepsCubemapOnlyLevelOnCubemapProgram)
+{
+    const auto asset_root = frame::file::FindDirectory("asset");
+    const frame::json::LevelDataOptions options{
+        .render_preset = frame::json::RenderPreset::Raytrace};
+    const auto level_data = frame::json::ParseLevelData(
+        glm::uvec2(320, 200),
+        frame::file::FindFile("asset/json/cubemap.json"),
+        asset_root,
+        options);
+
+    ASSERT_EQ(level_data.programs.size(), 1u);
+    EXPECT_EQ(level_data.programs.front().name, "CubemapProgram");
+    ASSERT_EQ(level_data.render_pass_programs.size(), 1u);
+    EXPECT_EQ(
+        level_data.render_pass_programs.front().render_time,
+        frame::proto::NodeMesh::SKYBOX_RENDER_TIME);
+    EXPECT_EQ(
+        level_data.render_pass_programs.front().program_name, "CubemapProgram");
+
+    auto built = frame::vulkan::BuildLevel(glm::uvec2(320, 200), level_data);
+    ASSERT_NE(built.level, nullptr);
+    const auto skybox_program_id = built.level->GetRenderPassProgramId(
+        frame::proto::NodeMesh::SKYBOX_RENDER_TIME);
+    ASSERT_NE(skybox_program_id, frame::NullId);
+    EXPECT_EQ(built.level->GetNameFromId(skybox_program_id), "CubemapProgram");
+    EXPECT_EQ(
+        built.level->GetRenderPassProgramId(
+            frame::proto::NodeMesh::SCENE_RENDER_TIME),
+        frame::NullId);
 }
 
 } // End namespace test.

--- a/tests/frame/opengl/window_test.cpp
+++ b/tests/frame/opengl/window_test.cpp
@@ -1,5 +1,8 @@
 #include "frame/opengl/window_test.h"
 
+#include "frame/file/file_system.h"
+#include "frame/json/parse_level.h"
+#include "frame/level_data_startup_internal.h"
 #include "frame/opengl/window_factory.h"
 
 namespace test
@@ -29,6 +32,28 @@ TEST_F(WindowTest, CreateDeviceWindowTest)
     EXPECT_EQ(window_->GetDrawingTargetEnum(), frame::DrawingTargetEnum::NONE);
     EXPECT_EQ(
         window_->GetDevice().GetDeviceEnum(), frame::RenderingAPIEnum::OPENGL);
+}
+
+TEST_F(WindowTest, DestroyWindowAfterLoadedRasterLevelKeepsContextAlive)
+{
+    ASSERT_FALSE(window_);
+    window_ = frame::opengl::CreateSDLOpenGLNone({320, 200});
+    ASSERT_TRUE(window_);
+
+    const auto asset_root = frame::file::FindDirectory("asset");
+    const frame::json::LevelDataOptions options{
+        .render_preset = frame::json::RenderPreset::Raster};
+    const auto level_data = frame::json::ParseLevelData(
+        glm::uvec2(320, 200),
+        frame::file::FindFile("asset/json/raytracing.json"),
+        asset_root,
+        options);
+
+    auto* loader = dynamic_cast<frame::internal::LevelDataStartupInterface*>(
+        &window_->GetDevice());
+    ASSERT_NE(loader, nullptr);
+    ASSERT_NO_THROW(loader->StartupFromLevelData(level_data));
+    EXPECT_NO_THROW(window_.reset());
 }
 
 } // End namespace test.

--- a/tests/frame/vulkan/scene_state_test.cpp
+++ b/tests/frame/vulkan/scene_state_test.cpp
@@ -1,7 +1,7 @@
 #include <cmath>
 #include <filesystem>
-#include <gtest/gtest.h>
 #include <glm/glm.hpp>
+#include <gtest/gtest.h>
 
 #include "frame/file/file_system.h"
 #include "frame/json/parse_level.h"
@@ -49,7 +49,8 @@ TEST_F(VulkanSceneStateTest, BuildsProjectionViewAndModelMatrices)
     // Projection Y is flipped for Vulkan.
     EXPECT_LT(state.projection[1][1], 0.0f);
     EXPECT_NE(state.view, glm::mat4(1.0f));
-    // Model may be identity if the mesh root is at the origin; ensure it's finite.
+    // Model may be identity if the mesh root is at the origin; ensure it's
+    // finite.
     EXPECT_TRUE(std::isfinite(state.model[0][0]));
 }
 
@@ -70,6 +71,44 @@ TEST_F(VulkanSceneStateTest, CarriesLightInformation)
     EXPECT_NEAR(state.light_dir.x, 0.7071f, 1e-3f);
     EXPECT_NEAR(state.light_dir.y, -0.7071f, 1e-3f);
     EXPECT_NEAR(state.light_dir.z, 0.0f, 1e-3f);
+}
+
+TEST_F(VulkanSceneStateTest, EnablesShadowStateForDirectionalShadowLight)
+{
+    auto built = frame::vulkan::BuildLevel(glm::uvec2(320, 200), level_data_);
+    ASSERT_NE(built.level, nullptr);
+
+    const auto state = frame::vulkan::BuildSceneState(
+        *built.level,
+        frame::Logger::GetInstance(),
+        {320u, 200u},
+        0.0f,
+        frame::NullId,
+        true);
+
+    EXPECT_FLOAT_EQ(state.shadow_enabled, 1.0f);
+    EXPECT_FLOAT_EQ(state.shadow_bias, 0.0035f);
+    EXPECT_FLOAT_EQ(state.shadow_map_size, 2048.0f);
+
+    float total_delta_from_identity = 0.0f;
+    const glm::mat4 identity(1.0f);
+    for (int column = 0; column < 4; ++column)
+    {
+        for (int row = 0; row < 4; ++row)
+        {
+            EXPECT_TRUE(
+                std::isfinite(state.light_view_projection[column][row]));
+            total_delta_from_identity += std::abs(
+                state.light_view_projection[column][row] -
+                identity[column][row]);
+        }
+    }
+    EXPECT_GT(total_delta_from_identity, 0.0f);
+
+    const auto block = frame::vulkan::MakeUniformBlock(state, 0.0f);
+    EXPECT_FLOAT_EQ(block.shadow_params.x, 1.0f);
+    EXPECT_FLOAT_EQ(block.shadow_params.y, state.shadow_bias);
+    EXPECT_FLOAT_EQ(block.shadow_params.z, state.shadow_map_size);
 }
 
 TEST_F(VulkanSceneStateTest, PrefersPointLightInformationWhenAvailable)
@@ -93,9 +132,7 @@ TEST_F(VulkanSceneStateTest, PrefersPointLightInformationWhenAvailable)
     level.AddSceneNode(std::move(directional_light));
 
     auto camera = std::make_unique<frame::NodeCamera>(
-        func,
-        glm::vec3(0.0f, 0.0f, 5.0f),
-        glm::vec3(0.0f, 0.0f, 0.0f));
+        func, glm::vec3(0.0f, 0.0f, 5.0f), glm::vec3(0.0f, 0.0f, 0.0f));
     camera->SetName("camera");
     level.SetDefaultCameraName("camera");
     level.AddSceneNode(std::move(camera));

--- a/tests/frame/vulkan/window_test.cpp
+++ b/tests/frame/vulkan/window_test.cpp
@@ -61,8 +61,7 @@ TEST_F(VulkanBuildLevelTest, BuildLevelRegistersProgramsMaterialsAndTextures)
 
     for (const auto& program_info : level_data_.programs)
     {
-        EXPECT_NE(
-            built.level->GetIdFromName(program_info.name), frame::NullId);
+        EXPECT_NE(built.level->GetIdFromName(program_info.name), frame::NullId);
     }
 
     const auto material_ids = built.level->GetMaterials();
@@ -83,6 +82,12 @@ TEST_F(VulkanBuildLevelTest, BuildMeshVerticesFromStaticMeshInfo)
     EXPECT_FLOAT_EQ(vertices.front().position.x, mesh_info.positions[0]);
     EXPECT_FLOAT_EQ(vertices.front().position.y, mesh_info.positions[1]);
     EXPECT_FLOAT_EQ(vertices.front().position.z, mesh_info.positions[2]);
+    if (!mesh_info.normals.empty())
+    {
+        EXPECT_FLOAT_EQ(vertices.front().normal.x, mesh_info.normals[0]);
+        EXPECT_FLOAT_EQ(vertices.front().normal.y, mesh_info.normals[1]);
+        EXPECT_FLOAT_EQ(vertices.front().normal.z, mesh_info.normals[2]);
+    }
     if (!mesh_info.uvs.empty())
     {
         EXPECT_FLOAT_EQ(vertices.front().uv.x, mesh_info.uvs[0]);


### PR DESCRIPTION
## Summary

Adds a rendering-mode override so examples can select `auto`, raytracing, or raster rendering from the command line while keeping the JSON scene files rendering agnostic.

Key changes:
- Adds `--rendering={auto|raytrace|raytracing|rasterise|rasterising|rasterize|rasterizing|raster}` handling in the common application/draw path.
- Builds raster level data from the existing raytracing-oriented JSON by removing raytrace resolve nodes, disabling acceleration structures, and wiring raster scene programs.
- Adds Vulkan and OpenGL raster GLTF shaders with PBR-style material inputs, environment lookup support, skinned mesh support, and shadow-map plumbing.
- Adds raster shadow-map rendering for Vulkan/OpenGL without reusing BVH/raytracing for shadows.
- Renames example `01_Raytracing` to `01_Refraction` and updates docs/examples.
- Fixes OpenGL window teardown order so GL-owned resources are destroyed while the context is current.

## Validation

Ran locally from the main checkout:

- `cmake --build --preset linux-debug --target FrameTest FrameJsonTest FrameVulkanTest FrameOpenGLTest`
- `./build/linux-debug/tests/FrameTest --gtest_filter=DrawRenderingOverrideTest.*`
- `./build/linux-debug/tests/FrameJsonTest --gtest_filter=ParseLevelTest.RasterOptionBuildsRasterSceneProgramForRaytracingJson:ParseLevelTest.RasterOptionKeepsSkinnedMeshAnimatedWithoutBvh:ParseLevelTest.RasterOptionKeepsCubemapOnlyLevelOnCubemapProgram:ParseLevelTest.RaytraceOptionKeepsCubemapOnlyLevelOnCubemapProgram`
- `./build/linux-debug/tests/FrameVulkanTest --gtest_filter=VulkanSceneStateTest.*`
- `./build/linux-debug/tests/FrameOpenGLTest --gtest_filter=WindowTest.DestroyWindowAfterLoadedRasterLevelKeepsContextAlive` with display access
- `ctest --test-dir build/linux-debug --output-on-failure -LE requires-opengl` passed: 90/90 tests, with existing Vulkan hardware-dependent tests skipped
- `git diff --check`

## Notes

The OpenGL teardown regression test is under `FrameOpenGLTest`; that target is labeled `requires-opengl`, so the hosted CI path that runs `ctest -LE requires-opengl` excludes it.