### PR TITLE
[codex] Use external Frame path in GUI tests

### DIFF
--- a/tests/frame/opengl/CMakeLists.txt
+++ b/tests/frame/opengl/CMakeLists.txt
@@ -83,7 +83,7 @@ target_include_directories(FrameOpenGLGUITest
     ${CMAKE_CURRENT_SOURCE_DIR}/../..
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_BINARY_DIR}/frame/proto/generated
-    ${CMAKE_BINARY_DIR}/external/frame/frame/proto/generated
+    ${CMAKE_BINARY_DIR}/external/Frame/frame/proto/generated
 )
 
 target_link_libraries(FrameOpenGLGUITest

--- a/tests/frame/vulkan/CMakeLists.txt
+++ b/tests/frame/vulkan/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(FrameVulkanGUITest
     ${CMAKE_CURRENT_SOURCE_DIR}/../..
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_BINARY_DIR}/frame/proto/generated
-    ${CMAKE_BINARY_DIR}/external/frame/frame/proto/generated
+    ${CMAKE_BINARY_DIR}/external/Frame/frame/proto/generated
 )
 
 target_link_libraries(FrameVulkanGUITest


### PR DESCRIPTION
Closed because this change was based on a repository-context mix-up: the expected `external/Frame` submodule belongs in the parent project, not inside the Frame repository itself.